### PR TITLE
backspace edge の責務を BackspaceAwareCommitter に分離

### DIFF
--- a/src/core/automaton.ts
+++ b/src/core/automaton.ts
@@ -1,8 +1,12 @@
 import * as AutomatonGetters from "./automatonGetters";
 import type { AutomatonState, EdgeHistory } from "./automatonState";
 import { buildKanaNode } from "./builderKanaGraph";
-import { StrokeEdge, StrokeNode, buildStrokeNode } from "./builderStrokeGraph";
-import { type CommitResult, type CommittedStroke, StrokeCommitter } from "./committer";
+import { type StrokeEdge, type StrokeNode, buildStrokeNode } from "./builderStrokeGraph";
+import {
+  type BackspaceAwareResult,
+  BackspaceAwareCommitter,
+  type CommittedStroke,
+} from "./committer";
 import type { InputEvent } from "./inputEvent";
 import { InputResult } from "./inputResult";
 import type { Rule } from "./rule";
@@ -21,10 +25,7 @@ export class AutomatonImpl implements AutomatonState {
     readonly rule: Rule,
   ) {
     this.currentNode = startNode;
-    this.committer = new StrokeCommitter();
-    this.backspaceEdges = rule.backspaceStrokes.map(
-      (stroke) => new StrokeEdge(stroke, this.startNode, this.backspaceSentinel),
-    );
+    this.committer = new BackspaceAwareCommitter(rule.backspaceStrokes);
   }
   currentNode: StrokeNode;
   /** 入力成功して遷移した履歴 */
