### PR TITLE
Automatonクラスのリファクタリング：拡張可能な設計への変更

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [22.x]
 
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,13 +13,13 @@ emiel is a universal Japanese typing game library written in pure TypeScript wit
 pnpm install
 
 # Build the library
-pnpm build
+pnpm run build
 
 # Run tests
-pnpm test
+pnpm run test
 
 # Run linting
-pnpm lint
+pnpm run lint
 
 # Publish the package
 make publish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,3 +24,32 @@ vite は事前に依存パッケージの最適化等を行っているため、
 ```
 pnpm exec vite optimize --force
 ```
+
+# 参考資料
+
+Microsoft キーボード入力の概要（真ん中以下にスキャンコード表がある）
+https://learn.microsoft.com/ja-jp/windows/win32/inputdev/about-keyboard-input
+
+W3C Writing System Keys（キーの名前）
+https://www.w3.org/TR/uievents-code/#key-alphanumeric-writing-system
+
+Windows のキーボードレイアウト一覧
+http://kbdlayout.info/
+
+USB キーボードと PS/2 キーボードの違い
+https://ascii.jp/elem/000/004/031/4031629/
+
+ブラウザのキーボードイベントの詳細確認ツール
+https://www.toptal.com/developers/keycode
+
+Keyboard Event Viewer(IME の状態による違いも確認できる)
+https://w3c.github.io/uievents/tools/key-event-viewer.html
+
+OS・ブラウザ別の code 一覧
+https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values
+
+USB HID Usage ID の Scancode 変換と対応するキー
+https://bsakatu.net/doc/usb-hid-to-scancode/
+
+USB HID Usage Tables ver.1.5
+https://www.usb.org/document-library/hid-usage-tables-15

--- a/docs/ADR.md
+++ b/docs/ADR.md
@@ -350,36 +350,51 @@ J は Rule.modifiers に含まれていないため、「ざ」を入力する�
 
 結果として、Rule.modifiers のキーを特別扱いする必要もなくなり、Rule.modifiers という定義そのものが不要になるはず。
 
-# 20250222
+# 20250617 Automaton クラスのリファクタリング
 
-「しる」を打つべきシーンで R↓I↓I↑R↑ という順に打つと「しょ」になって本来はミス。
-成功になってしまっている。
+## 背景
 
-# 参考資料
+Automaton クラスに getter 系の関数が集中し、クラスが肥大化していた。また、ユーザーが独自の統計関数や参照系関数を追加したい場合に対応できなかった。
 
-Microsoft キーボード入力の概要（真ん中以下にスキャンコード表がある）
-https://learn.microsoft.com/ja-jp/windows/win32/inputdev/about-keyboard-input
+## 決定事項
 
-W3C Writing System Keys（キーの名前）
-https://www.w3.org/TR/uievents-code/#key-alphanumeric-writing-system
+- Automaton の内部状態を `AutomatonState` インターフェースとして分離
+- getter 系関数を `automatonGetters.ts` にグローバル関数として分離
+- 動的な機能拡張のための `with()` メソッドを実装
 
-Windows のキーボードレイアウト一覧
-http://kbdlayout.info/
+## 実装詳細
 
-USB キーボードと PS/2 キーボードの違い
-https://ascii.jp/elem/000/004/031/4031629/
+### 拡張メカニズム
 
-ブラウザのキーボードイベントの詳細確認ツール
-https://www.toptal.com/developers/keycode
+```typescript
+// 拡張の定義
+const statsExtension = {
+  getKPM: (state: AutomatonState) => {
+    /* ... */
+  },
+  getAccuracy: (state: AutomatonState) => {
+    /* ... */
+  },
+};
 
-Keyboard Event Viewer(IME の状態による違いも確認できる)
-https://w3c.github.io/uievents/tools/key-event-viewer.html
+// 使用方法
+const automaton = rule.build("こんにちは");
+const extended = automaton.with(statsExtension);
+console.log(extended.getKPM()); // 型安全に拡張メソッドを使用
+```
 
-OS・ブラウザ別の code 一覧
-https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values
+### Proxy を使用した理由
 
-USB HID Usage ID の Scancode 変換と対応するキー
-https://bsakatu.net/doc/usb-hid-to-scancode/
+- 拡張メソッドが常に最新の Automaton の状態を参照できる
+- メモリ効率が良い（新しいオブジェクトを作成しない）
+- 型安全性を保ちながら動的に機能を追加できる
 
-USB HID Usage Tables ver.1.5
-https://www.usb.org/document-library/hid-usage-tables-15
+### デフォルト拡張
+
+`rule.build()` はデフォルトで基本的な getter を含む `defaultExtension` を適用する。これにより、既存のコードとの後方互換性を維持。
+
+## 結果
+
+- Automaton クラスの責務が明確になった（状態管理と入力処理に特化）
+- ユーザーが必要な機能だけを選択的に使用可能
+- 独自の拡張を簡単に追加できるようになった

