### PR TITLE
ruleExtenderをシンプルなアルゴリズムに書き直し

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,9 +7,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm run lint && pnpm run test",
+            "command": "pnpm run fmt && pnpm run lint && pnpm run test",
             "timeout": 120,
-            "statusMessage": "Running lint and test..."
+            "statusMessage": "Running fmt, lint and test..."
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,11 +3,11 @@
     "PreToolUse": [
       {
         "matcher": "Bash",
-        "if": "Bash(git commit *)",
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm run fmt && pnpm run lint && pnpm run test",
+            "if": "Bash(git commit *)",
+            "command": "pnpm run fmt && pnpm run lint && pnpm run test || exit 2",
             "timeout": 120,
             "statusMessage": "Running fmt, lint and test..."
           }

--- a/src/assets/rules/jis_kana.json
+++ b/src/assets/rules/jis_kana.json
@@ -185,51 +185,35 @@
       "output": "ろ"
     },
     {
-      "input": [
-        { "keys": ["Digit3"], "modifiers": [["ShiftLeft", "ShiftRight"]] }
-      ],
+      "input": [{ "keys": ["Digit3"], "modifiers": [["ShiftLeft", "ShiftRight"]] }],
       "output": "ぁ"
     },
     {
-      "input": [
-        { "keys": ["Digit4"], "modifiers": [["ShiftLeft", "ShiftRight"]] }
-      ],
+      "input": [{ "keys": ["Digit4"], "modifiers": [["ShiftLeft", "ShiftRight"]] }],
       "output": "ぅ"
     },
     {
-      "input": [
-        { "keys": ["Digit5"], "modifiers": [["ShiftLeft", "ShiftRight"]] }
-      ],
+      "input": [{ "keys": ["Digit5"], "modifiers": [["ShiftLeft", "ShiftRight"]] }],
       "output": "ぇ"
     },
     {
-      "input": [
-        { "keys": ["Digit6"], "modifiers": [["ShiftLeft", "ShiftRight"]] }
-      ],
+      "input": [{ "keys": ["Digit6"], "modifiers": [["ShiftLeft", "ShiftRight"]] }],
       "output": "ぉ"
     },
     {
-      "input": [
-        { "keys": ["Digit7"], "modifiers": [["ShiftLeft", "ShiftRight"]] }
-      ],
+      "input": [{ "keys": ["Digit7"], "modifiers": [["ShiftLeft", "ShiftRight"]] }],
       "output": "ゃ"
     },
     {
-      "input": [
-        { "keys": ["Digit8"], "modifiers": [["ShiftLeft", "ShiftRight"]] }
-      ],
+      "input": [{ "keys": ["Digit8"], "modifiers": [["ShiftLeft", "ShiftRight"]] }],
       "output": "ゅ"
     },
     {
-      "input": [
-        { "keys": ["Digit9"], "modifiers": [["ShiftLeft", "ShiftRight"]] }
-      ],
+      "input": [{ "keys": ["Digit9"], "modifiers": [["ShiftLeft", "ShiftRight"]] }],
       "output": "ょ"
     },
     {
-      "input": [
-        { "keys": ["Digit0"], "modifiers": [["ShiftLeft", "ShiftRight"]] }
-      ],
+      "input": [{ "keys": ["Digit0"], "modifiers": [["ShiftLeft", "ShiftRight"]] }],
       "output": "を"
     },
     {
@@ -237,9 +221,7 @@
       "output": "ぃ"
     },
     {
-      "input": [
-        { "keys": ["Quote"], "modifiers": [["ShiftLeft", "ShiftRight"]] }
-      ],
+      "input": [{ "keys": ["Quote"], "modifiers": [["ShiftLeft", "ShiftRight"]] }],
       "output": "ヶ"
     },
     {

--- a/src/core/rule.ts
+++ b/src/core/rule.ts
@@ -1,5 +1,5 @@
 import { build } from "./automatonBuilder";
-import { extendCommonPrefixOverlappedEntriesDeeply } from "./ruleExtender";
+import { expandPrefixRules } from "./ruleExtender";
 import type { RuleStroke } from "./ruleStroke";
 import type { VirtualKey } from "./virtualKey";
 
@@ -95,7 +95,7 @@ export class Rule {
     readonly normalize: normalizerFunc,
     readonly name: string = "",
   ) {
-    this.entries = extendCommonPrefixOverlappedEntriesDeeply(entries);
+    this.entries = expandPrefixRules(entries);
 
     // init mapEntriesByFirstInputKey
     this.entries.forEach((entry) => {

--- a/src/core/ruleExtender.test.ts
+++ b/src/core/ruleExtender.test.ts
@@ -75,16 +75,16 @@ test("複数の独立したプレフィックス競合", () => {
   const nk = nExpanded.find(
     (e) => inputKeys(e).join(",") === [VirtualKeys.N, VirtualKeys.K].join(","),
   );
-  expect(nk).toBeDefined();
-  expect(nextInputKeys(nk!)).toEqual([VirtualKeys.K]);
+  if (nk === undefined) throw new Error("nk not found");
+  expect(nextInputKeys(nk)).toEqual([VirtualKeys.K]);
 
   // s の展開: sk→さ/[k] が存在する
   const sExpanded = findByOutput(result, "さ");
   const sk = sExpanded.find(
     (e) => inputKeys(e).join(",") === [VirtualKeys.S, VirtualKeys.K].join(","),
   );
-  expect(sk).toBeDefined();
-  expect(nextInputKeys(sk!)).toEqual([VirtualKeys.K]);
+  if (sk === undefined) throw new Error("sk not found");
+  expect(nextInputKeys(sk)).toEqual([VirtualKeys.K]);
 });
 
 test("プレフィックスの連鎖", () => {
@@ -166,17 +166,17 @@ test("1ストロークの結合先はoutputがマージされる", () => {
   const nk = result.find(
     (e) => inputKeys(e).join(",") === [VirtualKeys.N, VirtualKeys.K].join(","),
   );
-  expect(nk).toBeDefined();
-  expect(nk!.output).toBe("んき");
-  expect(nk!.nextInput.length).toBe(0);
+  if (nk === undefined) throw new Error("nk not found");
+  expect(nk.output).toBe("んき");
+  expect(nk.nextInput.length).toBe(0);
 
   // nb→んぶ (1ストロークb→ぶとの結合でoutputがマージ)
   const nb = result.find(
     (e) => inputKeys(e).join(",") === [VirtualKeys.N, VirtualKeys.B].join(","),
   );
-  expect(nb).toBeDefined();
-  expect(nb!.output).toBe("んぶ");
-  expect(nb!.nextInput.length).toBe(0);
+  if (nb === undefined) throw new Error("nb not found");
+  expect(nb.output).toBe("んぶ");
+  expect(nb.nextInput.length).toBe(0);
 
   // k→き, b→ぶ はそのまま残る
   expect(findByOutput(result, "き").length).toBe(1);

--- a/src/core/ruleExtender.test.ts
+++ b/src/core/ruleExtender.test.ts
@@ -1,47 +1,206 @@
 import { expect, test } from "vitest";
 import { AndModifier } from "./modifier";
 import { RuleEntry } from "./rule";
-import { extendCommonPrefixOverlappedEntriesDeeply } from "./ruleExtender";
+import { expandPrefixRules } from "./ruleExtender";
 import { RuleStroke } from "./ruleStroke";
+import type { VirtualKey } from "./virtualKey";
 import { VirtualKeys } from "./virtualKey";
 
+const s = (key: VirtualKey) => new RuleStroke(key, AndModifier.empty);
+const entry = (input: VirtualKey[], output: string, nextInput: VirtualKey[] = [], extend = true) =>
+  new RuleEntry(input.map(s), output, nextInput.map(s), extend);
+
+function findByOutput(entries: RuleEntry[], output: string): RuleEntry[] {
+  return entries.filter((e) => e.output === output);
+}
+
+function inputKeys(entry: RuleEntry): string[] {
+  return entry.input.map((i) => i.key);
+}
+
+function nextInputKeys(entry: RuleEntry): string[] {
+  return entry.nextInput.map((i) => i.key);
+}
+
 test("英数字は展開しない", () => {
-  const entries = [
-    new RuleEntry([new RuleStroke(VirtualKeys.A, AndModifier.empty)], "a", [], true),
-    new RuleEntry([new RuleStroke(VirtualKeys.B, AndModifier.empty)], "b", [], true),
-  ];
-  const result = extendCommonPrefixOverlappedEntriesDeeply(entries);
+  const entries = [entry([VirtualKeys.A], "a"), entry([VirtualKeys.B], "b")];
+  const result = expandPrefixRules(entries);
   expect(result.length).toBe(2);
 });
 
 test("んの展開", () => {
   const entries = [
-    new RuleEntry([new RuleStroke(VirtualKeys.N, AndModifier.empty)], "ん", [], true),
-    new RuleEntry(
-      [
-        new RuleStroke(VirtualKeys.N, AndModifier.empty),
-        new RuleStroke(VirtualKeys.A, AndModifier.empty),
-      ],
-      "な",
-      [],
-      true,
-    ),
-    new RuleEntry(
-      [
-        new RuleStroke(VirtualKeys.K, AndModifier.empty),
-        new RuleStroke(VirtualKeys.A, AndModifier.empty),
-      ],
-      "か",
-      [],
-      true,
-    ),
+    entry([VirtualKeys.N], "ん"),
+    entry([VirtualKeys.N, VirtualKeys.A], "な"),
+    entry([VirtualKeys.K, VirtualKeys.A], "か"),
   ];
-  const result = extendCommonPrefixOverlappedEntriesDeeply(entries);
-  const extendedN = result.filter((e) => e.output === "ん");
+  const result = expandPrefixRules(entries);
+  // n→ん は nk→ん/[k] に展開される
+  const extendedN = findByOutput(result, "ん");
   expect(extendedN.length).toBe(1);
-  expect(extendedN[0].input.length).toBe(2);
-  expect(extendedN[0].input[0].key).toBe(VirtualKeys.N);
-  expect(extendedN[0].input[1].key).toBe(VirtualKeys.K);
-  expect(extendedN[0].nextInput.length).toBe(1);
-  expect(extendedN[0].nextInput[0].key).toBe(VirtualKeys.K);
+  expect(inputKeys(extendedN[0])).toEqual([VirtualKeys.N, VirtualKeys.K]);
+  expect(nextInputKeys(extendedN[0])).toEqual([VirtualKeys.K]);
+  // na→な, ka→か はそのまま残る
+  const na = findByOutput(result, "な");
+  expect(na.length).toBe(1);
+  expect(inputKeys(na[0])).toEqual([VirtualKeys.N, VirtualKeys.A]);
+  const ka = findByOutput(result, "か");
+  expect(ka.length).toBe(1);
+  expect(inputKeys(ka[0])).toEqual([VirtualKeys.K, VirtualKeys.A]);
+});
+
+test("複数の独立したプレフィックス競合", () => {
+  const entries = [
+    entry([VirtualKeys.N], "ん"),
+    entry([VirtualKeys.N, VirtualKeys.A], "な"),
+    entry([VirtualKeys.S], "さ"),
+    entry([VirtualKeys.S, VirtualKeys.I], "し"),
+    entry([VirtualKeys.K, VirtualKeys.A], "か"),
+  ];
+  const result = expandPrefixRules(entries);
+
+  // n→ん, s→さ は展開されて消える（元の形では残らない）
+  const originalN = result.filter((e) => e.output === "ん" && e.input.length === 1);
+  expect(originalN.length).toBe(0);
+  const originalS = result.filter((e) => e.output === "さ" && e.input.length === 1);
+  expect(originalS.length).toBe(0);
+
+  // na→な, si→し, ka→か はそのまま残る
+  expect(findByOutput(result, "な").length).toBe(1);
+  expect(findByOutput(result, "し").length).toBe(1);
+  expect(findByOutput(result, "か").length).toBe(1);
+
+  // n の展開: nk→ん/[k] が存在する
+  const nExpanded = findByOutput(result, "ん");
+  const nk = nExpanded.find(
+    (e) => inputKeys(e).join(",") === [VirtualKeys.N, VirtualKeys.K].join(","),
+  );
+  expect(nk).toBeDefined();
+  expect(nextInputKeys(nk!)).toEqual([VirtualKeys.K]);
+
+  // s の展開: sk→さ/[k] が存在する
+  const sExpanded = findByOutput(result, "さ");
+  const sk = sExpanded.find(
+    (e) => inputKeys(e).join(",") === [VirtualKeys.S, VirtualKeys.K].join(","),
+  );
+  expect(sk).toBeDefined();
+  expect(nextInputKeys(sk!)).toEqual([VirtualKeys.K]);
+});
+
+test("プレフィックスの連鎖", () => {
+  const entries = [
+    entry([VirtualKeys.N], "ん"),
+    entry([VirtualKeys.N, VirtualKeys.N], "なぬ"),
+    entry([VirtualKeys.N, VirtualKeys.N, VirtualKeys.N], "ななな"),
+    entry([VirtualKeys.K, VirtualKeys.A], "か"),
+  ];
+  const result = expandPrefixRules(entries);
+
+  // n→ん は nk→ん/[k] に展開
+  const nExpanded = findByOutput(result, "ん");
+  expect(nExpanded.length).toBe(1);
+  expect(inputKeys(nExpanded[0])).toEqual([VirtualKeys.N, VirtualKeys.K]);
+  expect(nextInputKeys(nExpanded[0])).toEqual([VirtualKeys.K]);
+
+  // nn→なぬ は nnk→なぬ/[k] に展開
+  const nnExpanded = findByOutput(result, "なぬ");
+  expect(nnExpanded.length).toBe(1);
+  expect(inputKeys(nnExpanded[0])).toEqual([VirtualKeys.N, VirtualKeys.N, VirtualKeys.K]);
+  expect(nextInputKeys(nnExpanded[0])).toEqual([VirtualKeys.K]);
+
+  // nnn→ななな はそのまま残る
+  const nnn = findByOutput(result, "ななな");
+  expect(nnn.length).toBe(1);
+  expect(inputKeys(nnn[0])).toEqual([VirtualKeys.N, VirtualKeys.N, VirtualKeys.N]);
+
+  // ka→か はそのまま残る
+  expect(findByOutput(result, "か").length).toBe(1);
+});
+
+test("nextInputを持つエントリがある場合（プレフィックス競合なし）", () => {
+  // tt→っ/[t] と ta→た は同じ長さ（2ストローク）でプレフィックス関係にない
+  const entries = [
+    entry([VirtualKeys.T, VirtualKeys.T], "っ", [VirtualKeys.T]),
+    entry([VirtualKeys.T, VirtualKeys.A], "た"),
+    entry([VirtualKeys.A], "あ"),
+  ];
+  const result = expandPrefixRules(entries);
+  // 全エントリがそのまま残る
+  expect(result.length).toBe(3);
+
+  const tsu = findByOutput(result, "っ");
+  expect(tsu.length).toBe(1);
+  expect(inputKeys(tsu[0])).toEqual([VirtualKeys.T, VirtualKeys.T]);
+  expect(nextInputKeys(tsu[0])).toEqual([VirtualKeys.T]);
+});
+
+test("extendCommonPrefixCommonEntry=false のエントリは展開対象外", () => {
+  const entries = [
+    entry([VirtualKeys.N], "ん", [], false), // extend=false
+    entry([VirtualKeys.N, VirtualKeys.A], "な"),
+    entry([VirtualKeys.K, VirtualKeys.A], "か"),
+  ];
+  const result = expandPrefixRules(entries);
+
+  // n→ん(extend=false) は展開されずにそのまま残る
+  const n = result.filter((e) => e.output === "ん" && e.input.length === 1);
+  expect(n.length).toBe(1);
+  expect(n[0].extendCommonPrefixCommonEntry).toBe(false);
+});
+
+test("1ストロークの結合先はoutputがマージされる", () => {
+  // k, b は1ストロークでプレフィックス競合なし
+  const entries = [
+    entry([VirtualKeys.N], "ん"),
+    entry([VirtualKeys.N, VirtualKeys.A], "な"),
+    entry([VirtualKeys.K], "き"),
+    entry([VirtualKeys.B], "ぶ"),
+  ];
+  const result = expandPrefixRules(entries);
+
+  // n→ん は展開される
+  const originalN = result.filter((e) => e.output === "ん" && e.input.length === 1);
+  expect(originalN.length).toBe(0);
+
+  // nk→んき (1ストロークk→きとの結合でoutputがマージ)
+  const nk = result.find(
+    (e) => inputKeys(e).join(",") === [VirtualKeys.N, VirtualKeys.K].join(","),
+  );
+  expect(nk).toBeDefined();
+  expect(nk!.output).toBe("んき");
+  expect(nk!.nextInput.length).toBe(0);
+
+  // nb→んぶ (1ストロークb→ぶとの結合でoutputがマージ)
+  const nb = result.find(
+    (e) => inputKeys(e).join(",") === [VirtualKeys.N, VirtualKeys.B].join(","),
+  );
+  expect(nb).toBeDefined();
+  expect(nb!.output).toBe("んぶ");
+  expect(nb!.nextInput.length).toBe(0);
+
+  // k→き, b→ぶ はそのまま残る
+  expect(findByOutput(result, "き").length).toBe(1);
+  expect(findByOutput(result, "ぶ").length).toBe(1);
+
+  // na→な はそのまま残る
+  expect(findByOutput(result, "な").length).toBe(1);
+});
+
+test("展開先候補がない場合は元エントリが削除される", () => {
+  // n以外で始まるエントリがないので展開先がない
+  // この場合 n→ん は使われる機会がないため削除される
+  const entries = [
+    entry([VirtualKeys.N], "ん"),
+    entry([VirtualKeys.N, VirtualKeys.A], "な"),
+    entry([VirtualKeys.N, VirtualKeys.I], "に"),
+    entry([VirtualKeys.N, VirtualKeys.U], "ぬ"),
+  ];
+  const result = expandPrefixRules(entries);
+
+  // n→ん は削除される（展開先がなく、常に na/ni/nu が優先されるため）
+  const n = result.filter((e) => e.output === "ん" && e.input.length === 1);
+  expect(n.length).toBe(0);
+
+  // na, ni, nu はそのまま残る
+  expect(result.length).toBe(3);
 });

--- a/src/core/ruleExtender.ts
+++ b/src/core/ruleExtender.ts
@@ -1,6 +1,46 @@
 import { RuleEntry } from "./rule";
 import type { RuleStroke } from "./ruleStroke";
 
+// プレフィックス競合の展開
+//
+// 日本語入力ルールでは、あるエントリの input が別のエントリの input の
+// 真のプレフィックスになっている場合がある。例：
+//   n → ん, na → な, ka → か
+// このとき n を打っただけでは「ん」を確定できない（次が a なら na → な になる）。
+// この関数は、そうしたプレフィックス競合を事前に解消し、
+// オートマトンが単純な最長一致で動作できるようにする。
+//
+// アルゴリズム:
+//   1. 全エントリを Map<inputHash, RuleEntry> に格納する
+//   2. Map 内で「自身の input が他エントリの input の真のプレフィックスになっている」
+//      エントリ（競合エントリ）を1つ探す
+//   3. 見つからなければ終了
+//   4. 競合エントリを Map から削除し、競合しないエントリと結合した拡張エントリを生成して追加する
+//   5. 2 に戻る
+//
+// 拡張エントリの生成ルール（競合エントリ E と結合先エントリ F について）:
+//   - F が1ストロークの場合: input=E.input+F.input, output=E.output+F.output
+//     例: n/ん + k/き → nk/んき
+//   - F が複数ストロークの場合: input=E.input+F.input[0], output=E.output, nextInput=[F.input[0]]
+//     例: n/ん + ka/か → nk/ん/[k]（nk まで打つと「ん」が確定し、k が次の入力として戻される）
+//
+// 結合先の選定:
+//   競合エントリ n/ん に対し、na/な の2打目 a は「取られたストローク」となる。
+//   a で始まるエントリは結合先にできない（na と区別できないため）。
+//   また n 自身の先頭ストローク n も除外する。
+//   残った先頭ストロークを持つエントリのみが結合先となる。
+//
+// 具体例:
+//   入力: n/ん, na/な, ka/か
+//   → n は na のプレフィックス。取られたストローク = {a, n}
+//   → 結合先: ka（先頭 k は取られていない、複数ストローク）
+//   → 拡張: nk/ん/[k]
+//   結果: nk/ん/[k], na/な, ka/か
+//
+// 停止性:
+//   各イテレーションで1エントリが削除され、追加されるエントリは元より長い input を持つ。
+//   ストロークの組み合わせは有限なので必ず停止する。
+
 export function expandPrefixRules(entries: RuleEntry[]): RuleEntry[] {
   const unextendable = entries.filter((e) => !e.extendCommonPrefixCommonEntry);
   const extendable = entries.filter((e) => e.extendCommonPrefixCommonEntry);
@@ -11,6 +51,9 @@ function strokeHash(...strokes: RuleStroke[]): string {
   return strokes.map((s) => `${s.key.toString()}/${s.requiredModifier.toString()}`).join("-");
 }
 
+// Map 内で最初に見つかったプレフィックス競合を返す。
+// takenStrokes: 競合エントリの次の位置で使われているストロークと自身の先頭ストロークの集合。
+// これらのストロークで始まるエントリは結合先にできない。
 function findPrefixConflict(entryMap: Map<string, RuleEntry>): {
   entry: RuleEntry;
   hash: string;
@@ -46,20 +89,24 @@ function resolvePrefixConflicts(entries: RuleEntry[]): RuleEntry[] {
 
     const { entry, hash, takenStrokes } = conflict;
 
+    // 取られたストロークで始まらないエントリを結合先として集める
     const availableEntries = [...entryMap.values()].filter(
       (e) => !takenStrokes.has(strokeHash(e.input[0])),
     );
 
+    // 競合エントリを削除し、結合先ごとに拡張エントリを生成
     entryMap.delete(hash);
 
     for (const avail of availableEntries) {
       if (avail.input.length === 1) {
+        // 1ストロークの結合先: output を結合する
         const newInput = [...entry.input, ...avail.input];
         entryMap.set(
           strokeHash(...newInput),
           new RuleEntry(newInput, entry.output + avail.output, avail.nextInput, true),
         );
       } else {
+        // 複数ストロークの結合先: 先頭1ストロークだけ取り、nextInput として戻す
         const newInput = [...entry.input, avail.input[0]];
         entryMap.set(
           strokeHash(...newInput),

--- a/src/core/ruleExtender.ts
+++ b/src/core/ruleExtender.ts
@@ -1,170 +1,73 @@
 import { RuleEntry } from "./rule";
 import type { RuleStroke } from "./ruleStroke";
 
-export function extendCommonPrefixOverlappedEntriesDeeply(entries: RuleEntry[]): RuleEntry[] {
-  return recursiveExtendCommontPrefixOverlappedEntries(entries);
+export function expandPrefixRules(entries: RuleEntry[]): RuleEntry[] {
+  const unextendable = entries.filter((e) => !e.extendCommonPrefixCommonEntry);
+  const extendable = entries.filter((e) => e.extendCommonPrefixCommonEntry);
+  return [...unextendable, ...resolvePrefixConflicts(extendable)];
 }
 
-function recursiveExtendCommontPrefixOverlappedEntries(entries: RuleEntry[]): RuleEntry[] {
-  let extendableEntries = entries.filter((entry) => entry.extendCommonPrefixCommonEntry);
-  const unextendableEntries = entries.filter((entry) => !entry.extendCommonPrefixCommonEntry);
-  while (true) {
-    const { extendRequiredEntries, extendedNewEntries } =
-      extendCommonPrefixOverlappedEntries(extendableEntries);
-    // console.log(
-    //   Array.from(extendRequiredEntries).map((v) => {
-    //     return {
-    //       input: v.input.map((i) => i.keys[0]).join("|"),
-    //       output: v.output,
-    //       nextInput: v.nextInput.map((i) => i.keys[0]).join("|"),
-    //     };
-    //   })
-    // );
-    // extend された entry は除外する
-    extendableEntries = extendableEntries.filter((entry) => !extendRequiredEntries.has(entry));
-    // console.log(
-    //   extendedNewEntries.map((v) => {
-    //     return {
-    //       input: v.input.map((i) => i.keys[0]).join("|"),
-    //       output: v.output,
-    //       nextInput: v.nextInput.map((i) => i.keys[0]).join("|"),
-    //     };
-    //   })
-    // );
-    // new entries を追加する
-    extendableEntries.push(...extendedNewEntries);
-    if (extendRequiredEntries.size === 0) {
-      break;
+function strokeHash(...strokes: RuleStroke[]): string {
+  return strokes.map((s) => `${s.key.toString()}/${s.requiredModifier.toString()}`).join("-");
+}
+
+function findPrefixConflict(entryMap: Map<string, RuleEntry>): {
+  entry: RuleEntry;
+  hash: string;
+  takenStrokes: Set<string>;
+} | null {
+  for (const [hash, entry] of entryMap) {
+    const takenStrokes = new Set<string>();
+    let hasConflict = false;
+    for (const other of entryMap.values()) {
+      if (other.input.length <= entry.input.length) continue;
+      if (strokeHash(...other.input.slice(0, entry.input.length)) === hash) {
+        takenStrokes.add(strokeHash(other.input[entry.input.length]));
+        hasConflict = true;
+      }
+    }
+    if (hasConflict) {
+      takenStrokes.add(strokeHash(entry.input[0]));
+      return { entry, hash, takenStrokes };
     }
   }
-  return [...unextendableEntries, ...extendableEntries];
+  return null;
 }
 
-function extendCommonPrefixOverlappedEntries(entries: RuleEntry[]): {
-  extendRequiredEntries: Set<RuleEntry>;
-  extendedNewEntries: RuleEntry[];
-} {
-  // console.log("called extendCommonPrefixOverlappedEntries");
-  // Map のキーにするために、RuleStroke を文字列に変換する
-  const strokeToHash = (...strokes: RuleStroke[]): string => {
-    return strokes
-      .map((stroke) => `${stroke.key.toString()}/${stroke.requiredModifier.toString()}`)
-      .join("-");
-  };
+function resolvePrefixConflicts(entries: RuleEntry[]): RuleEntry[] {
+  const entryMap = new Map<string, RuleEntry>();
+  for (const e of entries) {
+    entryMap.set(strokeHash(...e.input), e);
+  }
 
-  const entryMapByInput = new Map<string, RuleEntry[]>();
-  const entryMapByInputPrefix = new Map<string, RuleEntry[]>();
-  entries.forEach((entry) => {
-    // 各エントリの input をキーにして entry を Map に登録する
-    const hash = strokeToHash(...entry.input);
-    if (entryMapByInput.has(hash)) {
-      entryMapByInput.get(hash)?.push(entry);
-    } else {
-      entryMapByInput.set(hash, [entry]);
-    }
-    // 各エントリの input prefix をキーにして entry を Map に登録する
-    for (let i = 1; i < entry.input.length; i++) {
-      const prefixHash = strokeToHash(...entry.input.slice(0, i));
-      if (entryMapByInputPrefix.has(prefixHash)) {
-        entryMapByInputPrefix.get(prefixHash)?.push(entry);
+  while (true) {
+    const conflict = findPrefixConflict(entryMap);
+    if (!conflict) break;
+
+    const { entry, hash, takenStrokes } = conflict;
+
+    const availableEntries = [...entryMap.values()].filter(
+      (e) => !takenStrokes.has(strokeHash(e.input[0])),
+    );
+
+    entryMap.delete(hash);
+
+    for (const avail of availableEntries) {
+      if (avail.input.length === 1) {
+        const newInput = [...entry.input, ...avail.input];
+        entryMap.set(
+          strokeHash(...newInput),
+          new RuleEntry(newInput, entry.output + avail.output, avail.nextInput, true),
+        );
       } else {
-        entryMapByInputPrefix.set(prefixHash, [entry]);
-      }
-    }
-  });
-  // console.log("entryMapByInput", entryMapByInput);
-  // console.log("entryMapByInputPrefix", entryMapByInputPrefix);
-  const extendRequiredInput = new Map<string, RuleEntry[]>();
-  entries.forEach((entry) => {
-    // 各エントリの input の prefix に一致するものが entryMap にある場合、
-    // そのまま使うことはできないので、展開する
-    // 例： n/ん, na/な, ka/か
-    // このとき、n 単独で「ん」を打つことはできず、
-    // nka のときのみ「んか」となって「ん」を n 一打で打つことができる
-    // ※2打鍵目が a 以外でなければならず、a 以外で始まるエントリと結合する
-    //
-    // 展開対象が複数ある場合、展開されたものがさらに展開を要することもある
-    // 例：n/ん, na/な, ka/か, s/さ, si/し
-    // n/ん → nk/ん/k, ns/んさ, ns/ん/s となる
-    // ns/んさ → nsna/んさな, nska/んさか
-    // s/さ → sn/さん, sna/さな, ska/さか
-    // 最終的に
-    // nk/ん/k, nsna/んさな, nska/んさか, sn/さん, sna/さな, ska/さか, si/し, ka/か, na/な
-    // となる
-    // 疑問：展開されたことによって、すでにチェック済みのもの（上で言えば na/な とか）が
-    // あらためて展開が必要になることはあるか？
-    // →展開されると、重複しないように prefix が伸びていくので、一度展開不要となったエントリが
-    // あらためて展開必要になることはないはず
-    // nnn/ななな, nn/なぬ, n/ん, ka/か
-    // n/ん → nk/ん/k
-    // nn/なぬ → nnk/なぬ/k
-    for (let i = 1; i < entry.input.length; i++) {
-      const prefixHash = strokeToHash(...entry.input.slice(0, i));
-      if (!entryMapByInput.has(prefixHash)) {
-        // prefix と同じ入力を持つものがないときは展開不要
-        continue;
-      }
-      // console.log(prefixHash);
-      if (!extendRequiredInput.has(prefixHash)) {
-        // 同じ prefix を持つエントリ集合を P とする (entry=na の場合, na, ni, nu, ...)
-        // P に含まれないエントリのうち、「P に含まれるエントリの input[i] で使われていないキー」を
-        // 1打鍵目に持つエントリのみ、この後の展開で使うことができる
-        const usedStrokeHashes = new Set<string>(
-          entryMapByInputPrefix
-            .get(prefixHash)
-            ?.map((prefixEntry) => strokeToHash(prefixEntry.input[i])),
-        );
-        usedStrokeHashes.add(strokeToHash(entry.input[0]));
-        // console.log("usedStrokeHashes", usedStrokeHashes);
-        extendRequiredInput.set(
-          prefixHash,
-          entries.filter((entry) => {
-            const firstHash = strokeToHash(entry.input[0]);
-            return !usedStrokeHashes.has(firstHash);
-          }),
+        const newInput = [...entry.input, avail.input[0]];
+        entryMap.set(
+          strokeHash(...newInput),
+          new RuleEntry(newInput, entry.output, [avail.input[0]], true),
         );
       }
     }
-  });
-  // console.log("extendRequiredInput", extendRequiredInput);
-  const extendRequiredEntries = new Set<RuleEntry>();
-  const extendedNewEntries = new Map<string, RuleEntry>();
-  extendRequiredInput.forEach((availableEntries, hash) => {
-    // 展開が必要なエントリ（例：n/ん）
-    const prefixOverlapEntries = entryMapByInput.get(hash) as RuleEntry[];
-    prefixOverlapEntries.forEach((expandRequiredEntry) => {
-      extendRequiredEntries.add(expandRequiredEntry);
-      availableEntries.forEach((availableEntry) => {
-        if (availableEntry.input.length === 1) {
-          const newInput = [...expandRequiredEntry.input, ...availableEntry.input];
-          const newInputHash = strokeToHash(...newInput);
-          extendedNewEntries.set(
-            newInputHash,
-            new RuleEntry(
-              newInput,
-              expandRequiredEntry.output + availableEntry.output,
-              availableEntry.nextInput,
-              true,
-            ),
-          );
-        } else {
-          const newInput = [...expandRequiredEntry.input, availableEntry.input[0]];
-          const newInputHash = strokeToHash(...newInput);
-          extendedNewEntries.set(
-            newInputHash,
-            new RuleEntry(
-              [...expandRequiredEntry.input, availableEntry.input[0]],
-              expandRequiredEntry.output,
-              [availableEntry.input[0]],
-              true,
-            ),
-          );
-        }
-      });
-    });
-  });
-  return {
-    extendRequiredEntries: extendRequiredEntries,
-    extendedNewEntries: Array.from(extendedNewEntries.values()),
-  };
+  }
+
+  return [...entryMap.values()];
 }

--- a/src/impl/presetRules.test.ts
+++ b/src/impl/presetRules.test.ts
@@ -7,7 +7,7 @@ test("load google ime roman rule", () => {
   // rule.entries.forEach((entry) => {
   //   console.log(entryToString(entry));
   // });
-  expect(rule.entries.length).toBe(421);
+  expect(rule.entries.length).toBe(420);
 });
 
 test("load jis kana rule", () => {


### PR DESCRIPTION
## Summary

- ruleExtender.ts を171行から73行に削減。3つのMapを毎回再構築するバッチ処理から、1つのMapで1件ずつプレフィックス競合を解決する逐次ループに変更
- 公開関数名を `extendCommonPrefixOverlappedEntriesDeeply` → `expandPrefixRules` にリネーム
- テストを2件→8件に拡充（複数競合、プレフィックス連鎖、nextInput、extend=false、output結合、候補なし）
- 旧実装の重複エントリバグ（配列管理で同一inputのエントリが重複生成される問題）を Map 管理により解消
- コミットフックに `pnpm run fmt` を追加

## 設計の背景

旧実装は `extendCommonPrefixOverlappedEntries` が1パスで全競合を検出・展開し、それを while ループで繰り返す構造だった。各パスで `entryMapByInput`、`entryMapByInputPrefix`、`extendRequiredInput` の3つの Map を全エントリから再構築するため、コードが複雑で追跡が困難だった。

新実装は `Map<inputHash, RuleEntry>` を1つだけ保持し、`findPrefixConflict` で競合を1件見つけ → 該当エントリを削除 → 拡張エントリを追加、を繰り返す��各イテレーションで1エントリが削除され、追加されるエントリはより長いinputを持つため、停止性が自明。

## 検討した代替案

- Trie構造でプレフィックス検索を高速化する案: 日本語入力ルールは通常300〜400エントリ程度で、プレフィックス競合は5〜10件程度。Trieの構造的オーバーヘッドに見合わないため不採用
- バッチ処理を維持しつつMap管理に変更する案: 逐次処理の方がコードがシン��ルで、結果も等価なため不採用

## Test plan

- [x] `pnpm run test` 全82テスト通過
- [x] `pnpm run build` 成功
- [x] Google IME ローマ字ルールの展開結果を旧実装と比較し、差分が重複エントリ（`F,U→ふ`）の除去1件のみであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)