### PR TITLE
lint/fmt の対象に examples を追加し警告を修正

### DIFF
--- a/examples/cli/index.js
+++ b/examples/cli/index.js
@@ -13,12 +13,6 @@ const automaton = loadPresetRuleRoman(layout).build("かった");
 const Key = VirtualKeys;
 const inputResult = [Key.K, Key.A, Key.F, Key.T, Key.T, Key.A].map((k) => [
   k,
-  automaton.input(
-    new InputEvent(
-      new InputStroke(k, "keydown"),
-      new KeyboardState(),
-      new Date()
-    )
-  ),
+  automaton.input(new InputEvent(new InputStroke(k, "keydown"), new KeyboardState(), new Date())),
 ]);
 console.log(inputResult);

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -2,14 +2,14 @@
   "name": "cli",
   "version": "1.0.0",
   "description": "",
+  "license": "MIT",
+  "author": "",
   "type": "module",
   "scripts": {
     "dev": "node index.js",
     "build": "node --check index.js && node index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
-  "license": "MIT",
   "dependencies": {
     "emiel": "workspace:*"
   }

--- a/examples/react-backspace/package.json
+++ b/examples/react-backspace/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-backspace",
-  "private": true,
   "version": "0.0.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/examples/react-backspace/src/App.tsx
+++ b/examples/react-backspace/src/App.tsx
@@ -1,4 +1,5 @@
-import { activate, detectKeyboardLayout, InputStroke, KeyboardLayout, loadPresetRuleRoman, VirtualKeys } from "emiel";
+import type { InputStroke, KeyboardLayout } from "emiel";
+import { activate, detectKeyboardLayout, loadPresetRuleRoman, VirtualKeys } from "emiel";
 import { useEffect, useMemo, useState } from "react";
 import "./App.css";
 import { BackspaceRequirdAutomaton } from "./backspace";
@@ -16,15 +17,11 @@ function Typing(props: { layout: KeyboardLayout }) {
   const words = useMemo(() => ["おをひく", "こんとん", "がっこう", "aから@"], []);
   const [automatons] = useState(
     words.map((w) => {
-      return new BackspaceRequirdAutomaton(
-        romanRule.build(w)
-      );
-    })
+      return new BackspaceRequirdAutomaton(romanRule.build(w));
+    }),
   );
   const [index, setIndex] = useState(0);
-  const [lastInputKey, setLastInputKey] = useState<
-    InputStroke | undefined
-  >();
+  const [lastInputKey, setLastInputKey] = useState<InputStroke | undefined>();
   const automaton = automatons[index];
   useEffect(() => {
     return activate(window, (e) => {
@@ -71,12 +68,9 @@ function Typing(props: { layout: KeyboardLayout }) {
                   props.layout
                     .getCharByKey(
                       f.input.key,
-                      f.keyboardState.isAnyKeyDowned(
-                        VirtualKeys.ShiftLeft,
-                        VirtualKeys.ShiftRight
-                      )
+                      f.keyboardState.isAnyKeyDowned(VirtualKeys.ShiftLeft, VirtualKeys.ShiftRight),
                     )
-                    .replace(" ", "_")
+                    .replace(" ", "_"),
                 )
                 .join("")}
             </span>

--- a/examples/react-backspace/src/backspace.ts
+++ b/examples/react-backspace/src/backspace.ts
@@ -1,43 +1,43 @@
-import { Automaton, InputEvent, InputResult } from "emiel";
+import type { Automaton, InputEvent } from "emiel";
+import { InputResult } from "emiel";
 /**
  * 入力ミスしたキーを蓄積していき、Backspace 等の消去キーを入力して消さないと次の入力ができないオートマトン
  */
 export class BackspaceRequirdAutomaton {
-	private _failedInputs: InputEvent[] = [];
+  private _failedInputs: InputEvent[] = [];
 
-	constructor(readonly base: Automaton) { }
+  constructor(readonly base: Automaton) {}
 
-	get failedInputs(): readonly InputEvent[] {
-		return this._failedInputs;
-	}
+  get failedInputs(): readonly InputEvent[] {
+    return this._failedInputs;
+  }
 
-	input(stroke: InputEvent): InputResult {
-		const [result, apply] = this.base.testInput(stroke);
-		if (result.isIgnored) {
-			return result;
-		}
-		if (this._failedInputs.length > 0) {
-			// すでにミスしたキーが存在する場合は、それ以降の入力も自動的に失敗扱いにする
-			this._failedInputs.push(stroke);
-			return InputResult.FAILED;
-		}
-		if (result.isFailed) {
-			this._failedInputs.push(stroke);
-		}
-		// 状態遷移する
-		apply()
-		return result;
-	}
+  input(stroke: InputEvent): InputResult {
+    const [result, apply] = this.base.testInput(stroke);
+    if (result.isIgnored) {
+      return result;
+    }
+    if (this._failedInputs.length > 0) {
+      // すでにミスしたキーが存在する場合は、それ以降の入力も自動的に失敗扱いにする
+      this._failedInputs.push(stroke);
+      return InputResult.FAILED;
+    }
+    if (result.isFailed) {
+      this._failedInputs.push(stroke);
+    }
+    // 状態遷移する
+    apply();
+    return result;
+  }
 
-	backFailedInput(): void {
-		if (this._failedInputs.length > 0) {
-			this._failedInputs.pop();
-		}
-	}
+  backFailedInput(): void {
+    if (this._failedInputs.length > 0) {
+      this._failedInputs.pop();
+    }
+  }
 
-	reset(): void {
-		this._failedInputs = [];
-		this.base.reset();
-	}
+  reset(): void {
+    this._failedInputs = [];
+    this.base.reset();
+  }
 }
-

--- a/examples/react-backspace/src/main.tsx
+++ b/examples/react-backspace/src/main.tsx
@@ -1,10 +1,14 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+import "./index.css";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Root element #root not found");
+}
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-)
+);

--- a/examples/react-backspace/vite.config.ts
+++ b/examples/react-backspace/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+});

--- a/examples/react-keyboardguide/README.md
+++ b/examples/react-keyboardguide/README.md
@@ -17,12 +17,12 @@ If you are developing a production application, we recommend updating the config
 export default {
   // other rules...
   parserOptions: {
-    ecmaVersion: 'latest',
-    sourceType: 'module',
-    project: ['./tsconfig.json', './tsconfig.node.json'],
+    ecmaVersion: "latest",
+    sourceType: "module",
+    project: ["./tsconfig.json", "./tsconfig.node.json"],
     tsconfigRootDir: __dirname,
   },
-}
+};
 ```
 
 - Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`

