### PR TITLE
oxlintルール追加・CI改善・Claude Codeフック設定

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "if": "Bash(git commit *)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm run lint && pnpm run test",
+            "timeout": 120,
+            "statusMessage": "Running lint and test..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,14 +12,15 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b307475762933b98ed359c036b0e51f26b63b74b # v5.0.0
       - run: pnpm i
-      - run: pnpm test
+      - run: pnpm run lint
+      - run: pnpm run test

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "typescript/consistent-type-imports": "warn",
+    "typescript/no-explicit-any": "warn",
+    "no-non-null-assertion": "warn",
+    "no-this-alias": "warn",
+    "eqeqeq": "warn"
+  }
+}

--- a/examples/react-stroke-graph/src/grpahStyle.ts
+++ b/examples/react-stroke-graph/src/grpahStyle.ts
@@ -1,4 +1,4 @@
-import { StylesheetStyle } from "cytoscape";
+import type { StylesheetStyle } from "cytoscape";
 
 export const cyStylesheet: StylesheetStyle[] = [
   {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "build": "vite build && tsc",
-    "lint": "oxlint src",
+    "lint": "oxlint --deny-warnings src",
     "lint:fix": "oxlint --fix src",
     "test": "vitest",
     "fmt": "oxfmt --write src",

--- a/src/browser/eventHandler.ts
+++ b/src/browser/eventHandler.ts
@@ -1,6 +1,8 @@
-import { InputEvent, InputStroke, KeyEventType } from "../core/inputEvent";
+import type { KeyEventType } from "../core/inputEvent";
+import { InputEvent, InputStroke } from "../core/inputEvent";
 import { KeyboardState } from "../core/keyboardState";
-import { VirtualKey, VirtualKeys } from "../core/virtualKey";
+import type { VirtualKey } from "../core/virtualKey";
+import { VirtualKeys } from "../core/virtualKey";
 
 /**
  * @param target addEventListener,removeEventListener を持つ Window object のような型
@@ -62,7 +64,7 @@ function toInputKeyStrokeFromKeyboardEvent(
 
 function toVirtualKeyFromEventCode(code: string): VirtualKey {
   const key = codeToVirtualKey[code];
-  if (key == undefined) {
+  if (key === undefined) {
     throw new Error("invalid code: " + code);
   }
   return key;

--- a/src/browser/osKeyboardLayout.ts
+++ b/src/browser/osKeyboardLayout.ts
@@ -1,22 +1,24 @@
 import { VirtualKeys } from "..";
-import { KeyboardLayout } from "../core/keyboardLayout";
+import type { KeyboardLayout } from "../core/keyboardLayout";
 import {
   findMatchedKeyboardLayout,
   loadPresetKeyboardLayoutQwertyJis,
 } from "../impl/presetKeyboardLayout";
 
-export async function detectKeyboardLayout(window: any): Promise<KeyboardLayout> {
-  const layoutMap = await window?.navigator?.keyboard?.getLayoutMap();
+export async function detectKeyboardLayout(
+  window: Window & { navigator: { keyboard?: { getLayoutMap(): Promise<Map<string, string>> } } },
+): Promise<KeyboardLayout> {
+  const layoutMap = await window.navigator.keyboard?.getLayoutMap();
   if (!layoutMap) {
     // Chrome, Edge にしか対応していないので、未対応の場合は Qwery JIS として返す
     // https://developer.mozilla.org/en-US/docs/Web/API/Keyboard/getLayoutMap
     return loadPresetKeyboardLayoutQwertyJis();
   }
-  const layout = findMatchedKeyboardLayout(
-    new Map([
-      [VirtualKeys.BracketLeft, layoutMap.get("BracketLeft")],
-      [VirtualKeys.Z, layoutMap.get("KeyZ")],
-    ]),
-  );
+  const keyToCharMap = new Map<(typeof VirtualKeys)[keyof typeof VirtualKeys], string>();
+  const bracketLeft = layoutMap.get("BracketLeft");
+  if (bracketLeft) keyToCharMap.set(VirtualKeys.BracketLeft, bracketLeft);
+  const z = layoutMap.get("KeyZ");
+  if (z) keyToCharMap.set(VirtualKeys.Z, z);
+  const layout = findMatchedKeyboardLayout(keyToCharMap);
   return layout;
 }

--- a/src/core/automaton.test.ts
+++ b/src/core/automaton.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { loadPresetKeyboardLayoutQwertyJis } from "../impl/presetKeyboardLayout";
 import { loadPresetRuleRoman } from "../impl/presetRules";
-import { Automaton } from "./automatonBuilder";
-import { AutomatonState } from "./automatonState";
+import type { Automaton } from "./automatonBuilder";
+import type { AutomatonState } from "./automatonState";
 
 describe("Automaton with extensions", () => {
   const rule = loadPresetRuleRoman(loadPresetKeyboardLayoutQwertyJis());

--- a/src/core/automaton.ts
+++ b/src/core/automaton.ts
@@ -1,7 +1,7 @@
-import { AutomatonState, EdgeHistory } from "./automatonState";
-import { StrokeEdge, StrokeNode } from "./builderStrokeGraph";
-import { InputEvent, matchCandidateEdge, matchOtherEdge } from "./inputEvent";
-import { Rule } from "./rule";
+import type { AutomatonState, EdgeHistory } from "./automatonState";
+import { StrokeEdge, type StrokeNode } from "./builderStrokeGraph";
+import { type InputEvent, matchCandidateEdge, matchOtherEdge } from "./inputEvent";
+import type { Rule } from "./rule";
 
 export class InputResult {
   constructor(
@@ -287,13 +287,13 @@ export class AutomatonImpl implements AutomatonState {
     // 仮確定状態解除
     this.stagedEdge = undefined;
 
-    if (result.isSucceeded) {
+    if (result.isSucceeded && acceptedEdge) {
       this.edgeHistories.push({
         event: stroke,
-        previousEdge: acceptedEdge!,
+        previousEdge: acceptedEdge,
         failedEvents: this.failedEventsAtCurrentNode,
       });
-      this.currentNode = acceptedEdge!.next;
+      this.currentNode = acceptedEdge.next;
       this.failedEventsAtCurrentNode = [];
     } else if (result.isFailed) {
       this.failedEventsAtCurrentNode.push(stroke);
@@ -333,14 +333,13 @@ export class AutomatonImpl implements AutomatonState {
    * console.log(extended.getKPM()); // number
    * ```
    */
-  with<T extends Record<string, (state: AutomatonState) => any>>(
+  with<T extends Record<string, (state: AutomatonState) => unknown>>(
     extension: T,
   ): this & { [K in keyof T]: () => ReturnType<T[K]> } {
-    const self = this;
     const proxy = new Proxy(this, {
-      get(target, prop) {
+      get: (target, prop) => {
         if (prop in extension) {
-          return () => extension[prop as keyof T](self);
+          return () => extension[prop as keyof T](this);
         }
         return target[prop as keyof typeof target];
       },

--- a/src/core/automatonBuilder.ts
+++ b/src/core/automatonBuilder.ts
@@ -1,10 +1,10 @@
 import { AutomatonImpl } from "./automaton";
 import * as AutomatonGetters from "./automatonGetters";
-import { AutomatonState } from "./automatonState";
+import type { AutomatonState } from "./automatonState";
 import { buildKanaNode } from "./builderKanaGraph";
 import { buildStrokeNode } from "./builderStrokeGraph";
-import { Rule } from "./rule";
-import { RuleStroke } from "./ruleStroke";
+import type { Rule } from "./rule";
+import type { RuleStroke } from "./ruleStroke";
 
 export type Automaton = AutomatonImpl & DefaultExtensionType;
 

--- a/src/core/automatonGetters.ts
+++ b/src/core/automatonGetters.ts
@@ -1,5 +1,5 @@
-import { AutomatonState } from "./automatonState";
-import { RuleStroke } from "./ruleStroke";
+import type { AutomatonState } from "./automatonState";
+import type { RuleStroke } from "./ruleStroke";
 
 /**
  * 入力が完了したかな文字列

--- a/src/core/automatonState.ts
+++ b/src/core/automatonState.ts
@@ -1,12 +1,12 @@
-import { StrokeNode } from "./builderStrokeGraph";
-import { InputEvent } from "./inputEvent";
-import { Rule } from "./rule";
+import type { StrokeEdge, StrokeNode } from "./builderStrokeGraph";
+import type { InputEvent } from "./inputEvent";
+import type { Rule } from "./rule";
 
 export type EdgeHistory = {
   // 遷移のきっかけになった成功した入力イベント
   event: InputEvent;
   // 今回の遷移で利用されたエッジ（この Edge をたどると startNode まで戻れる）
-  previousEdge: import("./builderStrokeGraph").StrokeEdge;
+  previousEdge: StrokeEdge;
   // 今回の遷移に成功するまでに失敗した入力イベント
   // failedEvents[0], failedEvents[1], ..., event(入力成功) という時系列
   failedEvents: InputEvent[];

--- a/src/core/builderKanaGraph.ts
+++ b/src/core/builderKanaGraph.ts
@@ -1,6 +1,6 @@
 import { setDefaultFunc } from "../utils/map";
-import { Rule, RuleEntry } from "./rule";
-import { RuleStroke } from "./ruleStroke";
+import type { Rule, RuleEntry } from "./rule";
+import type { RuleStroke } from "./ruleStroke";
 
 // build 中にのみ使用する
 export class KanaNode {

--- a/src/core/builderStrokeGraph.ts
+++ b/src/core/builderStrokeGraph.ts
@@ -1,6 +1,6 @@
 import { setDefault } from "../utils/map";
-import { KanaNode } from "./builderKanaGraph";
-import { RuleStroke } from "./ruleStroke";
+import type { KanaNode } from "./builderKanaGraph";
+import type { RuleStroke } from "./ruleStroke";
 
 export class StrokeNode {
   private cost: number = 0; // このノードから打ち切るまでの最短ストローク数

--- a/src/core/inputEvent.ts
+++ b/src/core/inputEvent.ts
@@ -1,7 +1,7 @@
-import { StrokeEdge } from "./builderStrokeGraph";
-import { KeyboardStateReader } from "./keyboardState";
-import { Rule } from "./rule";
-import { VirtualKey } from "./virtualKey";
+import type { StrokeEdge } from "./builderStrokeGraph";
+import type { KeyboardStateReader } from "./keyboardState";
+import type { Rule } from "./rule";
+import type { VirtualKey } from "./virtualKey";
 
 export type KeyEventType = "keyup" | "keydown";
 export class InputStroke {

--- a/src/core/keyboardLayout.ts
+++ b/src/core/keyboardLayout.ts
@@ -1,7 +1,7 @@
 import { setDefault } from "../utils/map";
 import { AndModifier, ModifierGroup } from "./modifier";
 import { RuleStroke } from "./ruleStroke";
-import { VirtualKey } from "./virtualKey";
+import type { VirtualKey } from "./virtualKey";
 
 export class KeyboardLayout {
   readonly strokesByChar: Map<string, RuleStroke[]>;

--- a/src/core/keyboardState.ts
+++ b/src/core/keyboardState.ts
@@ -1,4 +1,4 @@
-import { VirtualKey } from "./virtualKey";
+import type { VirtualKey } from "./virtualKey";
 
 export interface KeyboardStateReader {
   get downedKeys(): readonly VirtualKey[];

--- a/src/core/modifier.ts
+++ b/src/core/modifier.ts
@@ -1,5 +1,5 @@
-import { KeyboardStateReader } from "./keyboardState";
-import { VirtualKey } from "./virtualKey";
+import type { KeyboardStateReader } from "./keyboardState";
+import type { VirtualKey } from "./virtualKey";
 
 /**
  * 同じ修飾キーを表す1つのグループ

--- a/src/core/rule.ts
+++ b/src/core/rule.ts
@@ -1,7 +1,7 @@
 import { build } from "./automatonBuilder";
 import { extendCommonPrefixOverlappedEntriesDeeply } from "./ruleExtender";
-import { RuleStroke } from "./ruleStroke";
-import { VirtualKey } from "./virtualKey";
+import type { RuleStroke } from "./ruleStroke";
+import type { VirtualKey } from "./virtualKey";
 
 export type normalizerFunc = (value: string) => string;
 

--- a/src/core/ruleExtender.ts
+++ b/src/core/ruleExtender.ts
@@ -1,5 +1,5 @@
 import { RuleEntry } from "./rule";
-import { RuleStroke } from "./ruleStroke";
+import type { RuleStroke } from "./ruleStroke";
 
 export function extendCommonPrefixOverlappedEntriesDeeply(entries: RuleEntry[]): RuleEntry[] {
   return recursiveExtendCommontPrefixOverlappedEntries(entries);

--- a/src/core/ruleMerger.ts
+++ b/src/core/ruleMerger.ts
@@ -1,4 +1,5 @@
-import { Rule, RuleEntry } from "./rule";
+import type { RuleEntry } from "./rule";
+import { Rule } from "./rule";
 
 // entries を結合した新しい Rule を返す
 export function mergeRule(thisRule: Rule, other: Rule, newName: string = ""): Rule {

--- a/src/core/ruleStroke.ts
+++ b/src/core/ruleStroke.ts
@@ -1,5 +1,5 @@
-import { AndModifier } from "./modifier";
-import { VirtualKey } from "./virtualKey";
+import type { AndModifier } from "./modifier";
+import type { VirtualKey } from "./virtualKey";
 
 export class RuleStroke {
   /**

--- a/src/core/selector.ts
+++ b/src/core/selector.ts
@@ -1,5 +1,5 @@
-import { InputResult } from "./automaton";
-import { InputEvent } from "./inputEvent";
+import type { InputResult } from "./automaton";
+import type { InputEvent } from "./inputEvent";
 
 export interface Inputtable {
   input(stroke: InputEvent): InputResult;

--- a/src/impl/alphaNumericRule.ts
+++ b/src/impl/alphaNumericRule.ts
@@ -1,4 +1,4 @@
-import { KeyboardLayout } from "../core/keyboardLayout";
+import type { KeyboardLayout } from "../core/keyboardLayout";
 import { Rule, RuleEntry } from "../core/rule";
 import { defaultAlphaNumericNormalize } from "./charNormalizer";
 

--- a/src/impl/keyboardGuide.ts
+++ b/src/impl/keyboardGuide.ts
@@ -1,5 +1,5 @@
-import { KeyboardLayout } from "../core/keyboardLayout";
-import { VirtualKey, VirtualKeys } from "../core/virtualKey";
+import type { KeyboardLayout } from "../core/keyboardLayout";
+import { type VirtualKey, VirtualKeys } from "../core/virtualKey";
 
 export type PhysicalKeyboardLayoutName = "jis_106" | "us_101" | "us_hhkb";
 

--- a/src/impl/keyboardGuideLoader.ts
+++ b/src/impl/keyboardGuideLoader.ts
@@ -1,5 +1,6 @@
 import { VirtualKey } from "../core/virtualKey";
-import { KeyboardGuideLabel, KeyboardGuide } from "./keyboardGuide";
+import type { KeyboardGuideLabel} from "./keyboardGuide";
+import { KeyboardGuide } from "./keyboardGuide";
 
 type jsonSchema = {
   name: string;

--- a/src/impl/mozcRuleLoader.ts
+++ b/src/impl/mozcRuleLoader.ts
@@ -1,6 +1,6 @@
-import { KeyboardLayout } from "../core/keyboardLayout";
+import type { KeyboardLayout } from "../core/keyboardLayout";
 import { Rule, RuleEntry } from "../core/rule";
-import { RuleStroke } from "../core/ruleStroke";
+import type { RuleStroke } from "../core/ruleStroke";
 import { product } from "../utils/itertools";
 import { defaultKanaNormalize } from "./charNormalizer";
 
@@ -16,7 +16,7 @@ export function loadMozcRule(text: string, layout: KeyboardLayout, name: string 
   const entries: RuleEntry[] = [];
   for (let line of lines) {
     line = line.trim();
-    if (line.length == 0) {
+    if (line.length === 0) {
       continue;
     }
     const cols = line.split("\t");

--- a/src/impl/presetKeyboardLayout.ts
+++ b/src/impl/presetKeyboardLayout.ts
@@ -1,8 +1,8 @@
 import dvorak from "../assets/keyboard_layouts/dvorak.json";
 import qwerty_jis from "../assets/keyboard_layouts/qwerty_jis.json";
 import qwerty_us from "../assets/keyboard_layouts/qwerty_us.json";
-import { KeyboardLayout } from "../core/keyboardLayout";
-import { VirtualKey } from "../core/virtualKey";
+import type { KeyboardLayout } from "../core/keyboardLayout";
+import type { VirtualKey } from "../core/virtualKey";
 import { loadJsonKeyboardLayout } from "./keyboardLayoutLoader";
 
 export function loadPresetKeyboardLayoutQwertyJis() {

--- a/src/impl/presetRules.ts
+++ b/src/impl/presetRules.ts
@@ -2,8 +2,8 @@ import presetRuleGoogleImeRoman from "../assets/rules/google_ime_default_roman.t
 import presetRuleJisKana from "../assets/rules/jis_kana.json";
 import presetRuleNaginatashikiV15 from "../assets/rules/naginatashiki_v15.json";
 import presetRuleNicola from "../assets/rules/nicola.json";
-import { KeyboardLayout } from "../core/keyboardLayout";
-import { Rule } from "../core/rule";
+import type { KeyboardLayout } from "../core/keyboardLayout";
+import type { Rule } from "../core/rule";
 import { loadJsonRuleWithLayout, loadMozcRuleWithLayout } from "./ruleLoaderWithLayout";
 
 export function loadPresetRuleRoman(layout: KeyboardLayout): Rule {

--- a/src/impl/ruleLoaderWithLayout.ts
+++ b/src/impl/ruleLoaderWithLayout.ts
@@ -1,8 +1,9 @@
-import { KeyboardLayout } from "../core/keyboardLayout";
-import { Rule } from "../core/rule";
+import type { KeyboardLayout } from "../core/keyboardLayout";
+import type { Rule } from "../core/rule";
 import { mergeRule } from "../core/ruleMerger";
 import { newAlphaNumericRuleByLayout } from "./alphaNumericRule";
-import { jsonSchema, loadJsonRule } from "./jsonRuleLoader";
+import type { jsonSchema} from "./jsonRuleLoader";
+import { loadJsonRule } from "./jsonRuleLoader";
 import { loadMozcRule } from "./mozcRuleLoader";
 
 export function loadMozcRuleWithLayout(


### PR DESCRIPTION
## Summary

- oxlint に consistent-type-imports, no-explicit-any, no-non-null-assertion, no-this-alias, eqeqeq ルールを追加し、全ソースの警告を修正
- lint スクリプトに --deny-warnings を追加し、警告があれば非ゼロ終了するよう変更
- GitHub Actions を最新バージョンに更新し SHA pinning を適用、lint ステップを追加、Node.js を 24.x に変更
- Claude Code の PreToolUse フックで git commit 前に lint・test を自動実行するよう設定

## 設計の背景

oxlint のデフォルトルールセットでは VSCode の oxc 拡張が検出する警告をカバーしきれず、ファイルを開くたびに新たな警告が見つかる状態だった。
.oxlintrc.json にルールを明示的に追加することで CLI (`pnpm run lint`) と VSCode の検査結果を一致させた。

--deny-warnings は package.json の lint スクリプトに含めることで、CI・Claude Code フック・手動実行のすべてで統一的に機能する。
ルール定義自体は warn のまま残し、VSCode 上ではエラーではなく警告として表示される。

detectKeyboardLayout の引数は元々 any 型だったが、Window & Keyboard API 拡張の intersection 型に変更した。
Keyboard API は標準化途上で lib.dom.d.ts に定義がないため、必要最小限の型を intersection で補った。

## Test plan

- [ ] `pnpm run lint` が警告なしで通ること
- [ ] `pnpm run test` が全テスト通過すること
- [ ] `pnpm run build` が成功すること
- [ ] GitHub Actions の CI が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)