@@ -37,21 +38,13 @@ export class AutomatonImpl implements AutomatonState {
    */
   backspaceEventsAtCurrentNode: InputEvent[] = [];
   /** 時間方向の判断を担う Committer */
-  private readonly committer: StrokeCommitter;
-  /** backspace edge の遷移先を示す sentinel node (通常ノードと区別するため) */
-  private readonly backspaceSentinel = new StrokeNode(-1, [], []);
-  /** Rule.backspaceStrokes から生成した仮想 StrokeEdge 群 */
-  private readonly backspaceEdges: readonly StrokeEdge[];
+  private readonly committer: BackspaceAwareCommitter;
   /**
    * 現在押下されていてまだ打鍵として確定していないキー集合 (可視化用)。
    * 例: SimultaneousStroke の partial 状態で W だけ押されているとき [W] を返す。
    */
   get pendingKeys(): readonly VirtualKey[] {
     return this.committer.pendingKeys;
-  }
-  /** 現在ノードの nextEdges に backspace edge を結合した配列 */
-  private get currentEdges(): readonly StrokeEdge[] {
-    return [...this.currentNode.nextEdges, ...this.backspaceEdges];
   }
   /**
    * 入力状態をリセットする
@@ -84,7 +77,7 @@ export class AutomatonImpl implements AutomatonState {
    * @returns [result, apply] result: 入力結果, apply: 状態遷移を適用する関数
    */
   testInput(stroke: InputEvent): [InputResult, () => void] {
-    const result = this.committer.dryRun(stroke, this.currentEdges, this.rule);
+    const result = this.committer.dryRun(stroke, this.currentNode.nextEdges, this.rule);
     return [
       this.resultToInputResult(result),
       () => {
@@ -104,14 +97,13 @@ export class AutomatonImpl implements AutomatonState {
    * 呼ぶ等) は呼び出し側の責務。Automaton は InputResult.BACK を返すことで通知するのみ。
    */
   input(stroke: InputEvent): InputResult {
-    const result = this.committer.feed(stroke, this.currentEdges, this.rule);
+    const result = this.committer.feed(stroke, this.currentNode.nextEdges, this.rule);
     switch (result.type) {
       case "committed":
-        if (result.stroke.edge.next === this.backspaceSentinel) {
-          this.backspaceEventsAtCurrentNode.push(stroke);
-          return InputResult.BACK;
-        }
         return this.consume(result.stroke);
+      case "backspace":
+        this.backspaceEventsAtCurrentNode.push(stroke);
+        return InputResult.BACK;
       case "pending":
         return InputResult.PENDING;
       case "failed":
@@ -125,13 +117,12 @@ export class AutomatonImpl implements AutomatonState {
   /**
    * CommitResult を副作用なしに InputResult へ変換する (testInput 用)。
    */
-  private resultToInputResult(result: CommitResult): InputResult {
+  private resultToInputResult(result: BackspaceAwareResult): InputResult {
     switch (result.type) {
       case "committed":
-        if (result.stroke.edge.next === this.backspaceSentinel) {
-          return InputResult.BACK;
-        }
         return this.edgeToResultType(this.currentNode.kanaIndex, result.stroke.edge);
+      case "backspace":
+        return InputResult.BACK;
       case "pending":
         return InputResult.PENDING;
       case "failed":

--- a/src/core/committer.ts
+++ b/src/core/committer.ts
@@ -1,7 +1,7 @@
-import type { StrokeEdge } from "./builderStrokeGraph";
+import { StrokeEdge, StrokeNode } from "./builderStrokeGraph";
 import type { InputEvent } from "./inputEvent";
 import type { Rule } from "./rule";
-import type { SimultaneousStroke } from "./ruleStroke";
+import type { RuleStroke, SimultaneousStroke } from "./ruleStroke";
 import type { VirtualKey } from "./virtualKey";
 
 /**
@@ -398,4 +398,57 @@ function matchOtherEdge(
     return { type: "modified", keyCount: 0 };
   }
   return { type: "none", keyCount: 0 };
+}
+
+/**
+ * BackspaceAwareCommitter の feed/dryRun 結果。
+ * CommitResult に backspace 分類を追加したもの。
+ */
+export type BackspaceAwareResult =
+  | CommitResult
+  | { readonly type: "backspace"; readonly stroke: CommittedStroke };
+
+/**
+ * StrokeCommitter をラップし、backspace edge の生成・結果分類を担う。
+ *
+ * Automaton が backspace の仕組み (sentinel ノード, edge マージ) を知らずに済むよう、
+ * 入力分類の責務をこの層に閉じ込める。
+ */
+export class BackspaceAwareCommitter {
+  private readonly inner = new StrokeCommitter();
+  private readonly backspaceSentinel = new StrokeNode(-1, [], []);
+  private readonly backspaceEdges: readonly StrokeEdge[];
+
+  constructor(backspaceStrokes: readonly RuleStroke[]) {
+    this.backspaceEdges = backspaceStrokes.map(
+      (stroke) => new StrokeEdge(stroke, this.backspaceSentinel, this.backspaceSentinel),
+    );
+  }
+
+  feed(event: InputEvent, nodeEdges: readonly StrokeEdge[], rule: Rule): BackspaceAwareResult {
+    const allEdges = [...nodeEdges, ...this.backspaceEdges];
+    const result = this.inner.feed(event, allEdges, rule);
+    return this.classify(result);
+  }
+
+  dryRun(event: InputEvent, nodeEdges: readonly StrokeEdge[], rule: Rule): BackspaceAwareResult {
+    const allEdges = [...nodeEdges, ...this.backspaceEdges];
+    const result = this.inner.dryRun(event, allEdges, rule);
+    return this.classify(result);
+  }
+
+  reset(): void {
+    this.inner.reset();
+  }
+
+  get pendingKeys(): readonly VirtualKey[] {
+    return this.inner.pendingKeys;
+  }
+
+  private classify(result: CommitResult): BackspaceAwareResult {
+    if (result.type === "committed" && result.stroke.edge.next === this.backspaceSentinel) {
+      return { type: "backspace", stroke: result.stroke };
+    }
+    return result;
+  }
 }


### PR DESCRIPTION
## Summary

- Automaton が直接持っていた backspace 関連の責務（sentinel ノード、backspaceEdges 生成、edges マージ、sentinel チェック）を BackspaceAwareCommitter に移譲
- Automaton は `result.type === "backspace"` だけで判断する形にシンプル化
- BackspaceAwareResult 型を CommitResult の union composition で定義し、型の重複を回避

## 設計の背景

Automaton が backspace edge の生成・マージ・sentinel 判定という入力分類の責務を直接持っていた。
これらは「入力イベントを評価して backspace か通常入力かを分類する」責務であり、StrokeCommitter と同じレイヤーに属する。
BackspaceAwareCommitter を StrokeCommitter のラッパーとして導入し、Automaton から backspace の仕組みの詳細を隠蔽した。

backspace edges は通常 edges と同一の keyCount 優先度ロジックで競合する必要があるが、
wrapper 内で edges をマージしてから inner StrokeCommitter に渡すことで、優先度評価ロジックに変更なく対応できる。

イベントバッファリング（backspaceEventsAtCurrentNode → EdgeHistory への転記）は Automaton レベルの状態管理のため、Automaton に残した。

## 検討した代替案

- StrokeCommitter 自体に backspace ロジックを組み込む案: StrokeCommitter は入力の時間方向の評価に特化しており、backspace という概念を持ち込むと責務が混在する。wrapper パターンの方が既存コードへの影響が小さい
- バッファリングも wrapper に移す案: EdgeHistory への転記は Automaton の状態管理であり、wrapper をステートフルにすると同期ポイントが増えるため不採用

## Test plan

- [x] `pnpm run test` 全117テスト通過（automaton.test.ts の backspace 関連テスト含む）
- [x] `pnpm run build` ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)