--- a/examples/react-keyboardguide/package.json
+++ b/examples/react-keyboardguide/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-keyboardguide",
-  "private": true,
   "version": "0.0.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/examples/react-keyboardguide/src/App.tsx
+++ b/examples/react-keyboardguide/src/App.tsx
@@ -1,5 +1,16 @@
-import { KeyRect, KeyTop, KeyboardState, KeyboardStateReader, PhysicalKeyboardLayoutName, activate, loadPresetKeyboardGuideJis106Default, loadPresetKeyboardGuideJis106JisKana, loadPresetKeyboardGuideJis106Nicola, loadPresetKeyboardGuideUs101Default, loadPresetKeyboardLayoutDvorak, loadPresetKeyboardLayoutQwertyJis, loadPresetKeyboardLayoutQwertyUs } from 'emiel';
-import { useEffect, useState } from 'react';
+import type { KeyRect, KeyTop, KeyboardStateReader, PhysicalKeyboardLayoutName } from "emiel";
+import {
+  KeyboardState,
+  activate,
+  loadPresetKeyboardGuideJis106Default,
+  loadPresetKeyboardGuideJis106JisKana,
+  loadPresetKeyboardGuideJis106Nicola,
+  loadPresetKeyboardGuideUs101Default,
+  loadPresetKeyboardLayoutDvorak,
+  loadPresetKeyboardLayoutQwertyJis,
+  loadPresetKeyboardLayoutQwertyUs,
+} from "emiel";
+import { useEffect, useState } from "react";
 
 type LayoutName = "qwerty-jis" | "qwerty-us" | "dvorak";
 type GuideName = "us_101_default" | "jis_106_default" | "jis_106_jis_kana" | "jis_106_nicola";
@@ -10,239 +21,276 @@ function App() {
     activate(window, (evt) => {
       if (evt.input.type === "keydown") {
         console.log("down", evt.input.key);
-        setKeyboardState(evt.keyboardState)
+        setKeyboardState(evt.keyboardState);
       } else {
         console.log("up", evt.input.key);
-        setKeyboardState(evt.keyboardState)
+        setKeyboardState(evt.keyboardState);
       }
-    }
-    );
+    });
   }, []);
-  const [physicalLayoutName, setPhysicalLayoutName] = useState<PhysicalKeyboardLayoutName>("jis_106");
+  const [physicalLayoutName, setPhysicalLayoutName] =
+    useState<PhysicalKeyboardLayoutName>("jis_106");
   const [layoutName, setLayoutName] = useState<LayoutName>("qwerty-jis");
   const [guideName, setGuideName] = useState<GuideName>("us_101_default");
   const [showVirtualKeyCodes, setShowVirtualKeyCodes] = useState(false);
-  return <>
-    <h1>Keyboard Guide</h1>
-    <div style={{ height: "20px" }}></div>
-    <PhysicalLayoutSelector onLayoutChange={(layout: PhysicalKeyboardLayoutName) => setPhysicalLayoutName(layout)} />
-    <LayoutSelector onLayoutChange={(layoutName: LayoutName) => setLayoutName(layoutName)} />
-    <GuideSelector onGuideChange={setGuideName} />
-    <label><input type="checkbox" onClick={(e) => setShowVirtualKeyCodes(e.currentTarget.checked)} />仮想キーコードの表示</label>
-    <div style={{ height: "20px" }}></div>
-    <KeyboardGuideComponent showVirtualKeyCodes={showVirtualKeyCodes} layoutName={layoutName} physicalLayoutName={physicalLayoutName} guideName={guideName} kbdState={keyboardState} />
-  </>
+  return (
+    <>
+      <h1>Keyboard Guide</h1>
+      <div style={{ height: "20px" }}></div>
+      <PhysicalLayoutSelector
+        onLayoutChange={(layout: PhysicalKeyboardLayoutName) => setPhysicalLayoutName(layout)}
+      />
+      <LayoutSelector onLayoutChange={(layoutName: LayoutName) => setLayoutName(layoutName)} />
+      <GuideSelector onGuideChange={setGuideName} />
+      <label>
+        <input type="checkbox" onClick={(e) => setShowVirtualKeyCodes(e.currentTarget.checked)} />
+        仮想キーコードの表示
+      </label>
+      <div style={{ height: "20px" }}></div>
+      <KeyboardGuideComponent
+        showVirtualKeyCodes={showVirtualKeyCodes}
+        layoutName={layoutName}
+        physicalLayoutName={physicalLayoutName}
+        guideName={guideName}
+        kbdState={keyboardState}
+      />
+    </>
+  );
 }
 
 function PhysicalLayoutSelector(props: {
-  onLayoutChange: (physicalLayoutName: PhysicalKeyboardLayoutName) => void,
+  onLayoutChange: (physicalLayoutName: PhysicalKeyboardLayoutName) => void;
 }) {
   const [selected, setSelected] = useState(0);
-  return <>
-    <div style={{ display: "flex", gap: "10px", alignItems: "center" }}>
-      <h3>物理配列</h3>
-      <button
-        className={selected === 0 ? "selected" : ""}
-        onClick={() => (props.onLayoutChange("jis_106"), setSelected(0))}>
-        JIS-106
-      </button>
-      <button
-        className={selected === 1 ? "selected" : ""}
-        onClick={() => (props.onLayoutChange("us_101"), setSelected(1))}
-      >
-        US-101
-      </button>
-      <button
-        className={selected === 2 ? "selected" : ""}
-        onClick={() => (props.onLayoutChange("us_hhkb"), setSelected(2))}
-      >
-        US-HHKB
-      </button>
-    </div>
-  </>
+  return (
+    <>
+      <div style={{ display: "flex", gap: "10px", alignItems: "center" }}>
+        <h3>物理配列</h3>
+        <button
+          className={selected === 0 ? "selected" : ""}
+          onClick={() => (props.onLayoutChange("jis_106"), setSelected(0))}
+        >
+          JIS-106
+        </button>
+        <button
+          className={selected === 1 ? "selected" : ""}
+          onClick={() => (props.onLayoutChange("us_101"), setSelected(1))}
+        >
+          US-101
+        </button>
+        <button
+          className={selected === 2 ? "selected" : ""}
+          onClick={() => (props.onLayoutChange("us_hhkb"), setSelected(2))}
+        >
+          US-HHKB
+        </button>
+      </div>
+    </>
+  );
 }
 
