### PR TITLE
examples の一括ビルドを CI とコミットフックに追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,9 +7,9 @@
           {
             "type": "command",
             "if": "Bash(git commit *)",
-            "command": "pnpm run fmt && pnpm run lint && pnpm run test || exit 2",
-            "timeout": 120,
-            "statusMessage": "Running fmt, lint and test..."
+            "command": "pnpm run fmt && pnpm run lint && pnpm run test && pnpm run build:all || exit 2",
+            "timeout": 300,
+            "statusMessage": "Running fmt, lint, test and build:all..."
           }
         ]
       }

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,3 +24,4 @@ jobs:
       - run: pnpm i
       - run: pnpm run lint
       - run: pnpm run test
+      - run: pnpm run build:all

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "node index.js",
+    "build": "node --check index.js && node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "scripts": {
     "build": "vite build && tsc",
+    "build:all": "pnpm run build && pnpm -r --filter \"./examples/*\" run build",
     "lint": "oxlint --deny-warnings src",
     "lint:fix": "oxlint --fix src",
     "test": "vitest",


### PR DESCRIPTION
## Summary

- ルート package.json に build:all スクリプトを追加（emiel 本体 → examples 全プロジェクトの順でビルド）
- examples/cli に build スクリプトを追加し、node --check + node index.js で構文・実行時エラーを検知
- .github/workflows/main.yaml の CI に pnpm run build:all を追加
- .claude/settings.json のコミットフックに build:all を追加し、timeout を 300 秒に延長

## 設計の背景

これまで CI とコミットフックでは lint / test / fmt のみを実行しており、emiel 本体の変更で examples の型やビルドが壊れても気付けない状態だった。examples は emiel の API に対する実質的な利用例兼統合テストとして機能するため、CI・コミット時点で examples が全てビルド可能であることを強制する。

pnpm workspace 構成を活かし、pnpm -r --filter \"./examples/*\" run build で一括実行する。1 つでも失敗すれば非 0 終了するため、「どれか1つでも失敗したらコマンドとして失敗」という要件を満たす。

examples/cli は TypeScript ではなく //@ts-check 付きの JS で、node index.js で実行するだけのサンプル。ビルド成果物は無いが emiel の API 変更で壊れうるため、build スクリプトとして node --check index.js && node index.js を登録し、実行自体を検証に含めた。

## 検討した代替案

- pnpm -r run build に cli の build を定義しない案: pnpm recursive は未定義スクリプトを自動スキップするため実装は楽だが、cli が検証対象から外れ emiel の API 変更で壊れても検知できない。却下。
- build:all の中で node examples/cli/index.js を個別に呼ぶ案: ルートスクリプトに cli 固有のパスが漏れ、examples が増減するたびにルートを触る必要がある。cli 側の package.json に build を持たせる方が pnpm workspace の世界観に沿う。却下。
- git の pre-commit hook として実装する案: このリポジトリのコミットフックは .claude/settings.json の PreToolUse Hook で統一されているため、既存の仕組みに合わせた。

## Test plan

- [x] ローカルで pnpm run build:all を実行し、emiel + 全 example（cli 含む）のビルドが成功することを確認
- [x] pnpm --filter cli run build が node --check を通過し index.js を実行して exit 0 になることを確認
- [ ] この PR の GitHub Actions で build:all step が成功することを確認
- [ ] コミットフック経由で build:all が呼ばれ、失敗時にコミットがブロックされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)