--- a/examples/react-backspace/src/App.tsx
+++ b/examples/react-backspace/src/App.tsx
@@ -44,26 +44,26 @@ function Typing(props: { layout: KeyboardLayout }) {
     <>
       <h1>
         <div style={{ display: "flex" }}>
-          <div style={{ color: "gray" }}>{automaton.base.finishedWord}</div>
+          <div style={{ color: "gray" }}>{automaton.base.getFinishedWord()}</div>
           <div
             style={{
-              marginLeft: automaton.base.finishedWord ? "0.5rem" : "0",
+              marginLeft: automaton.base.getFinishedWord() ? "0.5rem" : "0",
             }}
           >
-            {automaton.base.pendingWord}
+            {automaton.base.getPendingWord()}
           </div>
         </div>
       </h1>
       <h1>
         <div style={{ display: "flex" }}>
-          <div style={{ color: "gray" }}>{automaton.base.finishedRoman}</div>
+          <div style={{ color: "gray" }}>{automaton.base.getFinishedRoman()}</div>
           <div
             style={{
-              marginLeft: automaton.base.finishedRoman ? "0.5rem" : "0",
+              marginLeft: automaton.base.getFinishedRoman() ? "0.5rem" : "0",
               textAlign: "left",
             }}
           >
-            {automaton.base.pendingRoman}
+            {automaton.base.getPendingRoman()}
             <br />
             <span style={{ color: "yellow" }}>
               {automaton.failedInputs

--- a/examples/react-keyboardguide/src/App.tsx
+++ b/examples/react-keyboardguide/src/App.tsx
@@ -8,11 +8,13 @@ function App() {
   const [keyboardState, setKeyboardState] = useState<KeyboardStateReader>(new KeyboardState([]));
   useEffect(() => {
     activate(window, (evt) => {
-      console.log("down", evt.input.key);
-      setKeyboardState(evt.keyboardState)
-    }, (evt) => {
-      console.log("up", evt.input.key);
-      setKeyboardState(evt.keyboardState)
+      if (evt.input.type === "keydown") {
+        console.log("down", evt.input.key);
+        setKeyboardState(evt.keyboardState)
+      } else {
+        console.log("up", evt.input.key);
+        setKeyboardState(evt.keyboardState)
+      }
     }
     );
   }, []);

--- a/examples/react-mixed-guide/src/App.tsx
+++ b/examples/react-mixed-guide/src/App.tsx
@@ -1,7 +1,7 @@
 import { activate, detectKeyboardLayout, InputStroke, KeyboardLayout, loadPresetRuleRoman } from "emiel";
 import { useEffect, useMemo, useState } from "react";
 import "./App.css";
-import { MixedText, MixedTextAutomaton } from "./MixedGuide";
+import { MixedText, withMixedText } from "./MixedGuide";
 
 function App() {
   const [layout, setLayout] = useState<KeyboardLayout | undefined>();
@@ -21,7 +21,7 @@ function Typing(props: { layout: KeyboardLayout }) {
   ];
   const [automatons] = useState(
     words.map((w) =>
-      new MixedTextAutomaton(
+      withMixedText(
         romanRule.build(w.kanaText),
         w,
       )
@@ -34,11 +34,11 @@ function Typing(props: { layout: KeyboardLayout }) {
   useEffect(() => {
     return activate(window, (e) => {
       setLastInputKey(e.input);
-      const result = automatons[index].base.input(e);
+      const result = automatons[index].input(e);
       if (result.isFinished) {
         setIndex((current) => {
           const newIndex = (current + 1) % automatons.length;
-          automatons[newIndex].base.reset();
+          automatons[newIndex].reset();
           return newIndex;
         });
       }
@@ -49,16 +49,16 @@ function Typing(props: { layout: KeyboardLayout }) {
   return (
     <>
       <h1>
-        <span style={{ color: "gray" }}>{automaton.finishedMixedSubstr}</span>{" "}
-        {automaton.pendingMixedSubstr}
+        <span style={{ color: "gray" }}>{automaton.getFinishedMixedSubstr()}</span>{" "}
+        {automaton.getPendingMixedSubstr()}
       </h1>
       <h1>
-        <span style={{ color: "gray" }}>{automaton.base.finishedWord}</span>{" "}
-        {automaton.base.pendingWord}
+        <span style={{ color: "gray" }}>{automaton.getFinishedWord()}</span>{" "}
+        {automaton.getPendingWord()}
       </h1>
       <h1>
-        <span style={{ color: "gray" }}>{automaton.base.finishedRoman}</span>{" "}
-        {automaton.base.pendingRoman}
+        <span style={{ color: "gray" }}>{automaton.getFinishedRoman()}</span>{" "}
+        {automaton.getPendingRoman()}
       </h1>
       <h2>
         Key:{" "}

--- a/examples/react-mixed-guide/src/MixedGuide.ts
+++ b/examples/react-mixed-guide/src/MixedGuide.ts
@@ -1,53 +1,57 @@
 import { Automaton } from "emiel";
 
 export class MixedText {
-	readonly kanaText: string;
-	readonly mixedText: string;
-	readonly mixedTextIndex: number[];
+  readonly kanaText: string;
+  readonly mixedText: string;
+  readonly mixedTextIndex: number[];
 
-	/**
-	 * commaKanaText: "きょう,は,い,い,てん,き"
-	 * commaMixedTextSplit: "今日,は,い,い,天,気"
-	 */
-	constructor(readonly commaKanaText: string, readonly commaMixedText: string) {
-		const kanaTextSplit = commaKanaText.split(",");
-		const mixedTextSplit = commaMixedText.split(",");
-		if (kanaTextSplit.length !== mixedTextSplit.length) {
-			throw new Error(
-				`kanaTextSplit.length !== mixedTextSplit.length: ${commaKanaText} ${commaMixedText}`
-			);
-		}
-		/*
-		* mixedTextIndex はある kanaText の位置における mixedText の位置を指す
-		*                  き ょ う  は い い  て ん き
-		* mixedTextIndex: [0, 0, 0, 2, 3, 4, 5, 5, 6, 7]
-		*/
-		const mixedTextIndex = [];
-		let lastMixedIndex = 0;
-		kanaTextSplit.forEach((kana, i) => {
-			for (let j = 0; j < kana.length; j++) {
-				mixedTextIndex.push(lastMixedIndex);
-			}
-			lastMixedIndex += mixedTextSplit[i].length;
-		});
-		mixedTextIndex.push(lastMixedIndex);
-		this.mixedTextIndex = mixedTextIndex;
-		this.kanaText = kanaTextSplit.join("");
-		this.mixedText = mixedTextSplit.join("");
-	}
+  /**
+   * commaKanaText: "きょう,は,い,い,てん,き"
+   * commaMixedTextSplit: "今日,は,い,い,天,気"
+   */
+  constructor(
+    readonly commaKanaText: string,
+    readonly commaMixedText: string,
+  ) {
+    const kanaTextSplit = commaKanaText.split(",");
+    const mixedTextSplit = commaMixedText.split(",");
+    if (kanaTextSplit.length !== mixedTextSplit.length) {
+      throw new Error(
+        `kanaTextSplit.length !== mixedTextSplit.length: ${commaKanaText} ${commaMixedText}`,
+      );
+    }
+    /*
+     * mixedTextIndex はある kanaText の位置における mixedText の位置を指す
+     *                  き ょ う  は い い  て ん き
+     * mixedTextIndex: [0, 0, 0, 2, 3, 4, 5, 5, 6, 7]
+     */
+    const mixedTextIndex = [];
+    let lastMixedIndex = 0;
+    kanaTextSplit.forEach((kana, i) => {
+      for (let j = 0; j < kana.length; j++) {
+        mixedTextIndex.push(lastMixedIndex);
+      }
+      lastMixedIndex += mixedTextSplit[i].length;
+    });
+    mixedTextIndex.push(lastMixedIndex);
+    this.mixedTextIndex = mixedTextIndex;
+    this.kanaText = kanaTextSplit.join("");
+    this.mixedText = mixedTextSplit.join("");
+  }
 }
 
-export class MixedTextAutomaton {
-	constructor(readonly base: Automaton, readonly metadata: MixedText) { }
-	get finishedMixedSubstr(): string {
-		return this.metadata.mixedText.substring(
-			0,
-			this.metadata.mixedTextIndex[this.base.finishedWord.length]
-		);
-	}
-	get pendingMixedSubstr(): string {
-		return this.metadata.mixedText.substring(
-			this.metadata.mixedTextIndex[this.base.finishedWord.length]
-		);
-	}
+export function withMixedText(automaton: Automaton, mixedText: MixedText) {
+  return automaton.with({
+    getFinishedMixedSubstr(): string {
+      return mixedText.mixedText.substring(
+        0,
+        mixedText.mixedTextIndex[automaton.getFinishedWord().length],
+      );
+    },
+    getPendingMixedSubstr(): string {
+      return mixedText.mixedText.substring(
+        mixedText.mixedTextIndex[automaton.getFinishedWord().length],
+      );
+    },
+  });
 }

--- a/examples/react-multi-word/src/word.tsx
+++ b/examples/react-multi-word/src/word.tsx
@@ -12,12 +12,12 @@ export function Word(props: { automaton: emiel.Automaton }) {
       }}
     >
       <h2>
-        <span style={{ color: "gray" }}>{automaton.finishedWord}</span>{" "}
-        {automaton.pendingWord}
+        <span style={{ color: "gray" }}>{automaton.getFinishedWord()}</span>{" "}
+        {automaton.getPendingWord()}
       </h2>
       <h2>
-        <span style={{ color: "gray" }}>{automaton.finishedRoman}</span>{" "}
-        {automaton.pendingRoman}
+        <span style={{ color: "gray" }}>{automaton.getFinishedRoman()}</span>{" "}
+        {automaton.getPendingRoman()}
       </h2>
     </div>
   );

--- a/examples/react-result-record/src/App.tsx
+++ b/examples/react-result-record/src/App.tsx
@@ -31,9 +31,9 @@ function TypingRoot(props: { layout: KeyboardLayout }) {
       {
         automaton: a,
         displayedAt,
-        firstInputtedAt: a.histories[0].event.timestamp,
+        firstInputtedAt: a.edgeHistories[0].event.timestamp,
         finishedAt:
-          a.histories[a.histories.length - 1].event.timestamp,
+          a.edgeHistories[a.edgeHistories.length - 1].event.timestamp,
       },
     ]);
     setWordIndex((current) => {

--- a/examples/react-result-record/src/Record.tsx
+++ b/examples/react-result-record/src/Record.tsx
@@ -1,4 +1,4 @@
-import { Automaton, calcAccuracy, calcKpm, calcRkpm } from "emiel";
+import { Automaton, getAccuracy, getKpm, getRkpm } from "emiel";
 
 export type WordRecordValue = {
   automaton: Automaton;
@@ -10,15 +10,15 @@ export function Record(props: { wordRecords: WordRecordValue[] }) {
     // ワードが表示されてから1打鍵めに成功するまでの経過時間
     const automaton = record.automaton;
     const latency =
-      automaton.firstInputTime.getTime() - record.displayedAt.getTime();
-    const rkpm = calcRkpm(
-      automaton.histories.length,
-      automaton.firstInputTime,
-      automaton.lastInputTime);
+      automaton.getFirstInputTime().getTime() - record.displayedAt.getTime();
+    const rkpm = getRkpm(
+      automaton.edgeHistories.length,
+      automaton.getFirstInputTime(),
+      automaton.getLastInputTime());
 
     // latency の時間を含めた、1分あたりの打鍵数
-    const kpm = calcKpm(automaton.histories.length, record.displayedAt, automaton.lastInputTime);
-    const accuracy = calcAccuracy(record.automaton.failedInputCount, record.automaton.totalInputCount);
+    const kpm = getKpm(automaton.edgeHistories.length, record.displayedAt, automaton.getLastInputTime());
+    const accuracy = getAccuracy(record.automaton.getFailedInputCount(), record.automaton.getTotalInputCount());
     return {
       latency,
       kpm,
@@ -30,14 +30,14 @@ export function Record(props: { wordRecords: WordRecordValue[] }) {
   });
   const totalLatency = records.reduce((acc, r) => acc + r.latency, 0);
   const totalSucceededCount = records.reduce(
-    (acc, r) => acc + r.record.automaton.histories.length,
+    (acc, r) => acc + r.record.automaton.edgeHistories.length,
     0
   );
   const totalFailedCount = records.reduce(
-    (acc, r) => acc + r.record.automaton.failedInputCount,
+    (acc, r) => acc + r.record.automaton.getFailedInputCount(),
     0
   );
-  const totalAccuracy = calcAccuracy(totalFailedCount, totalSucceededCount);
+  const totalAccuracy = getAccuracy(totalFailedCount, totalSucceededCount);
   return (
     <div>
       <h1>Finished!</h1>

--- a/examples/react-result-record/src/Typing.tsx
+++ b/examples/react-result-record/src/Typing.tsx
@@ -1,6 +1,6 @@
-import "./App.css";
 import * as emiel from "emiel";
 import { useEffect, useState } from "react";
+import "./App.css";
 
 export function Typing(props: {
   layout: emiel.KeyboardLayout;
@@ -27,17 +27,17 @@ export function Typing(props: {
   return (
     <>
       <h1>
-        <span style={{ color: "gray" }}>{automaton.finishedWord}</span>{" "}
-        {automaton.pendingWord}
+        <span style={{ color: "gray" }}>{automaton.getFinishedWord()}</span>{" "}
+        {automaton.getPendingWord()}
       </h1>
       <h1>
-        <span style={{ color: "gray" }}>{automaton.finishedRoman}</span>{" "}
-        {automaton.pendingRoman}
+        <span style={{ color: "gray" }}>{automaton.getFinishedRoman()}</span>{" "}
+        {automaton.getPendingRoman()}
       </h1>
       <h2>
         Miss:{" "}
         <code>
-          {automaton.failedInputCount}
+          {automaton.getFailedInputCount()}
         </code>
       </h2>
       <h2>

--- a/examples/react-roman-or-kana/src/App.tsx
+++ b/examples/react-roman-or-kana/src/App.tsx
@@ -61,25 +61,25 @@ function Typing(props: { layout: KeyboardLayout }) {
       <h1>
         {/* 課題文かな表示 */}
         <span style={{ color: "gray" }}>
-          {selector.activeItems[0].finishedWord}
+          {selector.activeItems[0].getFinishedWord()}
         </span>{" "}
-        {selector.activeItems[0].pendingWord}
+        {selector.activeItems[0].getPendingWord()}
       </h1>
       {/* ローマ字入力 */}
       <h1>
         <p style={{ fontSize: "1rem" }}>ローマ字入力</p>
         <span style={{ color: "gray" }}>
-          {romanAutomaton.finishedRoman}
+          {romanAutomaton.getFinishedRoman()}
         </span>{" "}
-        {romanAutomaton.pendingRoman}
+        {romanAutomaton.getPendingRoman()}
       </h1>
       {/* かな入力 */}
       <h1>
         <p style={{ fontSize: "1rem" }}>かな入力</p>
         <span style={{ color: "gray" }}>
-          {kanaAutomaton.finishedWord}
+          {kanaAutomaton.getFinishedWord()}
         </span>{" "}
-        {kanaAutomaton.pendingWord}
+        {kanaAutomaton.getPendingWord()}
       </h1>
       <h2>
         Key:{" "}

--- a/examples/react-simple/src/App.tsx
+++ b/examples/react-simple/src/App.tsx
@@ -38,12 +38,12 @@ function Typing(props: { layout: KeyboardLayout }) {
   return (
     <>
       <h1>
-        <span style={{ color: "gray" }}>{automaton.finishedWord}</span>{" "}
-        {automaton.pendingWord}
+        <span style={{ color: "gray" }}>{automaton.getFinishedWord()}</span>{" "}
+        {automaton.getPendingWord()}
       </h1>
       <h1>
-        <span style={{ color: "gray" }}>{automaton.finishedRoman}</span>{" "}
-        {automaton.pendingRoman}
+        <span style={{ color: "gray" }}>{automaton.getFinishedRoman()}</span>{" "}
+        {automaton.getPendingRoman()}
       </h1>
       <h2>
         Key:{" "}

--- a/examples/react-stroke-graph/src/typingGraph.tsx
+++ b/examples/react-stroke-graph/src/typingGraph.tsx
@@ -1,6 +1,6 @@
 import cytoscape from "cytoscape";
 import dagre from "cytoscape-dagre";
-import * as emiel from "emiel";
+import { activate, Automaton, InputStroke } from "emiel";
 import { useEffect, useRef, useState } from "react";
 import { buildGraphData } from "./graphData";
 import { cyStylesheet } from "./grpahStyle";
@@ -9,14 +9,14 @@ import { cyStylesheet } from "./grpahStyle";
 cytoscape.use(dagre);
 
 export function TypingGraph(props: {
-  automaton: emiel.Automaton;
+  automaton: Automaton;
   ruleName: string;
   onFinished: () => void;
 }) {
   const automaton = props.automaton;
   const graphData = buildGraphData(automaton.startNode);
   const htmlElem = useRef(null);
-  const [, setLastInputKey] = useState<emiel.InputStroke | undefined>();
+  const [, setLastInputKey] = useState<InputStroke | undefined>();
   useEffect(() => {
     const cy = cytoscape({
       container: htmlElem.current!,
@@ -30,7 +30,7 @@ export function TypingGraph(props: {
     // @ts-expect-error rankDir is not defined in cytoscape
     cy.layout({ name: "dagre", rankDir: "LR" }).run();
 
-    return emiel.activate(window, (e) => {
+    return activate(window, (e) => {
       setLastInputKey(e.input);
       const result = automaton.input(e);
       console.log(e.input.key.toString(), e.input.type, result);
@@ -46,19 +46,19 @@ export function TypingGraph(props: {
     });
   }, [props]);
 
-  const finishedRomanSubstr = automaton.finishedRoman;
-  const pendingRomanSubstr = automaton.pendingRoman;
+  const finishedRomanSubstr = automaton.getFinishedRoman();
+  const pendingRomanSubstr = automaton.getPendingRoman();
   return (
     <>
       <h2>{props.ruleName}</h2>
       <h1>
-        <span style={{ color: "gray" }}>{automaton.finishedWord}</span>{" "}
-        {automaton.pendingWord}
+        <span style={{ color: "gray" }}>{automaton.getFinishedWord()}</span>{" "}
+        {automaton.getPendingWord()}
       </h1>
       {finishedRomanSubstr || pendingRomanSubstr ? (
         <h1>
-          <span style={{ color: "gray" }}>{automaton.finishedRoman}</span>{" "}
-          {automaton.pendingRoman}
+          <span style={{ color: "gray" }}>{automaton.getFinishedRoman()}</span>{" "}
+          {automaton.getPendingRoman()}
         </h1>
       ) : (
         <></>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "emiel",
   "author": "tomoemon",
   "packageManager": "pnpm@9.11.0",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "type": "module",
   "license": "MIT",
   "repository": {
@@ -32,14 +32,14 @@
   },
   "devDependencies": {
     "@base2/pretty-print-object": "^1.0.2",
-    "@types/estree": "^1.0.5",
+    "@types/estree": "^1.0.8",
     "@types/node": "^22.7.4",
     "@typescript-eslint/eslint-plugin": "^8.0.1",
     "@typescript-eslint/parser": "^8.0.1",
     "eslint": "^8.8.0",
     "prettier": "^3.5.3",
-    "typescript": "^5.6.2",
-    "vite": "^5.4.8",
-    "vitest": "^2.1.1"
+    "typescript": "^5.8.3",
+    "vite": "^6.3.5",
+    "vitest": "^3.2.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,17 +12,17 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       '@types/estree':
-        specifier: ^1.0.5
-        version: 1.0.5
+        specifier: ^1.0.8
+        version: 1.0.8
       '@types/node':
         specifier: ^22.7.4
         version: 22.7.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.0.1
-        version: 8.0.1(@typescript-eslint/parser@8.0.1(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2)
+        version: 8.0.1(@typescript-eslint/parser@8.0.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/parser':
         specifier: ^8.0.1
-        version: 8.0.1(eslint@8.57.1)(typescript@5.6.2)
+        version: 8.0.1(eslint@8.57.1)(typescript@5.8.3)
       eslint:
         specifier: ^8.8.0
         version: 8.57.1
@@ -30,14 +30,14 @@ importers:
         specifier: ^3.5.3
         version: 3.5.3
       typescript:
-        specifier: ^5.6.2
-        version: 5.6.2
+        specifier: ^5.8.3
+        version: 5.8.3
       vite:
-        specifier: ^5.4.8
-        version: 5.4.8(@types/node@22.7.4)
+        specifier: ^6.3.5
+        version: 6.3.5(@types/node@22.7.4)
       vitest:
-        specifier: ^2.1.1
-        version: 2.1.1(@types/node@22.7.4)
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.7.4)
 
 packages:
 
@@ -48,141 +48,153 @@ packages:
   '@base2/pretty-print-object@1.0.2':
     resolution: {integrity: sha512-rBha0UDfV7EmBRjWrGG7Cpwxg8WomPlo0q+R2so47ZFf9wy4YKJzLuHcVa0UGFjdcLZj/4F/1FNC46GIQhe7sA==}
 
-  '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
+  '@esbuild/aix-ppc64@0.25.5':
+    resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm64@0.25.5':
+    resolution: {integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm@0.25.5':
+    resolution: {integrity: sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
+  '@esbuild/android-x64@0.25.5':
+    resolution: {integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-arm64@0.25.5':
+    resolution: {integrity: sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-x64@0.25.5':
+    resolution: {integrity: sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-arm64@0.25.5':
+    resolution: {integrity: sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-x64@0.25.5':
+    resolution: {integrity: sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm64@0.25.5':
+    resolution: {integrity: sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm@0.25.5':
+    resolution: {integrity: sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ia32@0.25.5':
+    resolution: {integrity: sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-loong64@0.25.5':
+    resolution: {integrity: sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-mips64el@0.25.5':
+    resolution: {integrity: sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ppc64@0.25.5':
+    resolution: {integrity: sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-riscv64@0.25.5':
+    resolution: {integrity: sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-s390x@0.25.5':
+    resolution: {integrity: sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-x64@0.25.5':
+    resolution: {integrity: sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
+  '@esbuild/netbsd-arm64@0.25.5':
+    resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.5':
+    resolution: {integrity: sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
+  '@esbuild/openbsd-arm64@0.25.5':
+    resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.5':
+    resolution: {integrity: sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
+  '@esbuild/sunos-x64@0.25.5':
+    resolution: {integrity: sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-arm64@0.25.5':
+    resolution: {integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-ia32@0.25.5':
+    resolution: {integrity: sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-x64@0.25.5':
+    resolution: {integrity: sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -232,88 +244,117 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@rollup/rollup-android-arm-eabi@4.20.0':
-    resolution: {integrity: sha512-TSpWzflCc4VGAUJZlPpgAJE1+V60MePDQnBd7PPkpuEmOy8i87aL6tinFGKBFKuEDikYpig72QzdT3QPYIi+oA==}
+  '@rollup/rollup-android-arm-eabi@4.43.0':
+    resolution: {integrity: sha512-Krjy9awJl6rKbruhQDgivNbD1WuLb8xAclM4IR4cN5pHGAs2oIMMQJEiC3IC/9TZJ+QZkmZhlMO/6MBGxPidpw==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.20.0':
-    resolution: {integrity: sha512-u00Ro/nok7oGzVuh/FMYfNoGqxU5CPWz1mxV85S2w9LxHR8OoMQBuSk+3BKVIDYgkpeOET5yXkx90OYFc+ytpQ==}
+  '@rollup/rollup-android-arm64@4.43.0':
+    resolution: {integrity: sha512-ss4YJwRt5I63454Rpj+mXCXicakdFmKnUNxr1dLK+5rv5FJgAxnN7s31a5VchRYxCFWdmnDWKd0wbAdTr0J5EA==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.20.0':
-    resolution: {integrity: sha512-uFVfvzvsdGtlSLuL0ZlvPJvl6ZmrH4CBwLGEFPe7hUmf7htGAN+aXo43R/V6LATyxlKVC/m6UsLb7jbG+LG39Q==}
+  '@rollup/rollup-darwin-arm64@4.43.0':
+    resolution: {integrity: sha512-eKoL8ykZ7zz8MjgBenEF2OoTNFAPFz1/lyJ5UmmFSz5jW+7XbH1+MAgCVHy72aG59rbuQLcJeiMrP8qP5d/N0A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.20.0':
-    resolution: {integrity: sha512-xbrMDdlev53vNXexEa6l0LffojxhqDTBeL+VUxuuIXys4x6xyvbKq5XqTXBCEUA8ty8iEJblHvFaWRJTk/icAQ==}
+  '@rollup/rollup-darwin-x64@4.43.0':
+    resolution: {integrity: sha512-SYwXJgaBYW33Wi/q4ubN+ldWC4DzQY62S4Ll2dgfr/dbPoF50dlQwEaEHSKrQdSjC6oIe1WgzosoaNoHCdNuMg==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.20.0':
-    resolution: {integrity: sha512-jMYvxZwGmoHFBTbr12Xc6wOdc2xA5tF5F2q6t7Rcfab68TT0n+r7dgawD4qhPEvasDsVpQi+MgDzj2faOLsZjA==}
+  '@rollup/rollup-freebsd-arm64@4.43.0':
+    resolution: {integrity: sha512-SV+U5sSo0yujrjzBF7/YidieK2iF6E7MdF6EbYxNz94lA+R0wKl3SiixGyG/9Klab6uNBIqsN7j4Y/Fya7wAjQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.43.0':
+    resolution: {integrity: sha512-J7uCsiV13L/VOeHJBo5SjasKiGxJ0g+nQTrBkAsmQBIdil3KhPnSE9GnRon4ejX1XDdsmK/l30IYLiAaQEO0Cg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.43.0':
+    resolution: {integrity: sha512-gTJ/JnnjCMc15uwB10TTATBEhK9meBIY+gXP4s0sHD1zHOaIh4Dmy1X9wup18IiY9tTNk5gJc4yx9ctj/fjrIw==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.20.0':
-    resolution: {integrity: sha512-1asSTl4HKuIHIB1GcdFHNNZhxAYEdqML/MW4QmPS4G0ivbEcBr1JKlFLKsIRqjSwOBkdItn3/ZDlyvZ/N6KPlw==}
+  '@rollup/rollup-linux-arm-musleabihf@4.43.0':
+    resolution: {integrity: sha512-ZJ3gZynL1LDSIvRfz0qXtTNs56n5DI2Mq+WACWZ7yGHFUEirHBRt7fyIk0NsCKhmRhn7WAcjgSkSVVxKlPNFFw==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.20.0':
-    resolution: {integrity: sha512-COBb8Bkx56KldOYJfMf6wKeYJrtJ9vEgBRAOkfw6Ens0tnmzPqvlpjZiLgkhg6cA3DGzCmLmmd319pmHvKWWlQ==}
+  '@rollup/rollup-linux-arm64-gnu@4.43.0':
+    resolution: {integrity: sha512-8FnkipasmOOSSlfucGYEu58U8cxEdhziKjPD2FIa0ONVMxvl/hmONtX/7y4vGjdUhjcTHlKlDhw3H9t98fPvyA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.20.0':
-    resolution: {integrity: sha512-+it+mBSyMslVQa8wSPvBx53fYuZK/oLTu5RJoXogjk6x7Q7sz1GNRsXWjn6SwyJm8E/oMjNVwPhmNdIjwP135Q==}
+  '@rollup/rollup-linux-arm64-musl@4.43.0':
+    resolution: {integrity: sha512-KPPyAdlcIZ6S9C3S2cndXDkV0Bb1OSMsX0Eelr2Bay4EsF9yi9u9uzc9RniK3mcUGCLhWY9oLr6er80P5DE6XA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.20.0':
-    resolution: {integrity: sha512-yAMvqhPfGKsAxHN8I4+jE0CpLWD8cv4z7CK7BMmhjDuz606Q2tFKkWRY8bHR9JQXYcoLfopo5TTqzxgPUjUMfw==}
+  '@rollup/rollup-linux-loongarch64-gnu@4.43.0':
+    resolution: {integrity: sha512-HPGDIH0/ZzAZjvtlXj6g+KDQ9ZMHfSP553za7o2Odegb/BEfwJcR0Sw0RLNpQ9nC6Gy8s+3mSS9xjZ0n3rhcYg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.43.0':
+    resolution: {integrity: sha512-gEmwbOws4U4GLAJDhhtSPWPXUzDfMRedT3hFMyRAvM9Mrnj+dJIFIeL7otsv2WF3D7GrV0GIewW0y28dOYWkmw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.20.0':
-    resolution: {integrity: sha512-qmuxFpfmi/2SUkAw95TtNq/w/I7Gpjurx609OOOV7U4vhvUhBcftcmXwl3rqAek+ADBwSjIC4IVNLiszoj3dPA==}
+  '@rollup/rollup-linux-riscv64-gnu@4.43.0':
+    resolution: {integrity: sha512-XXKvo2e+wFtXZF/9xoWohHg+MuRnvO29TI5Hqe9xwN5uN8NKUYy7tXUG3EZAlfchufNCTHNGjEx7uN78KsBo0g==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.20.0':
-    resolution: {integrity: sha512-I0BtGXddHSHjV1mqTNkgUZLnS3WtsqebAXv11D5BZE/gfw5KoyXSAXVqyJximQXNvNzUo4GKlCK/dIwXlz+jlg==}
+  '@rollup/rollup-linux-riscv64-musl@4.43.0':
+    resolution: {integrity: sha512-ruf3hPWhjw6uDFsOAzmbNIvlXFXlBQ4nk57Sec8E8rUxs/AI4HD6xmiiasOOx/3QxS2f5eQMKTAwk7KHwpzr/Q==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.43.0':
+    resolution: {integrity: sha512-QmNIAqDiEMEvFV15rsSnjoSmO0+eJLoKRD9EAa9rrYNwO/XRCtOGM3A5A0X+wmG+XRrw9Fxdsw+LnyYiZWWcVw==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.20.0':
-    resolution: {integrity: sha512-y+eoL2I3iphUg9tN9GB6ku1FA8kOfmF4oUEWhztDJ4KXJy1agk/9+pejOuZkNFhRwHAOxMsBPLbXPd6mJiCwew==}
+  '@rollup/rollup-linux-x64-gnu@4.43.0':
+    resolution: {integrity: sha512-jAHr/S0iiBtFyzjhOkAics/2SrXE092qyqEg96e90L3t9Op8OTzS6+IX0Fy5wCt2+KqeHAkti+eitV0wvblEoQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.20.0':
-    resolution: {integrity: sha512-hM3nhW40kBNYUkZb/r9k2FKK+/MnKglX7UYd4ZUy5DJs8/sMsIbqWK2piZtVGE3kcXVNj3B2IrUYROJMMCikNg==}
+  '@rollup/rollup-linux-x64-musl@4.43.0':
+    resolution: {integrity: sha512-3yATWgdeXyuHtBhrLt98w+5fKurdqvs8B53LaoKD7P7H7FKOONLsBVMNl9ghPQZQuYcceV5CDyPfyfGpMWD9mQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.20.0':
-    resolution: {integrity: sha512-psegMvP+Ik/Bg7QRJbv8w8PAytPA7Uo8fpFjXyCRHWm6Nt42L+JtoqH8eDQ5hRP7/XW2UiIriy1Z46jf0Oa1kA==}
+  '@rollup/rollup-win32-arm64-msvc@4.43.0':
+    resolution: {integrity: sha512-wVzXp2qDSCOpcBCT5WRWLmpJRIzv23valvcTwMHEobkjippNf+C3ys/+wf07poPkeNix0paTNemB2XrHr2TnGw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.20.0':
-    resolution: {integrity: sha512-GabekH3w4lgAJpVxkk7hUzUf2hICSQO0a/BLFA11/RMxQT92MabKAqyubzDZmMOC/hcJNlc+rrypzNzYl4Dx7A==}
+  '@rollup/rollup-win32-ia32-msvc@4.43.0':
+    resolution: {integrity: sha512-fYCTEyzf8d+7diCw8b+asvWDCLMjsCEA8alvtAutqJOJp/wL5hs1rWSqJ1vkjgW0L2NB4bsYJrpKkiIPRR9dvw==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.20.0':
-    resolution: {integrity: sha512-aJ1EJSuTdGnM6qbVC4B5DSmozPTqIag9fSzXRNNo+humQLG89XpPgdt16Ia56ORD7s+H8Pmyx44uczDQ0yDzpg==}
+  '@rollup/rollup-win32-x64-msvc@4.43.0':
+    resolution: {integrity: sha512-SnGhLiE5rlK0ofq8kzuDkM0g7FN1s5VYY+YSMTibP7CqShxCQvqtNxTARS4xX4PFJfHjG0ZQYX9iGzI3FQh5Aw==}
     cpu: [x64]
     os: [win32]
 
-  '@types/estree@1.0.5':
-    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.7':
+    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/node@22.7.4':
     resolution: {integrity: sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==}
@@ -378,35 +419,34 @@ packages:
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  '@vitest/expect@2.1.1':
-    resolution: {integrity: sha512-YeueunS0HiHiQxk+KEOnq/QMzlUuOzbU1Go+PgAsHvvv3tUkJPm9xWt+6ITNTlzsMXUjmgm5T+U7KBPK2qQV6w==}
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
-  '@vitest/mocker@2.1.1':
-    resolution: {integrity: sha512-LNN5VwOEdJqCmJ/2XJBywB11DLlkbY0ooDJW3uRX5cZyYCrc4PI/ePX0iQhE3BiEGiQmK4GE7Q/PqCkkaiPnrA==}
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
-      '@vitest/spy': 2.1.1
-      msw: ^2.3.5
-      vite: ^5.0.0
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@2.1.1':
-    resolution: {integrity: sha512-SjxPFOtuINDUW8/UkElJYQSFtnWX7tMksSGW0vfjxMneFqxVr8YJ979QpMbDW7g+BIiq88RAGDjf7en6rvLPPQ==}
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
-  '@vitest/runner@2.1.1':
-    resolution: {integrity: sha512-uTPuY6PWOYitIkLPidaY5L3t0JJITdGTSwBtwMjKzo5O6RCOEncz9PUN+0pDidX8kTHYjO0EwUIvhlGpnGpxmA==}
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
-  '@vitest/snapshot@2.1.1':
-    resolution: {integrity: sha512-BnSku1WFy7r4mm96ha2FzN99AZJgpZOWrAhtQfoxjUU5YMRpq1zmHRq7a5K9/NjqonebO7iVDla+VvZS8BOWMw==}
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
-  '@vitest/spy@2.1.1':
-    resolution: {integrity: sha512-ZM39BnZ9t/xZ/nF4UwRH5il0Sw93QnZXd9NAZGRpIgj0yvVwPpLd702s/Cx955rGaMlyBQkZJ2Ir7qyY48VZ+g==}
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
-  '@vitest/utils@2.1.1':
-    resolution: {integrity: sha512-Y6Q9TsI+qJ2CC0ZKj6VBb+T8UPz593N113nnUykqwANqhgf3QkZeHFlusgKLTqrnVHbj/XDKZcDHol+dxVT+rQ==}
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -461,8 +501,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  chai@5.1.1:
-    resolution: {integrity: sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==}
+  chai@5.2.0:
+    resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
 
   chalk@4.1.2:
@@ -505,6 +545,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.1:
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -520,9 +569,12 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
-  esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.25.5:
+    resolution: {integrity: sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escape-string-regexp@4.0.0:
@@ -565,6 +617,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  expect-type@1.2.1:
+    resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
+    engines: {node: '>=12.0.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -580,6 +636,14 @@ packages:
 
   fastq@1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
+
+  fdir@6.4.6:
+    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -680,6 +744,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -710,8 +777,11 @@ packages:
   loupe@3.1.1:
     resolution: {integrity: sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==}
 
-  magic-string@0.30.11:
-    resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
+  loupe@3.1.4:
+    resolution: {integrity: sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==}
+
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -731,8 +801,11 @@ packages:
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
-  nanoid@3.3.7:
-    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -774,22 +847,26 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
 
-  picocolors@1.1.0:
-    resolution: {integrity: sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==}
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
-  postcss@8.4.47:
-    resolution: {integrity: sha512-56rxCq7G/XfB4EkXq9Egn5GCqugWvDFjafDOThIdMBsI15iqPqR5r15TfSr1YPYeEI19YeaXMCbY6u88Y76GLQ==}
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -821,8 +898,8 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rollup@4.20.0:
-    resolution: {integrity: sha512-6rbWBChcnSGzIlXeIdNIZTopKYad8ZG8ajhl78lGRLsI2rX8IkaotQhVas2Ma+GPxJav19wrSzvRvuiv0YKzWw==}
+  rollup@4.43.0:
+    resolution: {integrity: sha512-wdN2Kd3Twh8MAEOEJZsuxuLKCsBEo4PVNLK6tQWAn10VhsVewQLzcucMgLolRlhFybGxfclbPeEYBaP6RvUFGg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -856,8 +933,8 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.7.0:
-    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -866,6 +943,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -877,19 +957,23 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.0:
-    resolution: {integrity: sha512-tVGE0mVJPGb0chKhqmsoosjsS+qUnJVGJpZgsHYQcGoPlG3B51R3PouqTgEGH2Dc9jjFyOqOpix6ZHNMXp1FZg==}
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinypool@1.0.0:
-    resolution: {integrity: sha512-KIKExllK7jp3uvrNtvRBYBWBOAXSX8ZvoaD8T+7KB/QHIuoJW3Pmr60zucywjAlMb5TeXUkcs/MWeWLu0qvuAQ==}
+  tinyglobby@0.2.14:
+    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
-  tinyrainbow@1.2.0:
-    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
-  tinyspy@3.0.0:
-    resolution: {integrity: sha512-q5nmENpTHgiPVd1cJDDc9cVoYN5x4vCvwT3FMilvKPKneCBZAxn2YWQjDF0UMcE9k0Cay1gBiDfTMU0g+mPMQA==}
+  tinyspy@4.0.3:
+    resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
     engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
@@ -910,8 +994,8 @@ packages:
     resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
     engines: {node: '>=10'}
 
-  typescript@5.6.2:
-    resolution: {integrity: sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -921,26 +1005,31 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  vite-node@2.1.1:
-    resolution: {integrity: sha512-N/mGckI1suG/5wQI35XeR9rsMsPqKXzq1CdUndzVstBj/HvyxxGctwnK6WX43NGt5L3Z5tcRf83g4TITKJhPrA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@5.4.8:
-    resolution: {integrity: sha512-FqrItQ4DT1NC4zCUqMB4c4AZORMKIa0m8/URVCZ77OZ/QSNeJ54bU1vrFADbDsuwfIPcgknRkmqakQcgnL4GiQ==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vite@6.3.5:
+    resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^18.0.0 || >=20.0.0
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
       sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
-      terser: ^5.4.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
     peerDependenciesMeta:
       '@types/node':
+        optional: true
+      jiti:
         optional: true
       less:
         optional: true
@@ -956,20 +1045,27 @@ packages:
         optional: true
       terser:
         optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
-  vitest@2.1.1:
-    resolution: {integrity: sha512-97We7/VC0e9X5zBVkvt7SGQMGrRtn3KtySFQG5fpaMlS+l62eeXRQO633AYhSTC3z7IMebnPPNjGXVGNRFlxBA==}
-    engines: {node: ^18.0.0 || >=20.0.0}
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.1
-      '@vitest/ui': 2.1.1
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
       '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
         optional: true
       '@types/node':
         optional: true
@@ -1005,73 +1101,79 @@ snapshots:
 
   '@base2/pretty-print-object@1.0.2': {}
 
-  '@esbuild/aix-ppc64@0.21.5':
+  '@esbuild/aix-ppc64@0.25.5':
     optional: true
 
-  '@esbuild/android-arm64@0.21.5':
+  '@esbuild/android-arm64@0.25.5':
     optional: true
 
-  '@esbuild/android-arm@0.21.5':
+  '@esbuild/android-arm@0.25.5':
     optional: true
 
-  '@esbuild/android-x64@0.21.5':
+  '@esbuild/android-x64@0.25.5':
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.5':
+  '@esbuild/darwin-arm64@0.25.5':
     optional: true
 
-  '@esbuild/darwin-x64@0.21.5':
+  '@esbuild/darwin-x64@0.25.5':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.5':
+  '@esbuild/freebsd-arm64@0.25.5':
     optional: true
 
-  '@esbuild/freebsd-x64@0.21.5':
+  '@esbuild/freebsd-x64@0.25.5':
     optional: true
 
-  '@esbuild/linux-arm64@0.21.5':
+  '@esbuild/linux-arm64@0.25.5':
     optional: true
 
-  '@esbuild/linux-arm@0.21.5':
+  '@esbuild/linux-arm@0.25.5':
     optional: true
 
-  '@esbuild/linux-ia32@0.21.5':
+  '@esbuild/linux-ia32@0.25.5':
     optional: true
 
-  '@esbuild/linux-loong64@0.21.5':
+  '@esbuild/linux-loong64@0.25.5':
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.5':
+  '@esbuild/linux-mips64el@0.25.5':
     optional: true
 
-  '@esbuild/linux-ppc64@0.21.5':
+  '@esbuild/linux-ppc64@0.25.5':
     optional: true
 
-  '@esbuild/linux-riscv64@0.21.5':
+  '@esbuild/linux-riscv64@0.25.5':
     optional: true
 
-  '@esbuild/linux-s390x@0.21.5':
+  '@esbuild/linux-s390x@0.25.5':
     optional: true
 
-  '@esbuild/linux-x64@0.21.5':
+  '@esbuild/linux-x64@0.25.5':
     optional: true
 
-  '@esbuild/netbsd-x64@0.21.5':
+  '@esbuild/netbsd-arm64@0.25.5':
     optional: true
 
-  '@esbuild/openbsd-x64@0.21.5':
+  '@esbuild/netbsd-x64@0.25.5':
     optional: true
 
-  '@esbuild/sunos-x64@0.21.5':
+  '@esbuild/openbsd-arm64@0.25.5':
     optional: true
 
-  '@esbuild/win32-arm64@0.21.5':
+  '@esbuild/openbsd-x64@0.25.5':
     optional: true
 
-  '@esbuild/win32-ia32@0.21.5':
+  '@esbuild/sunos-x64@0.25.5':
     optional: true
 
-  '@esbuild/win32-x64@0.21.5':
+  '@esbuild/win32-arm64@0.25.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.5':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.1)':
@@ -1123,88 +1225,108 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  '@rollup/rollup-android-arm-eabi@4.20.0':
+  '@rollup/rollup-android-arm-eabi@4.43.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.20.0':
+  '@rollup/rollup-android-arm64@4.43.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.20.0':
+  '@rollup/rollup-darwin-arm64@4.43.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.20.0':
+  '@rollup/rollup-darwin-x64@4.43.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.20.0':
+  '@rollup/rollup-freebsd-arm64@4.43.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.20.0':
+  '@rollup/rollup-freebsd-x64@4.43.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.20.0':
+  '@rollup/rollup-linux-arm-gnueabihf@4.43.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.20.0':
+  '@rollup/rollup-linux-arm-musleabihf@4.43.0':
     optional: true
 
-  '@rollup/rollup-linux-powerpc64le-gnu@4.20.0':
+  '@rollup/rollup-linux-arm64-gnu@4.43.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.20.0':
+  '@rollup/rollup-linux-arm64-musl@4.43.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.20.0':
+  '@rollup/rollup-linux-loongarch64-gnu@4.43.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.20.0':
+  '@rollup/rollup-linux-powerpc64le-gnu@4.43.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.20.0':
+  '@rollup/rollup-linux-riscv64-gnu@4.43.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.20.0':
+  '@rollup/rollup-linux-riscv64-musl@4.43.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.20.0':
+  '@rollup/rollup-linux-s390x-gnu@4.43.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.20.0':
+  '@rollup/rollup-linux-x64-gnu@4.43.0':
     optional: true
 
-  '@types/estree@1.0.5': {}
+  '@rollup/rollup-linux-x64-musl@4.43.0':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.43.0':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.43.0':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.43.0':
+    optional: true
+
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.7': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/node@22.7.4':
     dependencies:
       undici-types: 6.19.8
 
-  '@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1)(typescript@5.6.2)':
+  '@typescript-eslint/eslint-plugin@8.0.1(@typescript-eslint/parser@8.0.1(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.11.0
-      '@typescript-eslint/parser': 8.0.1(eslint@8.57.1)(typescript@5.6.2)
+      '@typescript-eslint/parser': 8.0.1(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.0.1
-      '@typescript-eslint/type-utils': 8.0.1(eslint@8.57.1)(typescript@5.6.2)
-      '@typescript-eslint/utils': 8.0.1(eslint@8.57.1)(typescript@5.6.2)
+      '@typescript-eslint/type-utils': 8.0.1(eslint@8.57.1)(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.0.1(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.0.1
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.1
       natural-compare: 1.4.0
-      ts-api-utils: 1.3.0(typescript@5.6.2)
+      ts-api-utils: 1.3.0(typescript@5.8.3)
     optionalDependencies:
-      typescript: 5.6.2
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.0.1(eslint@8.57.1)(typescript@5.6.2)':
+  '@typescript-eslint/parser@8.0.1(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.0.1
       '@typescript-eslint/types': 8.0.1
-      '@typescript-eslint/typescript-estree': 8.0.1(typescript@5.6.2)
+      '@typescript-eslint/typescript-estree': 8.0.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.0.1
       debug: 4.3.4
       eslint: 8.57.1
     optionalDependencies:
-      typescript: 5.6.2
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -1213,21 +1335,21 @@ snapshots:
       '@typescript-eslint/types': 8.0.1
       '@typescript-eslint/visitor-keys': 8.0.1
 
-  '@typescript-eslint/type-utils@8.0.1(eslint@8.57.1)(typescript@5.6.2)':
+  '@typescript-eslint/type-utils@8.0.1(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.0.1(typescript@5.6.2)
-      '@typescript-eslint/utils': 8.0.1(eslint@8.57.1)(typescript@5.6.2)
+      '@typescript-eslint/typescript-estree': 8.0.1(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.0.1(eslint@8.57.1)(typescript@5.8.3)
       debug: 4.3.4
-      ts-api-utils: 1.3.0(typescript@5.6.2)
+      ts-api-utils: 1.3.0(typescript@5.8.3)
     optionalDependencies:
-      typescript: 5.6.2
+      typescript: 5.8.3
     transitivePeerDependencies:
       - eslint
       - supports-color
 
   '@typescript-eslint/types@8.0.1': {}
 
-  '@typescript-eslint/typescript-estree@8.0.1(typescript@5.6.2)':
+  '@typescript-eslint/typescript-estree@8.0.1(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 8.0.1
       '@typescript-eslint/visitor-keys': 8.0.1
@@ -1236,18 +1358,18 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.6.3
-      ts-api-utils: 1.3.0(typescript@5.6.2)
+      ts-api-utils: 1.3.0(typescript@5.8.3)
     optionalDependencies:
-      typescript: 5.6.2
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.0.1(eslint@8.57.1)(typescript@5.6.2)':
+  '@typescript-eslint/utils@8.0.1(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 8.0.1
       '@typescript-eslint/types': 8.0.1
-      '@typescript-eslint/typescript-estree': 8.0.1(typescript@5.6.2)
+      '@typescript-eslint/typescript-estree': 8.0.1(typescript@5.8.3)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
@@ -1260,45 +1382,47 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitest/expect@2.1.1':
+  '@vitest/expect@3.2.4':
     dependencies:
-      '@vitest/spy': 2.1.1
-      '@vitest/utils': 2.1.1
-      chai: 5.1.1
-      tinyrainbow: 1.2.0
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.0
+      tinyrainbow: 2.0.0
 
-  '@vitest/mocker@2.1.1(@vitest/spy@2.1.1)(vite@5.4.8(@types/node@22.7.4))':
+  '@vitest/mocker@3.2.4(vite@6.3.5(@types/node@22.7.4))':
     dependencies:
-      '@vitest/spy': 2.1.1
+      '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
-      magic-string: 0.30.11
+      magic-string: 0.30.17
     optionalDependencies:
-      vite: 5.4.8(@types/node@22.7.4)
+      vite: 6.3.5(@types/node@22.7.4)
 
-  '@vitest/pretty-format@2.1.1':
+  '@vitest/pretty-format@3.2.4':
     dependencies:
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
-  '@vitest/runner@2.1.1':
+  '@vitest/runner@3.2.4':
     dependencies:
-      '@vitest/utils': 2.1.1
-      pathe: 1.1.2
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.0.0
 
-  '@vitest/snapshot@2.1.1':
+  '@vitest/snapshot@3.2.4':
     dependencies:
-      '@vitest/pretty-format': 2.1.1
-      magic-string: 0.30.11
-      pathe: 1.1.2
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.17
+      pathe: 2.0.3
 
-  '@vitest/spy@2.1.1':
+  '@vitest/spy@3.2.4':
     dependencies:
-      tinyspy: 3.0.0
+      tinyspy: 4.0.3
 
-  '@vitest/utils@2.1.1':
+  '@vitest/utils@3.2.4':
     dependencies:
-      '@vitest/pretty-format': 2.1.1
-      loupe: 3.1.1
-      tinyrainbow: 1.2.0
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.1.4
+      tinyrainbow: 2.0.0
 
   acorn-jsx@5.3.2(acorn@8.12.1):
     dependencies:
@@ -1344,7 +1468,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  chai@5.1.1:
+  chai@5.2.0:
     dependencies:
       assertion-error: 2.0.1
       check-error: 2.1.1
@@ -1381,6 +1505,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
@@ -1393,31 +1521,35 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  esbuild@0.21.5:
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.25.5:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
+      '@esbuild/aix-ppc64': 0.25.5
+      '@esbuild/android-arm': 0.25.5
+      '@esbuild/android-arm64': 0.25.5
+      '@esbuild/android-x64': 0.25.5
+      '@esbuild/darwin-arm64': 0.25.5
+      '@esbuild/darwin-x64': 0.25.5
+      '@esbuild/freebsd-arm64': 0.25.5
+      '@esbuild/freebsd-x64': 0.25.5
+      '@esbuild/linux-arm': 0.25.5
+      '@esbuild/linux-arm64': 0.25.5
+      '@esbuild/linux-ia32': 0.25.5
+      '@esbuild/linux-loong64': 0.25.5
+      '@esbuild/linux-mips64el': 0.25.5
+      '@esbuild/linux-ppc64': 0.25.5
+      '@esbuild/linux-riscv64': 0.25.5
+      '@esbuild/linux-s390x': 0.25.5
+      '@esbuild/linux-x64': 0.25.5
+      '@esbuild/netbsd-arm64': 0.25.5
+      '@esbuild/netbsd-x64': 0.25.5
+      '@esbuild/openbsd-arm64': 0.25.5
+      '@esbuild/openbsd-x64': 0.25.5
+      '@esbuild/sunos-x64': 0.25.5
+      '@esbuild/win32-arm64': 0.25.5
+      '@esbuild/win32-ia32': 0.25.5
+      '@esbuild/win32-x64': 0.25.5
 
   escape-string-regexp@4.0.0: {}
 
@@ -1489,9 +1621,11 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.8
 
   esutils@2.0.3: {}
+
+  expect-type@1.2.1: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -1510,6 +1644,10 @@ snapshots:
   fastq@1.15.0:
     dependencies:
       reusify: 1.0.4
+
+  fdir@6.4.6(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -1603,6 +1741,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -1632,7 +1772,9 @@ snapshots:
     dependencies:
       get-func-name: 2.0.2
 
-  magic-string@0.30.11:
+  loupe@3.1.4: {}
+
+  magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
@@ -1653,7 +1795,9 @@ snapshots:
 
   ms@2.1.2: {}
 
-  nanoid@3.3.7: {}
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
 
@@ -1690,18 +1834,20 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  pathe@1.1.2: {}
+  pathe@2.0.3: {}
 
   pathval@2.0.0: {}
 
-  picocolors@1.1.0: {}
+  picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
-  postcss@8.4.47:
+  picomatch@4.0.2: {}
+
+  postcss@8.5.6:
     dependencies:
-      nanoid: 3.3.7
-      picocolors: 1.1.0
+      nanoid: 3.3.11
+      picocolors: 1.1.1
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
@@ -1720,26 +1866,30 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rollup@4.20.0:
+  rollup@4.43.0:
     dependencies:
-      '@types/estree': 1.0.5
+      '@types/estree': 1.0.7
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.20.0
-      '@rollup/rollup-android-arm64': 4.20.0
-      '@rollup/rollup-darwin-arm64': 4.20.0
-      '@rollup/rollup-darwin-x64': 4.20.0
-      '@rollup/rollup-linux-arm-gnueabihf': 4.20.0
-      '@rollup/rollup-linux-arm-musleabihf': 4.20.0
-      '@rollup/rollup-linux-arm64-gnu': 4.20.0
-      '@rollup/rollup-linux-arm64-musl': 4.20.0
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.20.0
-      '@rollup/rollup-linux-riscv64-gnu': 4.20.0
-      '@rollup/rollup-linux-s390x-gnu': 4.20.0
-      '@rollup/rollup-linux-x64-gnu': 4.20.0
-      '@rollup/rollup-linux-x64-musl': 4.20.0
-      '@rollup/rollup-win32-arm64-msvc': 4.20.0
-      '@rollup/rollup-win32-ia32-msvc': 4.20.0
-      '@rollup/rollup-win32-x64-msvc': 4.20.0
+      '@rollup/rollup-android-arm-eabi': 4.43.0
+      '@rollup/rollup-android-arm64': 4.43.0
+      '@rollup/rollup-darwin-arm64': 4.43.0
+      '@rollup/rollup-darwin-x64': 4.43.0
+      '@rollup/rollup-freebsd-arm64': 4.43.0
+      '@rollup/rollup-freebsd-x64': 4.43.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.43.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.43.0
+      '@rollup/rollup-linux-arm64-gnu': 4.43.0
+      '@rollup/rollup-linux-arm64-musl': 4.43.0
+      '@rollup/rollup-linux-loongarch64-gnu': 4.43.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.43.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.43.0
+      '@rollup/rollup-linux-riscv64-musl': 4.43.0
+      '@rollup/rollup-linux-s390x-gnu': 4.43.0
+      '@rollup/rollup-linux-x64-gnu': 4.43.0
+      '@rollup/rollup-linux-x64-musl': 4.43.0
+      '@rollup/rollup-win32-arm64-msvc': 4.43.0
+      '@rollup/rollup-win32-ia32-msvc': 4.43.0
+      '@rollup/rollup-win32-x64-msvc': 4.43.0
       fsevents: 2.3.3
 
   run-parallel@1.2.0:
@@ -1762,13 +1912,17 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.7.0: {}
+  std-env@3.9.0: {}
 
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   supports-color@7.2.0:
     dependencies:
@@ -1778,21 +1932,26 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.0: {}
+  tinyexec@0.3.2: {}
 
-  tinypool@1.0.0: {}
+  tinyglobby@0.2.14:
+    dependencies:
+      fdir: 6.4.6(picomatch@4.0.2)
+      picomatch: 4.0.2
 
-  tinyrainbow@1.2.0: {}
+  tinypool@1.1.1: {}
 
-  tinyspy@3.0.0: {}
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.3: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
-  ts-api-utils@1.3.0(typescript@5.6.2):
+  ts-api-utils@1.3.0(typescript@5.8.3):
     dependencies:
-      typescript: 5.6.2
+      typescript: 5.8.3
 
   type-check@0.4.0:
     dependencies:
@@ -1800,7 +1959,7 @@ snapshots:
 
   type-fest@0.20.2: {}
 
-  typescript@5.6.2: {}
+  typescript@5.8.3: {}
 
   undici-types@6.19.8: {}
 
@@ -1808,14 +1967,16 @@ snapshots:
     dependencies:
       punycode: 2.3.0
 
-  vite-node@2.1.1(@types/node@22.7.4):
+  vite-node@3.2.4(@types/node@22.7.4):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.6
-      pathe: 1.1.2
-      vite: 5.4.8(@types/node@22.7.4)
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.3.5(@types/node@22.7.4)
     transitivePeerDependencies:
       - '@types/node'
+      - jiti
       - less
       - lightningcss
       - sass
@@ -1824,40 +1985,50 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
 
-  vite@5.4.8(@types/node@22.7.4):
+  vite@6.3.5(@types/node@22.7.4):
     dependencies:
-      esbuild: 0.21.5
-      postcss: 8.4.47
-      rollup: 4.20.0
+      esbuild: 0.25.5
+      fdir: 6.4.6(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.6
+      rollup: 4.43.0
+      tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 22.7.4
       fsevents: 2.3.3
 
-  vitest@2.1.1(@types/node@22.7.4):
+  vitest@3.2.4(@types/node@22.7.4):
     dependencies:
-      '@vitest/expect': 2.1.1
-      '@vitest/mocker': 2.1.1(@vitest/spy@2.1.1)(vite@5.4.8(@types/node@22.7.4))
-      '@vitest/pretty-format': 2.1.1
-      '@vitest/runner': 2.1.1
-      '@vitest/snapshot': 2.1.1
-      '@vitest/spy': 2.1.1
-      '@vitest/utils': 2.1.1
-      chai: 5.1.1
-      debug: 4.3.6
-      magic-string: 0.30.11
-      pathe: 1.1.2
-      std-env: 3.7.0
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.3.5(@types/node@22.7.4))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.0
+      debug: 4.4.1
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      std-env: 3.9.0
       tinybench: 2.9.0
-      tinyexec: 0.3.0
-      tinypool: 1.0.0
-      tinyrainbow: 1.2.0
-      vite: 5.4.8(@types/node@22.7.4)
-      vite-node: 2.1.1(@types/node@22.7.4)
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.3.5(@types/node@22.7.4)
+      vite-node: 3.2.4(@types/node@22.7.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.7.4
     transitivePeerDependencies:
+      - jiti
       - less
       - lightningcss
       - msw
@@ -1867,6 +2038,8 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
 
   which@2.0.2:
     dependencies:

--- a/src/core/automaton.test.ts
+++ b/src/core/automaton.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import { loadPresetKeyboardLayoutQwertyJis } from "../impl/presetKeyboardLayout";
+import { loadPresetRuleRoman } from "../impl/presetRules";
+import { Automaton } from "./automatonBuilder";
+import { AutomatonState } from "./automatonState";
+
+describe("Automaton with extensions", () => {
+  const rule = loadPresetRuleRoman(loadPresetKeyboardLayoutQwertyJis());
+
+  it("should work with default extension after build", () => {
+    const automaton = rule.build("こんにちは");
+
+    // デフォルト拡張のメソッドが使える（rule.build はデフォルト拡張を含む）
+    expect(automaton.getFinishedWord()).toBe("");
+    expect(automaton.getPendingWord()).toBe("こんにちは");
+    expect(automaton.isFinished()).toBe(false);
+  });
+
+  it("should add extension methods with correct types", () => {
+    const automaton = rule.build("こんにちは");
+
+    // 型推論が正しく動作する
+    const finishedWord: string = automaton.getFinishedWord();
+    const pendingWord: string = automaton.getPendingWord();
+    const isFinished: boolean = automaton.isFinished();
+
+    expect(finishedWord).toBe("");
+    expect(pendingWord).toBe("こんにちは");
+    expect(isFinished).toBe(false);
+  });
+
+  it("should chain multiple extensions", () => {
+    const customExtension = {
+      getWordLength: (state: AutomatonState) => state.word.length,
+      getCustomStat: (state: AutomatonState) => state.currentNode.kanaIndex * 2,
+    };
+
+    // baseAutomaton を作るための startNode を取得
+    const baseAutomaton = rule.build("こんにちは");
+
+    // 拡張を段階的に適用
+    const withDefault = baseAutomaton;
+    const automaton = withDefault.with(customExtension);
+
+    // すべての拡張メソッドが使える
+    expect(automaton.getFinishedWord()).toBe("");
+    expect(automaton.getWordLength()).toBe(5);
+    expect(automaton.getCustomStat()).toBe(0);
+  });
+
+  it("should preserve Automaton methods", () => {
+    const automaton = rule.build("こんにちは");
+
+    // 元の Automaton のメソッドも使える
+    expect(automaton.word).toBe("こんにちは");
+    expect(automaton.currentNode).toBeDefined();
+    expect(automaton.input).toBeDefined();
+    expect(automaton.reset).toBeDefined();
+  });
+
+  it("should infer correct return types", () => {
+    const testExtension = {
+      getNumber: (_state: AutomatonState) => 42,
+      getString: (_state: AutomatonState) => "hello",
+      getBoolean: (_state: AutomatonState) => true,
+      getArray: (_state: AutomatonState) => [1, 2, 3],
+      getObject: (_state: AutomatonState) => ({ foo: "bar" }),
+      getLiteral: (_state: AutomatonState) => "success" as const,
+      getUnion: (_state: AutomatonState) => (Math.random() > 0.5 ? "a" : "b"),
+    } as const;
+
+    const automaton = rule.build("test").with(testExtension);
+
+    // 型推論のテスト
+    const num: number = automaton.getNumber();
+    const str: string = automaton.getString();
+    const bool: boolean = automaton.getBoolean();
+    const arr: number[] = automaton.getArray();
+    const obj: { foo: string } = automaton.getObject();
+    const literal: "success" = automaton.getLiteral();
+    const union: "a" | "b" = automaton.getUnion();
+
+    expect(num).toBe(42);
+    expect(str).toBe("hello");
+    expect(bool).toBe(true);
+    expect(arr).toEqual([1, 2, 3]);
+    expect(obj).toEqual({ foo: "bar" });
+    expect(literal).toBe("success");
+    expect(["a", "b"]).toContain(union);
+  });
+
+  // automaton ごとに実行時特有の値を割り当てる
+  it("should have their own value", () => {
+    const automaton1 = rule.build("こんにちは").with({
+      getPosition: (_: AutomatonState) => 10,
+    });
+    const automaton2 = rule.build("さようなら").with({
+      getPosition: (_: AutomatonState) => 20,
+    });
+
+    expect(automaton1.getPosition()).toBe(10);
+    expect(automaton2.getPosition()).toBe(20);
+  });
+
+  it("should allow functions to call other functions in the same extension", () => {
+    const extension = {
+      getSucceededCount: (_: AutomatonState) => 100,
+      getTotalCount(state: AutomatonState) {
+        return this.getSucceededCount(state) + this.getMissedCount(state);
+      },
+      getMissedCount: (_: AutomatonState) => 50,
+    };
+
+    const automaton = rule.build("こんにちは").with(extension);
+
+    expect(automaton.getSucceededCount()).toBe(100);
+    expect(automaton.getMissedCount()).toBe(50);
+    expect(automaton.getTotalCount()).toBe(150);
+  });
+
+  it("should have their own state", () => {
+    const counterWrapper = (a: Automaton) => {
+      let count = 0;
+      return a.with({
+        increment: () => {
+          count++;
+        },
+        getCount: () => count,
+      });
+    };
+    const automaton1 = counterWrapper(rule.build("こんにちは"));
+    const automaton2 = counterWrapper(rule.build("さようなら"));
+
+    expect(automaton1.getCount()).toBe(0);
+    expect(automaton2.getCount()).toBe(0);
+
+    automaton1.increment();
+    expect(automaton1.getCount()).toBe(1);
+    expect(automaton2.getCount()).toBe(0);
+
+    automaton1.increment();
+    expect(automaton1.getCount()).toBe(2);
+    expect(automaton2.getCount()).toBe(0);
+
+    automaton2.increment();
+    expect(automaton1.getCount()).toBe(2);
+    expect(automaton2.getCount()).toBe(1);
+  });
+});

--- a/src/core/automatonBuilder.ts
+++ b/src/core/automatonBuilder.ts
@@ -1,9 +1,112 @@
-import { Automaton } from "./automaton";
+import { AutomatonImpl } from "./automaton";
+import * as AutomatonGetters from "./automatonGetters";
+import { AutomatonState } from "./automatonState";
 import { buildKanaNode } from "./builderKanaGraph";
 import { buildStrokeNode } from "./builderStrokeGraph";
 import { Rule } from "./rule";
+import { RuleStroke } from "./ruleStroke";
+
+export type Automaton = AutomatonImpl & DefaultExtensionType;
 
 export function build(rule: Rule, kanaText: string): Automaton {
   const [_, endKanaNode] = buildKanaNode(rule, kanaText);
-  return new Automaton(kanaText, buildStrokeNode(endKanaNode), rule);
+  const automaton = new AutomatonImpl(kanaText, buildStrokeNode(endKanaNode), rule);
+  return automaton.with(defaultExtension);
 }
+
+/**
+ * デフォルトの拡張
+ */
+const defaultExtension = {
+  /**
+   * 入力が完了したかな文字列
+   */
+  getFinishedWord(state: AutomatonState): string {
+    return AutomatonGetters.getFinishedWord(state);
+  },
+
+  /**
+   * 入力が完了していないかな文字列
+   */
+  getPendingWord(state: AutomatonState): string {
+    return AutomatonGetters.getPendingWord(state);
+  },
+
+  /**
+   * 入力が完了したローマ字列（ローマ字系の Rule の場合のみ）
+   */
+  getFinishedRoman(state: AutomatonState): string {
+    return AutomatonGetters.getFinishedRoman(state);
+  },
+
+  /**
+   * 入力が完了していないローマ字列（ローマ字系の Rule の場合のみ）
+   */
+  getPendingRoman(state: AutomatonState): string {
+    return AutomatonGetters.getPendingRoman(state);
+  },
+
+  /**
+   * 入力が完了したキーストローク列
+   */
+  getFinishedStroke(state: AutomatonState): RuleStroke[] {
+    return AutomatonGetters.getFinishedStroke(state);
+  },
+
+  /**
+   * 現在の入力状態から最短ストローク数で打ち切れるストローク列を返す
+   */
+  getPendingStroke(state: AutomatonState): RuleStroke[] {
+    return AutomatonGetters.getPendingStroke(state);
+  },
+
+  /**
+   * 1打目の入力時刻
+   */
+  getFirstInputTime(state: AutomatonState): Date {
+    return AutomatonGetters.getFirstInputTime(state);
+  },
+
+  /**
+   * 最後の入力時刻
+   */
+  getLastInputTime(state: AutomatonState): Date {
+    return AutomatonGetters.getLastInputTime(state);
+  },
+
+  /**
+   * ミス入力数の合計
+   */
+  getFailedInputCount(state: AutomatonState): number {
+    return AutomatonGetters.getFailedInputCount(state);
+  },
+
+  /**
+   * ミス入力も含めた打鍵数の合計
+   */
+  getTotalInputCount(state: AutomatonState): number {
+    return AutomatonGetters.getTotalInputCount(state);
+  },
+
+  /**
+   * 入力が完了しているかどうか
+   */
+  isFinished(state: AutomatonState): boolean {
+    return AutomatonGetters.isFinished(state);
+  },
+} as const;
+
+// デフォルト拡張の型（引数なしバージョン）
+export type DefaultExtensionType = {
+  getFinishedWord(): string;
+  getPendingWord(): string;
+  getFinishedRoman(): string;
+  getPendingRoman(): string;
+  getFinishedStroke(): RuleStroke[];
+  getPendingStroke(): RuleStroke[];
+  getFirstInputTime(): Date;
+  getLastInputTime(): Date;
+  getFailedInputCount(): number;
+  getTotalInputCount(): number;
+  isFinished(): boolean;
+};

--- a/src/core/automatonGetters.ts
+++ b/src/core/automatonGetters.ts
@@ -1,0 +1,92 @@
+import { AutomatonState } from "./automatonState";
+import { RuleStroke } from "./ruleStroke";
+
+/**
+ * 入力が完了したかな文字列
+ */
+export function getFinishedWord(state: AutomatonState): string {
+  return state.word.substring(0, state.currentNode.kanaIndex);
+}
+
+/**
+ * 入力が完了していないかな文字列
+ */
+export function getPendingWord(state: AutomatonState): string {
+  return state.word.substring(state.currentNode.kanaIndex);
+}
+
+/**
+ * 入力が完了したローマ字列（ローマ字系の Rule の場合のみ）
+ */
+export function getFinishedRoman(state: AutomatonState): string {
+  return state.edgeHistories.map((v) => v.previousEdge.input.romanChar).join("");
+}
+
+/**
+ * 入力が完了していないローマ字列（ローマ字系の Rule の場合のみ）
+ */
+export function getPendingRoman(state: AutomatonState): string {
+  return getPendingStroke(state).map((v) => v.romanChar).join("");
+}
+
+/**
+ * 入力が完了したキーストローク列
+ */
+export function getFinishedStroke(state: AutomatonState): RuleStroke[] {
+  return state.edgeHistories.map((v) => v.previousEdge.input);
+}
+
+/**
+ * 現在の入力状態から最短ストローク数で打ち切れるストローク列を返す
+ */
+export function getPendingStroke(state: AutomatonState): RuleStroke[] {
+  let node = state.currentNode;
+  const result: RuleStroke[] = [];
+  while (node.nextEdges.length > 0) {
+    result.push(node.nextEdges[0].input);
+    node = node.nextEdges[0].next;
+  }
+  return result;
+}
+
+/**
+ * 1打目の入力時刻
+ */
+export function getFirstInputTime(state: AutomatonState): Date {
+  return state.edgeHistories[0].event.timestamp;
+}
+
+/**
+ * 最後の入力時刻
+ */
+export function getLastInputTime(state: AutomatonState): Date {
+  return state.edgeHistories[state.edgeHistories.length - 1].event.timestamp;
+}
+
+/**
+ * ミス入力数の合計
+ */
+export function getFailedInputCount(state: AutomatonState): number {
+  return (
+    state.failedEventsAtCurrentNode.length +
+    state.edgeHistories.reduce((acc, v) => acc + v.failedEvents.length, 0)
+  );
+}
+
+/**
+ * ミス入力も含めた打鍵数の合計
+ */
+export function getTotalInputCount(state: AutomatonState): number {
+  return (
+    state.failedEventsAtCurrentNode.length +
+    state.edgeHistories.reduce((acc, v) => acc + v.failedEvents.length, 0) +
+    state.edgeHistories.length
+  );
+}
+
+/**
+ * 入力が完了しているかどうか
+ */
+export function isFinished(state: AutomatonState): boolean {
+  return state.currentNode.nextEdges.length === 0;
+}

--- a/src/core/automatonState.ts
+++ b/src/core/automatonState.ts
@@ -1,0 +1,25 @@
+import { StrokeNode } from "./builderStrokeGraph";
+import { InputEvent } from "./inputEvent";
+import { Rule } from "./rule";
+
+export type EdgeHistory = {
+  // 遷移のきっかけになった成功した入力イベント
+  event: InputEvent;
+  // 今回の遷移で利用されたエッジ（この Edge をたどると startNode まで戻れる）
+  previousEdge: import("./builderStrokeGraph").StrokeEdge;
+  // 今回の遷移に成功するまでに失敗した入力イベント
+  // failedEvents[0], failedEvents[1], ..., event(入力成功) という時系列
+  failedEvents: InputEvent[];
+};
+
+/**
+ * Automaton の内部状態を表すインターフェース
+ */
+export type AutomatonState = {
+  readonly word: string;
+  readonly startNode: StrokeNode;
+  readonly rule: Rule;
+  readonly currentNode: StrokeNode;
+  readonly edgeHistories: ReadonlyArray<EdgeHistory>;
+  readonly failedEventsAtCurrentNode: ReadonlyArray<InputEvent>;
+};

--- a/src/core/rule.ts
+++ b/src/core/rule.ts
@@ -1,4 +1,3 @@
-import { Automaton } from "./automaton";
 import { build } from "./automatonBuilder";
 import { extendCommonPrefixOverlappedEntriesDeeply } from "./ruleExtender";
 import { RuleStroke } from "./ruleStroke";
@@ -134,7 +133,7 @@ export class Rule {
     return this.mapEntriesByFirstInputModifier.get(modifierKey) ?? [];
   }
 
-  build(kanaText: string): Automaton {
+  build(kanaText: string) {
     return build(this, kanaText);
   }
 }

--- a/src/impl/stats.ts
+++ b/src/impl/stats.ts
@@ -5,7 +5,7 @@
  * @param succeededCount 正しく入力できた打鍵数
  * @returns
  */
-export function calcAccuracy(failedCount: number, succeededCount: number): number {
+export function getAccuracy(failedCount: number, succeededCount: number): number {
   return succeededCount / (succeededCount + failedCount);
 }
 /**
@@ -16,7 +16,7 @@ export function calcAccuracy(failedCount: number, succeededCount: number): numbe
  * @param finishedAt 終了時刻（一般的にワードの入力が完了した時刻）
  * @returns
  */
-export function calcKpm(succeededCount: number, startedAt: Date, finishedAt: Date): number {
+export function getKpm(succeededCount: number, startedAt: Date, finishedAt: Date): number {
   return Math.trunc((succeededCount / (finishedAt.getTime() - startedAt.getTime())) * 1000 * 60);
 }
 
@@ -30,7 +30,7 @@ export function calcKpm(succeededCount: number, startedAt: Date, finishedAt: Dat
  * @param finishedAt 終了時刻（一般的にワードの入力が完了した時刻）
  * @returns
  */
-export function calcRkpm(succeededCount: number, firstInputtedAt: Date, finishedAt: Date): number {
+export function getRkpm(succeededCount: number, firstInputtedAt: Date, finishedAt: Date): number {
   return Math.trunc(
     ((succeededCount - 1) / (finishedAt.getTime() - firstInputtedAt.getTime())) * 1000 * 60,
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-export { Automaton } from "./core/automaton";
+export * as AutomatonGetters from "./core/automatonGetters";
+export type { AutomatonState, EdgeHistory } from "./core/automatonState";
 export { StrokeEdge, StrokeNode } from "./core/builderStrokeGraph";
 export { InputEvent, InputStroke } from "./core/inputEvent";
 export { KeyboardLayout } from "./core/keyboardLayout";
@@ -25,3 +26,5 @@ export type { PhysicalKeyboardLayoutName } from "./impl/keyboardGuide";
 export * from "./impl/presetKeyboardGuide";
 export * from "./impl/presetRules";
 export * from "./impl/stats";
+
+export type { Automaton } from "./core/automatonBuilder";


### PR DESCRIPTION
## 概要
- Automatonクラスの責務を明確化し、拡張可能な設計に変更
    - Automaton クラス自体のメソッドは状態変更（入力系）に特化し、参照系のメソッドはすべて extension として外出しした
- getter系関数を分離し、ユーザーが独自の拡張を追加できるようにした
- それに伴い既存コードとの後方互換性を一部破壊
    - Automaton クラスの getter メソッドはすべて get〜 関数に変更（pendingWord → getPendingWord）

## テスト計画
- [x] 既存のテストがすべてパスすることを確認
- [x] 各exampleが正常に動作することを確認
- [x] with()メソッドによる拡張が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)