-function LayoutSelector(props: {
-  onLayoutChange: (layoutName: LayoutName) => void,
-}) {
+function LayoutSelector(props: { onLayoutChange: (layoutName: LayoutName) => void }) {
   const [selected, setSelected] = useState(0);
-  return <>
-    <div style={{ display: "flex", gap: "10px", alignItems: "center" }}>
-      <h3>英字配列</h3>
-      <button
-        className={selected === 0 ? "selected" : ""}
-        onClick={() => (props.onLayoutChange("qwerty-jis"), setSelected(0))}>
-        Qwerty-JIS
-      </button>
-      <button
-        className={selected === 1 ? "selected" : ""}
-        onClick={() => (props.onLayoutChange("qwerty-us"), setSelected(1))}
-      >
-        Qwerty-US
-      </button>
-      <button
-        className={selected === 2 ? "selected" : ""}
-        onClick={() => (props.onLayoutChange("dvorak"), setSelected(2))}
-      >
-        Dvorak
-      </button>
-    </div>
-  </>
+  return (
+    <>
+      <div style={{ display: "flex", gap: "10px", alignItems: "center" }}>
+        <h3>英字配列</h3>
+        <button
+          className={selected === 0 ? "selected" : ""}
+          onClick={() => (props.onLayoutChange("qwerty-jis"), setSelected(0))}
+        >
+          Qwerty-JIS
+        </button>
+        <button
+          className={selected === 1 ? "selected" : ""}
+          onClick={() => (props.onLayoutChange("qwerty-us"), setSelected(1))}
+        >
+          Qwerty-US
+        </button>
+        <button
+          className={selected === 2 ? "selected" : ""}
+          onClick={() => (props.onLayoutChange("dvorak"), setSelected(2))}
+        >
+          Dvorak
+        </button>
+      </div>
+    </>
+  );
 }
 
-function GuideSelector(props: {
-  onGuideChange: (guideName: GuideName) => void,
-}) {
+function GuideSelector(props: { onGuideChange: (guideName: GuideName) => void }) {
   const [selected, setSelected] = useState(0);
-  return <>
-    <div style={{ display: "flex", gap: "10px", alignItems: "center" }}>
-      <h3>配列ガイド</h3>
-      <button
-        className={selected === 0 ? "selected" : ""}
-        onClick={() => (props.onGuideChange("us_101_default"), setSelected(0))}
-      >
-        US101
-      </button>
-      <button
-        className={selected === 1 ? "selected" : ""}
-        onClick={() => (props.onGuideChange("jis_106_default"), setSelected(1))}
-      >
-        JIS106
-      </button>
-      <button
-        className={selected === 2 ? "selected" : ""}
-        onClick={() => (props.onGuideChange("jis_106_jis_kana"), setSelected(2))}
-      >
-        JIS106 JISかな
-      </button>
-      <button
-        className={selected === 3 ? "selected" : ""}
-        onClick={() => (props.onGuideChange("jis_106_nicola"), setSelected(3))}
-      >
-        JIS106 NICOLA
-      </button>
-    </div >
-  </>
+  return (
+    <>
+      <div style={{ display: "flex", gap: "10px", alignItems: "center" }}>
+        <h3>配列ガイド</h3>
+        <button
+          className={selected === 0 ? "selected" : ""}
+          onClick={() => (props.onGuideChange("us_101_default"), setSelected(0))}
+        >
+          US101
+        </button>
+        <button
+          className={selected === 1 ? "selected" : ""}
+          onClick={() => (props.onGuideChange("jis_106_default"), setSelected(1))}
+        >
+          JIS106
+        </button>
+        <button
+          className={selected === 2 ? "selected" : ""}
+          onClick={() => (props.onGuideChange("jis_106_jis_kana"), setSelected(2))}
+        >
+          JIS106 JISかな
+        </button>
+        <button
+          className={selected === 3 ? "selected" : ""}
+          onClick={() => (props.onGuideChange("jis_106_nicola"), setSelected(3))}
+        >
+          JIS106 NICOLA
+        </button>
+      </div>
+    </>
+  );
 }
 
 function KeyboardGuideComponent(props: {
-  layoutName: LayoutName,
-  physicalLayoutName: string,
-  guideName: GuideName,
-  kbdState: KeyboardStateReader,
-  showVirtualKeyCodes: boolean,
+  layoutName: LayoutName;
+  physicalLayoutName: string;
+  guideName: GuideName;
+  kbdState: KeyboardStateReader;
+  showVirtualKeyCodes: boolean;
 }) {
   // console.log("guide component", props.layout.name, props.kbdGuide.guideData.name);
   const layout = {
     "qwerty-jis": loadPresetKeyboardLayoutQwertyJis,
     "qwerty-us": loadPresetKeyboardLayoutQwertyUs,
-    "dvorak": loadPresetKeyboardLayoutDvorak
+    dvorak: loadPresetKeyboardLayoutDvorak,
   }[props.layoutName]();
   const kbdGuide = {
-    "us_101_default": loadPresetKeyboardGuideUs101Default,
-    "jis_106_default": loadPresetKeyboardGuideJis106Default,
-    "jis_106_jis_kana": loadPresetKeyboardGuideJis106JisKana,
-    "jis_106_nicola": loadPresetKeyboardGuideJis106Nicola,
-  }[props.guideName]().swapPhysicalLayout(props.physicalLayoutName as PhysicalKeyboardLayoutName);
+    us_101_default: loadPresetKeyboardGuideUs101Default,
+    jis_106_default: loadPresetKeyboardGuideJis106Default,
+    jis_106_jis_kana: loadPresetKeyboardGuideJis106JisKana,
+    jis_106_nicola: loadPresetKeyboardGuideJis106Nicola,
+  }
+    [props.guideName]()
+    .swapPhysicalLayout(props.physicalLayoutName as PhysicalKeyboardLayoutName);
   return (
     <>
       <div style={{ position: "relative" }}>
-        {
-          kbdGuide.keyTops(layout, {
-            keyWidth: 50, keyHeight: 50, gapX: 10, gapY: 10
-          }).map((keyTop, i) => {
-            return props.showVirtualKeyCodes ?
+        {kbdGuide
+          .keyTops(layout, {
+            keyWidth: 50,
+            keyHeight: 50,
+            gapX: 10,
+            gapY: 10,
+          })
+          .map((keyTop, i) => {
+            return props.showVirtualKeyCodes ? (
               <KeyCode
                 keyRect={keyTop.keyRect}
                 key={i}
                 isKeyDowned={props.kbdState.isKeyDowned(keyTop.keyRect.key)}
               ></KeyCode>
-              : <KeyWithLabel
+            ) : (
+              <KeyWithLabel
                 keyRect={keyTop.keyRect}
                 key={i}
                 keyTop={keyTop}
-                isKeyDowned={props.kbdState.isKeyDowned(keyTop.keyRect.key)} />
-          })
-        }
+                isKeyDowned={props.kbdState.isKeyDowned(keyTop.keyRect.key)}
+              />
+            );
+          })}
       </div>
     </>
-  )
+  );
 }
-function KeyCode(props: { keyRect: KeyRect, isKeyDowned: boolean }) {
+function KeyCode(props: { keyRect: KeyRect; isKeyDowned: boolean }) {
   const rect = props.keyRect.rect;
-  return <div style={{
-    display: "flex",
-    flexDirection: "column",
-    position: "absolute",
-    justifyContent: "center",
-    lineHeight: "12pt",
-    fontSize: "12pt",
-    left: `${rect.leftTop.x}px`,
-    top: `${rect.leftTop.y}px`,
-    border: "1px yellow solid",
-    width: `${rect.width}px`,
-    height: `${rect.height}px`,
-    backgroundColor: props.isKeyDowned ? "yellow" : "",
-  }}>
-    <span style={{ textAlign: "center", wordBreak: "break-all" }}>{props.keyRect.key.toString()}</span>
-  </div>
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        position: "absolute",
+        justifyContent: "center",
+        lineHeight: "12pt",
+        fontSize: "12pt",
+        left: `${rect.leftTop.x}px`,
+        top: `${rect.leftTop.y}px`,
+        border: "1px yellow solid",
+        width: `${rect.width}px`,
+        height: `${rect.height}px`,
+        backgroundColor: props.isKeyDowned ? "yellow" : "",
+      }}
+    >
+      <span style={{ textAlign: "center", wordBreak: "break-all" }}>
+        {props.keyRect.key.toString()}
+      </span>
+    </div>
+  );
 }
 
-function KeyWithLabel(props: {
-  keyRect: KeyRect,
-  keyTop: KeyTop,
-  isKeyDowned: boolean,
-}) {
+function KeyWithLabel(props: { keyRect: KeyRect; keyTop: KeyTop; isKeyDowned: boolean }) {
   const rect = props.keyRect.rect;
   const keyTop = props.keyTop;
-  return <div style={{
-    display: "flex",
-    flexDirection: "column",
-    position: "absolute",
-    justifyContent: "space-around",
-    lineHeight: "12pt",
-    fontSize: "12pt",
-    left: `${rect.leftTop.x}px`,
-    top: `${rect.leftTop.y}px`,
-    border: "1px yellow solid",
-    width: `${rect.width}px`,
-    height: `${rect.height}px`,
-    backgroundColor: props.isKeyDowned ? "yellow" : "",
-  }}>
-    <div style={{
-      display: "flex",
-      justifyContent: "space-around",
-      height: `${rect.height / 3}px`,
-      position: "relative",
-      top: "3px",
-    }}>
-      <div>{keyTop.topLeft ?? ""}</div>
-      <div>{keyTop.top ?? ""}</div>
-      <div>{keyTop.topRight ?? ""}</div>
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        position: "absolute",
+        justifyContent: "space-around",
+        lineHeight: "12pt",
+        fontSize: "12pt",
+        left: `${rect.leftTop.x}px`,
+        top: `${rect.leftTop.y}px`,
+        border: "1px yellow solid",
+        width: `${rect.width}px`,
+        height: `${rect.height}px`,
+        backgroundColor: props.isKeyDowned ? "yellow" : "",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-around",
+          height: `${rect.height / 3}px`,
+          position: "relative",
+          top: "3px",
+        }}
+      >
+        <div>{keyTop.topLeft ?? ""}</div>
+        <div>{keyTop.top ?? ""}</div>
+        <div>{keyTop.topRight ?? ""}</div>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-around",
+          height: `${rect.height / 3}px`,
+          position: "relative",
+          top: "0px",
+        }}
+      >
+        <div>{keyTop.left ?? ""}</div>
+        <div style={{ fontSize: "10pt" }}>{keyTop.center ?? ""}</div>
+        <div>{keyTop.right ?? ""}</div>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-around",
+          height: `${rect.height / 3}px`,
+          position: "relative",
+          top: "-3px",
+        }}
+      >
+        <div>{keyTop.bottomLeft ?? ""}</div>
+        <div>{keyTop.bottom ?? ""}</div>
+        <div>{keyTop.bottomRight ?? ""}</div>
+      </div>
     </div>
-    <div style={{
-      display: "flex",
-      justifyContent: "space-around",
-      height: `${rect.height / 3}px`,
-      position: "relative",
-      top: "0px",
-    }}>
-      <div>{keyTop.left ?? ""}</div>
-      <div style={{ fontSize: "10pt" }}>{keyTop.center ?? ""}</div>
-      <div>{keyTop.right ?? ""}</div>
-    </div>
-    <div style={{
-      display: "flex",
-      justifyContent: "space-around",
-      height: `${rect.height / 3}px`,
-      position: "relative",
-      top: "-3px",
-    }}>
-      <div>{keyTop.bottomLeft ?? ""}</div>
-      <div>{keyTop.bottom ?? ""}</div>
-      <div>{keyTop.bottomRight ?? ""}</div>
-    </div>
-  </div >
+  );
 }
 
-export default App
+export default App;

--- a/examples/react-keyboardguide/src/index.css
+++ b/examples/react-keyboardguide/src/index.css
@@ -13,7 +13,9 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-h1, h2, h3 {
+h1,
+h2,
+h3 {
   margin: 0;
   padding: 0;
 }

--- a/examples/react-keyboardguide/src/main.tsx
+++ b/examples/react-keyboardguide/src/main.tsx
@@ -1,10 +1,14 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+import "./index.css";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Root element #root not found");
+}
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-)
+);

--- a/examples/react-keyboardguide/vite.config.ts
+++ b/examples/react-keyboardguide/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+});

--- a/examples/react-mixed-guide/index.html
+++ b/examples/react-mixed-guide/index.html
@@ -1,15 +1,13 @@
 <!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Demo: React TW</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Demo: React TW</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/examples/react-mixed-guide/package.json
+++ b/examples/react-mixed-guide/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-mixed-guide",
-  "private": true,
   "version": "0.0.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/examples/react-mixed-guide/src/App.tsx
+++ b/examples/react-mixed-guide/src/App.tsx
@@ -1,4 +1,5 @@
-import { activate, detectKeyboardLayout, InputStroke, KeyboardLayout, loadPresetRuleRoman } from "emiel";
+import type { InputStroke, KeyboardLayout } from "emiel";
+import { activate, detectKeyboardLayout, loadPresetRuleRoman } from "emiel";
 import { useEffect, useMemo, useState } from "react";
 import "./App.css";
 import { MixedText, withMixedText } from "./MixedGuide";
@@ -19,18 +20,9 @@ function Typing(props: { layout: KeyboardLayout }) {
     new MixedText("がっ,こう", "学,校"),
     new MixedText("a,か,ら,@", "a,か,ら,@"),
   ];
-  const [automatons] = useState(
-    words.map((w) =>
-      withMixedText(
-        romanRule.build(w.kanaText),
-        w,
-      )
-    )
-  );
+  const [automatons] = useState(words.map((w) => withMixedText(romanRule.build(w.kanaText), w)));
   const [index, setIndex] = useState(0);
-  const [lastInputKey, setLastInputKey] = useState<
-    InputStroke | undefined
-  >();
+  const [lastInputKey, setLastInputKey] = useState<InputStroke | undefined>();
   useEffect(() => {
     return activate(window, (e) => {
       setLastInputKey(e.input);

--- a/examples/react-mixed-guide/src/MixedGuide.ts
+++ b/examples/react-mixed-guide/src/MixedGuide.ts
@@ -1,4 +1,4 @@
-import { Automaton } from "emiel";
+import type { Automaton } from "emiel";
 
 export class MixedText {
   readonly kanaText: string;

--- a/examples/react-mixed-guide/src/main.tsx
+++ b/examples/react-mixed-guide/src/main.tsx
@@ -1,10 +1,14 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+import "./index.css";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Root element #root not found");
+}
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-)
+);

--- a/examples/react-mixed-guide/vite.config.ts
+++ b/examples/react-mixed-guide/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+});

--- a/examples/react-multi-word/package.json
+++ b/examples/react-multi-word/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-multi-word",
-  "private": true,
   "version": "0.0.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/examples/react-multi-word/src/App.tsx
+++ b/examples/react-multi-word/src/App.tsx
@@ -1,19 +1,12 @@
-import { activate, Automaton, detectKeyboardLayout, InputStroke, KeyboardLayout, loadPresetRuleRoman, Selector, VirtualKeys } from "emiel";
+import type { Automaton, InputStroke, KeyboardLayout } from "emiel";
+import { activate, detectKeyboardLayout, loadPresetRuleRoman, Selector, VirtualKeys } from "emiel";
 import { useEffect, useMemo, useState } from "react";
 import "./App.css";
 import { Word } from "./word";
 
 // 繰り返し次のワードを生成するジェネレータ
 const wordGen = (function* wordGenerator(): Generator<string, string> {
-  const words = [
-    "こうきょう",
-    "こんとん",
-    "がっこう",
-    "aから@",
-    "トイレ",
-    "でんしゃ",
-    "どうろ",
-  ];
+  const words = ["こうきょう", "こんとん", "がっこう", "aから@", "トイレ", "でんしゃ", "どうろ"];
   for (let i = 0; ; i++) {
     yield words[i % words.length];
   }
@@ -24,14 +17,13 @@ const initialWords = Array.from({ length: 3 }, () => wordGen.next().value);
 
 type PositionAutomaton = Automaton & {
   getPosition: () => number;
-}
+};
 
 function withPosition(automaton: Automaton, position: number): PositionAutomaton {
   return automaton.with({
     getPosition: () => position,
   });
 }
-
 
 function App() {
   const [layout, setLayout] = useState<KeyboardLayout | undefined>();
@@ -46,18 +38,10 @@ function Typing(props: { layout: KeyboardLayout }) {
   const [selector, setSelector] = useState(
     new Selector(
       // 各 automaton の metadata として表示位置をもたせる
-      initialWords.map(
-        (w, i) =>
-          withPosition(
-            romanRule.build(w),
-            i
-          )
-      )
-    )
+      initialWords.map((w, i) => withPosition(romanRule.build(w), i)),
+    ),
   );
-  const [lastInputKey, setLastInputKey] = useState<
-    InputStroke | undefined
-  >();
+  const [lastInputKey, setLastInputKey] = useState<InputStroke | undefined>();
   useEffect(() => {
     return activate(window, (e) => {
       setLastInputKey(e.input);
@@ -70,10 +54,7 @@ function Typing(props: { layout: KeyboardLayout }) {
       const { finished, succeeded, failed } = selector.input(e);
       finished.forEach((a) => {
         console.log("finished", a);
-        const newAutomaton = withPosition(
-          romanRule.build(wordGen.next().value),
-          a.getPosition()
-        );
+        const newAutomaton = withPosition(romanRule.build(wordGen.next().value), a.getPosition());
         setSelector((current) => current.replaced(a, newAutomaton));
       });
       succeeded.forEach((a) => {

--- a/examples/react-multi-word/src/main.tsx
+++ b/examples/react-multi-word/src/main.tsx
@@ -1,10 +1,14 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+import "./index.css";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Root element #root not found");
+}
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-)
+);

--- a/examples/react-multi-word/src/word.tsx
+++ b/examples/react-multi-word/src/word.tsx
@@ -1,4 +1,4 @@
-import * as emiel from "emiel";
+import type * as emiel from "emiel";
 
 export function Word(props: { automaton: emiel.Automaton }) {
   console.log("Word", props.automaton.word);

--- a/examples/react-multi-word/vite.config.ts
+++ b/examples/react-multi-word/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+});

--- a/examples/react-result-record/package.json
+++ b/examples/react-result-record/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-result-record",
-  "private": true,
   "version": "0.0.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/examples/react-result-record/src/App.tsx
+++ b/examples/react-result-record/src/App.tsx
@@ -1,7 +1,9 @@
-import { Automaton, detectKeyboardLayout, KeyboardLayout, loadPresetRuleRoman } from "emiel";
+import type { Automaton, KeyboardLayout } from "emiel";
+import { detectKeyboardLayout, loadPresetRuleRoman } from "emiel";
 import { useEffect, useMemo, useState } from "react";
 import "./App.css";
-import { Record, WordRecordValue } from "./Record";
+import type { WordRecordValue } from "./Record";
+import { Record } from "./Record";
 import { Typing } from "./Typing";
 
 function App() {
@@ -18,22 +20,18 @@ function TypingRoot(props: { layout: KeyboardLayout }) {
     const words = ["おをひく", "こんとん", "がっこう", "aから@"];
     return words.map((w) => {
       return romanRule.build(w);
-    })
-  }, [props.layout])
+    });
+  }, [props.layout]);
   const [wordIndex, setWordIndex] = useState(0);
   const [wordRecords, setWordRecords] = useState<WordRecordValue[]>([]);
-  const onWordFinished = (
-    a: Automaton,
-    displayedAt: Date,
-  ) => {
+  const onWordFinished = (a: Automaton, displayedAt: Date) => {
     setWordRecords((wordRecords) => [
       ...wordRecords,
       {
         automaton: a,
         displayedAt,
         firstInputtedAt: a.edgeHistories[0].event.timestamp,
-        finishedAt:
-          a.edgeHistories[a.edgeHistories.length - 1].event.timestamp,
+        finishedAt: a.edgeHistories[a.edgeHistories.length - 1].event.timestamp,
       },
     ]);
     setWordIndex((current) => {
@@ -48,7 +46,7 @@ function TypingRoot(props: { layout: KeyboardLayout }) {
       automaton={automatons[wordIndex]}
       onWordFinished={onWordFinished}
     />
-  )
+  );
 }
 
 export default App;

--- a/examples/react-result-record/src/Record.tsx
+++ b/examples/react-result-record/src/Record.tsx
@@ -1,4 +1,5 @@
-import { Automaton, getAccuracy, getKpm, getRkpm } from "emiel";
+import type { Automaton } from "emiel";
+import { getAccuracy, getKpm, getRkpm } from "emiel";
 
 export type WordRecordValue = {
   automaton: Automaton;
@@ -9,16 +10,23 @@ export function Record(props: { wordRecords: WordRecordValue[] }) {
   const records = props.wordRecords.map((record) => {
     // ワードが表示されてから1打鍵めに成功するまでの経過時間
     const automaton = record.automaton;
-    const latency =
-      automaton.getFirstInputTime().getTime() - record.displayedAt.getTime();
+    const latency = automaton.getFirstInputTime().getTime() - record.displayedAt.getTime();
     const rkpm = getRkpm(
       automaton.edgeHistories.length,
       automaton.getFirstInputTime(),
-      automaton.getLastInputTime());
+      automaton.getLastInputTime(),
+    );
 
     // latency の時間を含めた、1分あたりの打鍵数
-    const kpm = getKpm(automaton.edgeHistories.length, record.displayedAt, automaton.getLastInputTime());
-    const accuracy = getAccuracy(record.automaton.getFailedInputCount(), record.automaton.getTotalInputCount());
+    const kpm = getKpm(
+      automaton.edgeHistories.length,
+      record.displayedAt,
+      automaton.getLastInputTime(),
+    );
+    const accuracy = getAccuracy(
+      record.automaton.getFailedInputCount(),
+      record.automaton.getTotalInputCount(),
+    );
     return {
       latency,
       kpm,
@@ -31,11 +39,11 @@ export function Record(props: { wordRecords: WordRecordValue[] }) {
   const totalLatency = records.reduce((acc, r) => acc + r.latency, 0);
   const totalSucceededCount = records.reduce(
     (acc, r) => acc + r.record.automaton.edgeHistories.length,
-    0
+    0,
   );
   const totalFailedCount = records.reduce(
     (acc, r) => acc + r.record.automaton.getFailedInputCount(),
-    0
+    0,
   );
   const totalAccuracy = getAccuracy(totalFailedCount, totalSucceededCount);
   return (
@@ -57,9 +65,7 @@ export function Record(props: { wordRecords: WordRecordValue[] }) {
           </tr>
           <tr>
             <td>accuracy</td>
-            <td>
-              {(totalAccuracy * 100).toFixed(2)} %
-            </td>
+            <td>{(totalAccuracy * 100).toFixed(2)} %</td>
           </tr>
         </table>
       </div>

--- a/examples/react-result-record/src/Typing.tsx
+++ b/examples/react-result-record/src/Typing.tsx
@@ -5,14 +5,9 @@ import "./App.css";
 export function Typing(props: {
   layout: emiel.KeyboardLayout;
   automaton: emiel.Automaton;
-  onWordFinished: (
-    a: emiel.Automaton,
-    displayedAt: Date,
-  ) => void;
+  onWordFinished: (a: emiel.Automaton, displayedAt: Date) => void;
 }) {
-  const [lastInputKey, setLastInputKey] = useState<
-    emiel.InputStroke | undefined
-  >();
+  const [lastInputKey, setLastInputKey] = useState<emiel.InputStroke | undefined>();
   const automaton = props.automaton;
   useEffect(() => {
     const wordDisplayedAt = new Date();
@@ -35,10 +30,7 @@ export function Typing(props: {
         {automaton.getPendingRoman()}
       </h1>
       <h2>
-        Miss:{" "}
-        <code>
-          {automaton.getFailedInputCount()}
-        </code>
+        Miss: <code>{automaton.getFailedInputCount()}</code>
       </h2>
       <h2>
         Key:{" "}

--- a/examples/react-result-record/src/main.tsx
+++ b/examples/react-result-record/src/main.tsx
@@ -3,8 +3,12 @@ import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Root element #root not found");
+}
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );

--- a/examples/react-result-record/vite.config.ts
+++ b/examples/react-result-record/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+});

--- a/examples/react-roman-or-kana/package.json
+++ b/examples/react-roman-or-kana/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-roman-or-kana",
-  "private": true,
   "version": "0.0.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/examples/react-roman-or-kana/src/App.tsx
+++ b/examples/react-roman-or-kana/src/App.tsx
@@ -1,4 +1,12 @@
-import { activate, detectKeyboardLayout, InputStroke, KeyboardLayout, loadPresetRuleJisKana, loadPresetRuleRoman, Selector, VirtualKeys } from "emiel";
+import type { InputStroke, KeyboardLayout } from "emiel";
+import {
+  activate,
+  detectKeyboardLayout,
+  loadPresetRuleJisKana,
+  loadPresetRuleRoman,
+  Selector,
+  VirtualKeys,
+} from "emiel";
 import { useEffect, useMemo, useState } from "react";
 import "./App.css";
 
@@ -15,17 +23,9 @@ function Typing(props: { layout: KeyboardLayout }) {
   const romanRule = useMemo(() => loadPresetRuleRoman(props.layout), [props.layout]);
   const kanaRule = useMemo(() => loadPresetRuleJisKana(props.layout), [props.layout]);
   const [selectors] = useState(
-    words.map(
-      (w) =>
-        new Selector([
-          romanRule.build(w),
-          kanaRule.build(w),
-        ])
-    )
+    words.map((w) => new Selector([romanRule.build(w), kanaRule.build(w)])),
   );
-  const [lastInputKey, setLastInputKey] = useState<
-    InputStroke | undefined
-  >();
+  const [lastInputKey, setLastInputKey] = useState<InputStroke | undefined>();
   const [wordIndex, setWordIndex] = useState(0);
   useEffect(() => {
     return activate(window, (e) => {
@@ -60,25 +60,19 @@ function Typing(props: { layout: KeyboardLayout }) {
     <>
       <h1>
         {/* 課題文かな表示 */}
-        <span style={{ color: "gray" }}>
-          {selector.activeItems[0].getFinishedWord()}
-        </span>{" "}
+        <span style={{ color: "gray" }}>{selector.activeItems[0].getFinishedWord()}</span>{" "}
         {selector.activeItems[0].getPendingWord()}
       </h1>
       {/* ローマ字入力 */}
       <h1>
         <p style={{ fontSize: "1rem" }}>ローマ字入力</p>
-        <span style={{ color: "gray" }}>
-          {romanAutomaton.getFinishedRoman()}
-        </span>{" "}
+        <span style={{ color: "gray" }}>{romanAutomaton.getFinishedRoman()}</span>{" "}
         {romanAutomaton.getPendingRoman()}
       </h1>
       {/* かな入力 */}
       <h1>
         <p style={{ fontSize: "1rem" }}>かな入力</p>
-        <span style={{ color: "gray" }}>
-          {kanaAutomaton.getFinishedWord()}
-        </span>{" "}
+        <span style={{ color: "gray" }}>{kanaAutomaton.getFinishedWord()}</span>{" "}
         {kanaAutomaton.getPendingWord()}
       </h1>
       <h2>

--- a/examples/react-roman-or-kana/src/main.tsx
+++ b/examples/react-roman-or-kana/src/main.tsx
@@ -1,10 +1,14 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+import "./index.css";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Root element #root not found");
+}
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-)
+);

--- a/examples/react-roman-or-kana/vite.config.ts
+++ b/examples/react-roman-or-kana/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+});

--- a/examples/react-simple/index.html
+++ b/examples/react-simple/index.html
@@ -1,15 +1,13 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Demo: Simple</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Demo: Simple</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/examples/react-simple/package.json
+++ b/examples/react-simple/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-simple",
-  "private": true,
   "version": "0.0.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/examples/react-simple/src/App.tsx
+++ b/examples/react-simple/src/App.tsx
@@ -1,4 +1,5 @@
-import { activate, detectKeyboardLayout, InputStroke, KeyboardLayout, loadPresetRuleRoman } from "emiel";
+import type { InputStroke, KeyboardLayout } from "emiel";
+import { activate, detectKeyboardLayout, loadPresetRuleRoman } from "emiel";
 import { useEffect, useMemo, useState } from "react";
 import "./App.css";
 
@@ -17,12 +18,10 @@ function Typing(props: { layout: KeyboardLayout }) {
   const [automatons] = useState(
     words.map((w) => {
       return romanRule.build(w);
-    })
+    }),
   );
   const [wordIndex, setWordIndex] = useState(0);
-  const [lastInputKey, setLastInputKey] = useState<
-    InputStroke | undefined
-  >();
+  const [lastInputKey, setLastInputKey] = useState<InputStroke | undefined>();
   useEffect(() => {
     return activate(window, (e) => {
       setLastInputKey(e.input);

--- a/examples/react-simple/src/main.tsx
+++ b/examples/react-simple/src/main.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+import "./index.css";
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-)
+);

--- a/examples/react-simple/vite.config.ts
+++ b/examples/react-simple/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+});

--- a/examples/react-stroke-graph/index.html
+++ b/examples/react-stroke-graph/index.html
@@ -1,15 +1,13 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Demo: React Stroke Graph</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Demo: React Stroke Graph</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/examples/react-stroke-graph/package.json
+++ b/examples/react-stroke-graph/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-stroke-graph",
-  "private": true,
   "version": "0.0.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/examples/react-stroke-graph/src/App.css
+++ b/examples/react-stroke-graph/src/App.css
@@ -42,7 +42,7 @@
 }
 
 h1 {
-    margin: 0;
+  margin: 0;
 }
 
 /* for Cytoscape */

--- a/examples/react-stroke-graph/src/App.tsx
+++ b/examples/react-stroke-graph/src/App.tsx
@@ -1,6 +1,13 @@
 import cytoscape from "cytoscape";
 import dagre from "cytoscape-dagre";
-import { Automaton, detectKeyboardLayout, KeyboardLayout, loadPresetRuleJisKana, loadPresetRuleNaginatashikiV15, loadPresetRuleNicola, loadPresetRuleRoman } from "emiel";
+import type { Automaton, KeyboardLayout } from "emiel";
+import {
+  detectKeyboardLayout,
+  loadPresetRuleJisKana,
+  loadPresetRuleNaginatashikiV15,
+  loadPresetRuleNicola,
+  loadPresetRuleRoman,
+} from "emiel";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import "./App.css";
 import { TypingGraph } from "./typingGraph";
@@ -17,15 +24,16 @@ function App() {
 }
 
 function Typing(props: { layout: KeyboardLayout }) {
-  const rules = useMemo(() => [
-    { name: "ローマ字", rule: loadPresetRuleRoman(props.layout) },
-    { name: "JISかな", rule: loadPresetRuleJisKana(props.layout) },
-    { name: "NICOLA", rule: loadPresetRuleNicola(props.layout) },
-    { name: "薙刀式", rule: loadPresetRuleNaginatashikiV15(props.layout) },
-  ], [props.layout]);
-  const [automaton, setAutomaton] = useState<Automaton | undefined>(
-    undefined
+  const rules = useMemo(
+    () => [
+      { name: "ローマ字", rule: loadPresetRuleRoman(props.layout) },
+      { name: "JISかな", rule: loadPresetRuleJisKana(props.layout) },
+      { name: "NICOLA", rule: loadPresetRuleNicola(props.layout) },
+      { name: "薙刀式", rule: loadPresetRuleNaginatashikiV15(props.layout) },
+    ],
+    [props.layout],
   );
+  const [automaton, setAutomaton] = useState<Automaton | undefined>(undefined);
   const [ruleName, setRuleName] = useState("");
   const [wordIndex, setWordIndex] = useState(0);
   const [ruleIndex, setRuleIndex] = useState(0);

--- a/examples/react-stroke-graph/src/graphData.ts
+++ b/examples/react-stroke-graph/src/graphData.ts
@@ -14,10 +14,15 @@ export function buildGraphData(startNode: emiel.StrokeNode) {
       classes: id === 0 ? "success" : "",
     })),
     edges: Array.from(edges).map((edge) => {
+      const source = nodes.get(edge.previous);
+      const target = nodes.get(edge.next);
+      if (source === undefined || target === undefined) {
+        throw new Error("Edge references a node that is not in the nodes map");
+      }
       return {
         data: {
-          source: nodes.get(edge.previous)!.toString(),
-          target: nodes.get(edge.next)!.toString(),
+          source: source.toString(),
+          target: target.toString(),
           label: strokeToString(edge),
         },
       };
@@ -28,7 +33,7 @@ export function buildGraphData(startNode: emiel.StrokeNode) {
 function walkTree(
   startNode: emiel.StrokeNode,
   nodes: Map<emiel.StrokeNode, number>,
-  edges: Set<emiel.StrokeEdge>
+  edges: Set<emiel.StrokeEdge>,
 ) {
   if (nodes.has(startNode)) {
     return;
@@ -54,15 +59,12 @@ function strokeToString(stroke: emiel.StrokeEdge): string {
       mod.groups
         .flatMap((v) => v.modifiers)
         .map((v) => {
-          if (
-            v === emiel.VirtualKeys.ShiftLeft ||
-            v === emiel.VirtualKeys.ShiftRight
-          ) {
+          if (v === emiel.VirtualKeys.ShiftLeft || v === emiel.VirtualKeys.ShiftRight) {
             return "⇧";
           }
           return keyToString(v);
-        })
-    )
+        }),
+    ),
   ).join("|");
   return (modStr.length > 0 ? `${modStr}|` : "") + keyToString(key);
 }

--- a/examples/react-stroke-graph/src/main.tsx
+++ b/examples/react-stroke-graph/src/main.tsx
@@ -1,10 +1,14 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+import "./index.css";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Root element #root not found");
+}
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-)
+);

--- a/examples/react-stroke-graph/src/typingGraph.tsx
+++ b/examples/react-stroke-graph/src/typingGraph.tsx
@@ -1,6 +1,7 @@
 import cytoscape from "cytoscape";
 import dagre from "cytoscape-dagre";
-import { activate, Automaton, InputStroke } from "emiel";
+import type { Automaton, InputStroke } from "emiel";
+import { activate } from "emiel";
 import { useEffect, useRef, useState } from "react";
 import { buildGraphData } from "./graphData";
 import { cyStylesheet } from "./grpahStyle";
@@ -18,8 +19,11 @@ export function TypingGraph(props: {
   const htmlElem = useRef(null);
   const [, setLastInputKey] = useState<InputStroke | undefined>();
   useEffect(() => {
+    if (htmlElem.current === null) {
+      return;
+    }
     const cy = cytoscape({
-      container: htmlElem.current!,
+      container: htmlElem.current,
       // @ts-expect-error rankDir is not defined in cytoscape
       layout: { name: "dagre", rankDir: "LR" },
       userZoomingEnabled: false,
@@ -37,11 +41,15 @@ export function TypingGraph(props: {
       if (result.isFinished) {
         props.onFinished();
       } else if (result.isSucceeded) {
-        const nodeId = graphData.nodesMap.get(automaton.currentNode)!;
-        cy.elements(`#${nodeId}`).addClass("success");
+        const nodeId = graphData.nodesMap.get(automaton.currentNode);
+        if (nodeId !== undefined) {
+          cy.elements(`#${nodeId}`).addClass("success");
+        }
       } else if (result.isFailed) {
-        const nodeId = graphData.nodesMap.get(automaton.currentNode)!;
-        cy.elements(`#${nodeId}`).addClass("miss");
+        const nodeId = graphData.nodesMap.get(automaton.currentNode);
+        if (nodeId !== undefined) {
+          cy.elements(`#${nodeId}`).addClass("miss");
+        }
       }
     });
   }, [props]);
@@ -63,10 +71,7 @@ export function TypingGraph(props: {
       ) : (
         <></>
       )}
-      <div
-        ref={htmlElem}
-        style={{ width: "600px", height: "300px", border: "1px solid white" }}
-      />
+      <div ref={htmlElem} style={{ width: "600px", height: "300px", border: "1px solid white" }} />
     </>
   );
 }

--- a/examples/react-stroke-graph/vite.config.ts
+++ b/examples/react-stroke-graph/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+});

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   "scripts": {
     "build": "vite build && tsc",
     "build:all": "pnpm run build && pnpm -r --filter \"./examples/*\" run build",
-    "lint": "oxlint --deny-warnings src",
-    "lint:fix": "oxlint --fix src",
+    "lint": "oxlint --deny-warnings src examples",
+    "lint:fix": "oxlint --fix src examples",
     "test": "vitest",
-    "fmt": "oxfmt --write src",
-    "fmt:check": "oxfmt --check src"
+    "fmt": "oxfmt --write src examples",
+    "fmt:check": "oxfmt --check src examples"
   },
   "devDependencies": {
     "@base2/pretty-print-object": "^1.0.2",


### PR DESCRIPTION
## Summary

- package.json の lint / lint:fix / fmt / fmt:check を src に加えて examples も対象に変更
- consistent-type-imports 警告（14 件）を oxlint --fix で自動修正し、型のみ import を import type に統一
- no-non-null-assertion 警告（12 件）を安全な形に書き換え
- examples 配下の ts / tsx / json / html / css に oxfmt を一括適用

## 設計の背景

VSCode 上で examples/react-stroke-graph/src/graphData.ts の `!` に警告が出ていたが、pnpm run lint は src のみを対象としていたため検出できていなかった。examples も lint/fmt の対象に含めることで、同様の警告を CI とローカルの双方で早期に検出できるようにする。

no-non-null-assertion の修正方針は「lint を無効化せず、できるだけ安全に」という要件に従い、以下のように置き換えた。

- main.tsx × 7: document.getElementById("root") を変数化し、null なら throw する
- graphData.ts: nodes.get(...) の結果を変数化し、undefined なら throw する
- typingGraph.tsx: htmlElem.current の null チェックで early return、nodesMap.get(...) は undefined の場合にスキップする

## 検討した代替案

- eslint-disable コメントで警告を抑制する案: lint を無効化しないという方針に反するため不採用
- react-simple/src/main.tsx で既に使われている `as HTMLElement` キャスト: 実質的にチェックを迂回しているだけで安全性が向上しないため不採用
- ルール自体を oxlint 設定で無効化する案: 他の意図しない `!` の混入を防ぐため、ルールは有効のまま残した

## Test plan

- [x] pnpm run lint が 0 warnings で通る
- [x] pnpm run fmt:check が通る
- [x] pnpm run test が全 97 件パスする

🤖 Generated with [Claude Code](https://claude.com/claude-code)