### PR TITLE
Rule を interface 化し、normalize と query を impl に集約する

### DIFF
--- a/docs/automaton-api-design.md
+++ b/docs/automaton-api-design.md
@@ -5,16 +5,13 @@
 Automaton の状態参照 API は、用途に応じてビルダーチェーンで必要な機能を追加する設計をとる。
 
 ```typescript
-import { build } from "emiel";
+import { build, backspaceExtension } from "emiel";
 
 // 基本
 const a = build(rule, "こんにちは");
 
 // backspace 考慮クエリ付き
-const a = build(rule, "こんにちは").withBackspace();
-
-// 組み合わせ
-const a = build(rule, "こんにちは").withBackspace();
+const a = build(rule, "こんにちは").with(backspaceExtension);
 
 // カスタム拡張
 const a = build(rule, "こんにちは").with({
@@ -53,9 +50,9 @@ const a = build(rule, "こんにちは").with({
 - `getPendingRoman()` — 未入力のローマ字列（同上）
 - `back()` — 直前の成功遷移を1つ取り消す
 
-### Backspace 拡張（withBackspace）
+### Backspace 拡張（backspaceExtension）
 
-back() で取り消された区間を考慮した統計クエリを別名で追加する。基本クエリの挙動は変わらない。
+back() で取り消された区間を考慮した統計クエリを別名で追加する。利用者は `.with(backspaceExtension)` で opt-in する。基本クエリの挙動は変わらない。
 
 - `getEffectiveFailedInputCount()` — back() で取り消された区間のミスを除外した失敗数
 - `getEffectiveTotalInputCount()` — getEffectiveEdges.length + getEffectiveFailedInputCount
@@ -84,16 +81,16 @@ a.getKPM();      // number
 
 ```
 Automaton = AutomatonImpl & BaseExtensionType
-  .withBackspace() -> this & BackspaceExtensionType
-  .with(custom)    -> this & { [K]: () => ReturnType<custom[K]> }
+  .with(backspaceExtension) -> this & BackspaceExtensionType
+  .with(custom)              -> this & { [K]: () => ReturnType<custom[K]> }
 ```
 
 back() は AutomatonImpl のメソッドとして常に公開。
-各チェーンは `this &` を返すため、自由に組み合わせられる。
+`.with()` は `this &` を返すため、自由に組み合わせられる。
 
 ## Selector との互換性
 
-Selector は `Inputtable` インターフェース（`input()` + `reset()` のみ）に依存する。withBackspace の有無に関わらず、すべての Automaton は Selector で管理できる。
+Selector は `Inputtable` インターフェース（`input()` + `reset()` のみ）に依存する。backspaceExtension の有無に関わらず、すべての Automaton は Selector で管理できる。
 
 ```typescript
 import { build, Selector } from "emiel";

--- a/examples/react-backspace/src/App.tsx
+++ b/examples/react-backspace/src/App.tsx
@@ -1,5 +1,12 @@
 import type { InputStroke, KeyboardLayout } from "emiel";
-import { activate, build, detectKeyboardLayout, loadPresetRuleRoman, VirtualKeys } from "emiel";
+import {
+  activate,
+  backspaceExtension,
+  build,
+  detectKeyboardLayout,
+  loadPresetRuleRoman,
+  VirtualKeys,
+} from "emiel";
 import { useEffect, useMemo, useState } from "react";
 import "./App.css";
 import { MissAccumulatingAutomaton } from "./MissAccumulatingAutomaton";
@@ -19,7 +26,8 @@ function Typing(props: { layout: KeyboardLayout }) {
   const [lastInputKey, setLastInputKey] = useState<InputStroke | undefined>();
 
   const wrappers = useMemo(
-    () => words.map((w) => new MissAccumulatingAutomaton(build(romanRule, w).withBackspace())),
+    () =>
+      words.map((w) => new MissAccumulatingAutomaton(build(romanRule, w).with(backspaceExtension))),
     [romanRule, words],
   );
   const wrapper = wrappers[index];

--- a/src/core/automaton.test.ts
+++ b/src/core/automaton.test.ts
@@ -5,7 +5,7 @@ import {
   loadPresetRuleNaginatashikiV15,
   loadPresetRuleRoman,
 } from "../impl/presets";
-import { build, type Automaton } from "./automaton";
+import { build, type Automaton } from "../impl/buildAutomaton";
 import type { AutomatonState, HistoryEntry, InputHistoryEntry } from "./automatonState";
 import { InputEvent, InputStroke } from "./inputEvent";
 import { KeyboardState } from "./keyboardState";

--- a/src/core/automaton.ts
+++ b/src/core/automaton.ts
@@ -1,7 +1,5 @@
-import * as AutomatonQuery from "./automatonQuery";
 import type { AutomatonState, HistoryEntry } from "./automatonState";
-import { buildKanaNode } from "./builderKanaGraph";
-import { type StrokeEdge, type StrokeNode, buildStrokeNode } from "./builderStrokeGraph";
+import type { StrokeEdge, StrokeNode } from "./builderStrokeGraph";
 import {
   type BackspaceAwareResult,
   BackspaceAwareCommitter,
@@ -9,7 +7,7 @@ import {
 } from "./committer";
 import type { InputEvent } from "./inputEvent";
 import { InputResult } from "./inputResult";
-import type { Rule } from "./rule";
+import type { Rule, RulePrimitive } from "./rule";
 import type { VirtualKey } from "./virtualKey";
 
 export class AutomatonImpl implements AutomatonState {
@@ -17,24 +15,24 @@ export class AutomatonImpl implements AutomatonState {
    * @param word かな文字列（配列定義 Rule で使用可能な文字で構成される文字列）
    * @param startNode 打鍵を受け付ける開始ノード
    * @param rule このAutomatonを生成した入力ルール
-   * @param rulesByKanaIndex 各 kanaIndex で入力を始めるエントリを寄与した rule 集合
+   * @param rulesByKanaIndex 各 kanaIndex で入力を始めるエントリを寄与した primitive 集合
    */
   constructor(
     readonly word: string,
     readonly startNode: StrokeNode,
     readonly rule: Rule,
-    private readonly rulesByKanaIndex: readonly (readonly Rule[])[],
+    private readonly rulesByKanaIndex: readonly (readonly RulePrimitive[])[],
   ) {
     this.currentNode = startNode;
     this.committer = new BackspaceAwareCommitter(rule.backspaceStrokes);
   }
 
   /**
-   * 現在の入力位置 (currentNode.kanaIndex) で入力対象となっている rule の集合を返す。
-   * チェーン化された Rule では、この位置から入力を始めるエントリを提供した rule が
-   * チェーン順で列挙される。候補がない位置 (ワード完了後など) では空配列。
+   * 現在の入力位置 (currentNode.kanaIndex) で入力対象となっている primitive の集合を返す。
+   * 合成された Rule では、この位置から入力を始めるエントリを提供した primitive が
+   * 合成順で列挙される。候補がない位置 (ワード完了後など) では空配列。
    */
-  getCurrentOriginRules(): readonly Rule[] {
+  getCurrentOriginRules(): readonly RulePrimitive[] {
     return this.rulesByKanaIndex[this.currentNode.kanaIndex] ?? [];
   }
   /** 現在の入力位置を表すノード。入力が進むと次のノードに遷移し、back() で前のノードに戻る。 */
@@ -43,7 +41,7 @@ export class AutomatonImpl implements AutomatonState {
    * すべての入力イベントと back() 操作の時系列ログ。
    * input() の結果（IGNORED, PENDING 含む）と back() の BackHistoryEntry が記録される。
    *
-   * 有効な遷移 edge の取得: AutomatonQuery.getEffectiveEdges(automaton)
+   * 有効な遷移 edge の取得: build 後の Automaton で automaton.getEffectiveEdges()
    * 失敗イベントの抽出: inputHistory.filter(e => !("back" in e) && e.result.isFailed)
    */
   inputHistory: HistoryEntry[] = [];
@@ -70,14 +68,28 @@ export class AutomatonImpl implements AutomatonState {
    * 直前の成功遷移を1つ取り消し、currentNode を遷移前のノードに戻す。
    * inputHistory に BackHistoryEntry を追記する（履歴は削除しない）。
    * startNode にいる場合は何もしない。
+   *
+   * 実装: inputHistory を末尾から逆順に走査し、既出の back() で取り消し済みの
+   * 成功 edge を skip しながら、最初に見つかった未取り消しの成功 edge を取り消す。
    */
   back(): void {
     if (this.currentNode === this.startNode) return;
-    const effectiveEdges = AutomatonQuery.getEffectiveEdges(this);
-    const lastEdge = effectiveEdges[effectiveEdges.length - 1];
-    if (lastEdge) {
-      this.inputHistory.push({ back: true, undoneEdge: lastEdge });
-      this.currentNode = lastEdge.previous;
+    let skip = 0;
+    for (let i = this.inputHistory.length - 1; i >= 0; i--) {
+      const entry = this.inputHistory[i];
+      if ("back" in entry) {
+        skip++;
+        continue;
+      }
+      if (entry.edge) {
+        if (skip > 0) {
+          skip--;
+          continue;
+        }
+        this.inputHistory.push({ back: true, undoneEdge: entry.edge });
+        this.currentNode = entry.edge.previous;
+        break;
+      }
     }
     this.committer.reset();
   }
@@ -203,51 +215,4 @@ export class AutomatonImpl implements AutomatonState {
     });
     return proxy as this & { [K in keyof T]: () => ReturnType<T[K]> };
   }
-
-  /**
-   * backspace を考慮した統計クエリを追加する
-   */
-  withBackspace(): this & BackspaceExtensionType {
-    return this.with(backspaceExtension) as this & BackspaceExtensionType;
-  }
 }
-
-export type Automaton = AutomatonImpl & BaseExtensionType;
-
-export function build(rule: Rule, kanaText: string): Automaton {
-  const { endNode, rulesByKanaIndex } = buildKanaNode(rule, kanaText);
-  const automaton = new AutomatonImpl(kanaText, buildStrokeNode(endNode), rule, rulesByKanaIndex);
-  return automaton.with(baseExtension);
-}
-
-const baseExtension = {
-  getFinishedWord: AutomatonQuery.getFinishedWord,
-  getPendingWord: AutomatonQuery.getPendingWord,
-  getFinishedStroke: AutomatonQuery.getFinishedStroke,
-  getPendingStroke: AutomatonQuery.getPendingStroke,
-  getEffectiveEdges: AutomatonQuery.getEffectiveEdges,
-  isFinished: AutomatonQuery.isFinished,
-  getFirstInputTime: AutomatonQuery.getFirstInputTime,
-  getLastInputTime: AutomatonQuery.getLastInputTime,
-  getFirstSucceededInputTime: AutomatonQuery.getFirstSucceededInputTime,
-  getLastSucceededInputTime: AutomatonQuery.getLastSucceededInputTime,
-  getFailedInputCount: AutomatonQuery.getFailedInputCount,
-  getTotalInputCount: AutomatonQuery.getTotalInputCount,
-  getFinishedRoman: AutomatonQuery.getFinishedRoman,
-  getPendingRoman: AutomatonQuery.getPendingRoman,
-};
-
-export type BaseExtensionType = {
-  [K in keyof typeof baseExtension]: () => ReturnType<(typeof baseExtension)[K]>;
-};
-
-const backspaceExtension = {
-  getEffectiveFailedInputCount: AutomatonQuery.getEffectiveFailedInputCount,
-  getEffectiveTotalInputCount: AutomatonQuery.getEffectiveTotalInputCount,
-  getEffectiveFirstSucceededInputTime: AutomatonQuery.getEffectiveFirstSucceededInputTime,
-  getEffectiveLastSucceededInputTime: AutomatonQuery.getEffectiveLastSucceededInputTime,
-};
-
-export type BackspaceExtensionType = {
-  [K in keyof typeof backspaceExtension]: () => ReturnType<(typeof backspaceExtension)[K]>;
-};

--- a/src/core/builderKanaGraph.test.ts
+++ b/src/core/builderKanaGraph.test.ts
@@ -1,53 +1,52 @@
 import { expect, test } from "vitest";
 import { buildKanaNode } from "./builderKanaGraph";
 import { AndModifier } from "./modifier";
-import { Rule, RuleEntry } from "./rule";
+import { RuleEntry, RulePrimitive } from "./rule";
 import { ModifierStroke } from "./ruleStroke";
 import { VirtualKeys } from "./virtualKey";
 
-const defaultRule = new Rule(
-  [
-    new RuleEntry([new ModifierStroke(VirtualKeys.A, AndModifier.empty)], "あ", [], true),
-    new RuleEntry(
-      [
-        new ModifierStroke(VirtualKeys.T, AndModifier.empty),
-        new ModifierStroke(VirtualKeys.A, AndModifier.empty),
-      ],
-      "た",
-      [],
-      true,
-    ),
-    new RuleEntry(
-      [
-        new ModifierStroke(VirtualKeys.L, AndModifier.empty),
-        new ModifierStroke(VirtualKeys.T, AndModifier.empty),
-        new ModifierStroke(VirtualKeys.U, AndModifier.empty),
-      ],
-      "っ",
-      [],
-      true,
-    ),
-    new RuleEntry(
-      [
-        new ModifierStroke(VirtualKeys.T, AndModifier.empty),
-        new ModifierStroke(VirtualKeys.T, AndModifier.empty),
-      ],
-      "っ",
-      [new ModifierStroke(VirtualKeys.T, AndModifier.empty)],
-      true,
-    ),
-    new RuleEntry([new ModifierStroke(VirtualKeys.X, AndModifier.empty)], "あい", [], true),
-  ],
-  (v) => v,
-);
+const identityNormalize = (v: string) => v;
+
+const defaultRule = new RulePrimitive([
+  new RuleEntry([new ModifierStroke(VirtualKeys.A, AndModifier.empty)], "あ", [], true),
+  new RuleEntry(
+    [
+      new ModifierStroke(VirtualKeys.T, AndModifier.empty),
+      new ModifierStroke(VirtualKeys.A, AndModifier.empty),
+    ],
+    "た",
+    [],
+    true,
+  ),
+  new RuleEntry(
+    [
+      new ModifierStroke(VirtualKeys.L, AndModifier.empty),
+      new ModifierStroke(VirtualKeys.T, AndModifier.empty),
+      new ModifierStroke(VirtualKeys.U, AndModifier.empty),
+    ],
+    "っ",
+    [],
+    true,
+  ),
+  new RuleEntry(
+    [
+      new ModifierStroke(VirtualKeys.T, AndModifier.empty),
+      new ModifierStroke(VirtualKeys.T, AndModifier.empty),
+    ],
+    "っ",
+    [new ModifierStroke(VirtualKeys.T, AndModifier.empty)],
+    true,
+  ),
+  new RuleEntry([new ModifierStroke(VirtualKeys.X, AndModifier.empty)], "あい", [], true),
+]);
 
 test("test buildKanaNode: empty text", () => {
-  const { startNode, endNode } = buildKanaNode(defaultRule, "");
+  const { startNode, endNode } = buildKanaNode(defaultRule, "", identityNormalize);
   expect(startNode).toBe(endNode);
 });
 
 test("test buildKanaNode: あ", () => {
-  const { startNode, endNode } = buildKanaNode(defaultRule, "あ");
+  const { startNode, endNode } = buildKanaNode(defaultRule, "あ", identityNormalize);
   expect(startNode).not.toBe(endNode);
   expect(startNode.nextEdges.length).toBe(1);
   expect(startNode.nextEdges[0].entries).toEqual([
@@ -57,7 +56,7 @@ test("test buildKanaNode: あ", () => {
 });
 
 test("test buildKanaNode: あっ", () => {
-  const { startNode, endNode } = buildKanaNode(defaultRule, "あっ");
+  const { startNode, endNode } = buildKanaNode(defaultRule, "あっ", identityNormalize);
   expect(startNode).not.toBe(endNode);
   expect(startNode.nextEdges.length).toBe(1);
   expect(startNode.nextEdges[0].entries).toEqual([
@@ -81,7 +80,7 @@ test("test buildKanaNode: あっ", () => {
 });
 
 test("test buildKanaNode: あった", () => {
-  const { startNode, endNode } = buildKanaNode(defaultRule, "あった");
+  const { startNode, endNode } = buildKanaNode(defaultRule, "あった", identityNormalize);
   expect(startNode).not.toBe(endNode);
   expect(startNode.nextEdges.length).toBe(1);
   expect(startNode.nextEdges[0].entries).toEqual([
@@ -142,7 +141,7 @@ test("test buildKanaNode: あいた, erase あ->い edge", () => {
   // 「あ」単独で入力できるエントリは存在するが
   // 「い」「いた」を入力できるエントリは存在しないため、
   // 「あ」単独で入力する Edge は削除される
-  const { startNode, endNode } = buildKanaNode(defaultRule, "あいた");
+  const { startNode, endNode } = buildKanaNode(defaultRule, "あいた", identityNormalize);
   expect(startNode).not.toBe(endNode);
   expect(startNode.nextEdges.length).toBe(1);
   expect(startNode.nextEdges[0].entries).toEqual([
@@ -165,7 +164,13 @@ test("test buildKanaNode: あいた, erase あ->い edge", () => {
 });
 
 test("test buildKanaNode: can't generate error", () => {
-  expect(() => buildKanaNode(defaultRule, "ほげ")).toThrowError("can't generate");
-  expect(() => buildKanaNode(defaultRule, "あっち")).toThrowError("can't generate");
-  expect(() => buildKanaNode(defaultRule, "ちあっ")).toThrowError("can't generate");
+  expect(() => buildKanaNode(defaultRule, "ほげ", identityNormalize)).toThrowError(
+    "can't generate",
+  );
+  expect(() => buildKanaNode(defaultRule, "あっち", identityNormalize)).toThrowError(
+    "can't generate",
+  );
+  expect(() => buildKanaNode(defaultRule, "ちあっ", identityNormalize)).toThrowError(
+    "can't generate",
+  );
 });

--- a/src/core/builderKanaGraph.ts
+++ b/src/core/builderKanaGraph.ts
@@ -1,5 +1,5 @@
 import { setDefaultFunc } from "../utils/map";
-import type { Rule, RuleEntry } from "./rule";
+import type { normalizerFunc, Rule, RuleEntry, RulePrimitive } from "./rule";
 import type { RuleStroke } from "./ruleStroke";
 
 // build 中にのみ使用する
@@ -88,24 +88,28 @@ export type BuildKanaNodeResult = {
   endNode: KanaNode;
   /**
    * 各 kanaIndex (= 正規化後の文字列上の位置) で、その位置からの入力を開始するエントリを
-   * 1つ以上寄与した Rule をチェーン順に unique 化した配列。
+   * 1つ以上寄与した RulePrimitive を合成順に unique 化した配列。
    *
-   * 例: NICOLA → alphanumeric のチェーンで "ABCマート" を build した場合
+   * 例: NICOLA + alphanumeric の合成で "ABCマート" を build した場合
    *   rulesByKanaIndex[0..2] = [alphanumeric]  (A, B, C)
    *   rulesByKanaIndex[3..6] = [nicola]        (マ, ー, ト)
    */
-  rulesByKanaIndex: readonly (readonly Rule[])[];
+  rulesByKanaIndex: readonly (readonly RulePrimitive[])[];
 };
 
-export function buildKanaNode(rule: Rule, kanaText: string): BuildKanaNodeResult {
-  const normalizedKanaText = rule.normalize(kanaText);
+export function buildKanaNode(
+  rule: Rule,
+  kanaText: string,
+  normalize: normalizerFunc,
+): BuildKanaNodeResult {
+  const normalizedKanaText = normalize(kanaText);
   // かなテキスト1文字1文字に対応する KanaNode を作成する
   const kanaNodes = [...normalizedKanaText].map((_, i) => new KanaNode(i, [], []));
   const endNode = new KanaNode(normalizedKanaText.length, [], []); // 終端ノード
   const kanaNodesWithEnd = [...kanaNodes, endNode];
-  const rulesByKanaIndex: Set<Rule>[] = Array.from(
+  const rulesByKanaIndex: Set<RulePrimitive>[] = Array.from(
     { length: normalizedKanaText.length + 1 },
-    () => new Set<Rule>(),
+    () => new Set<RulePrimitive>(),
   );
   if (normalizedKanaText.length === 0) {
     // 空文字列の場合は終端ノードのみを返す
@@ -121,14 +125,14 @@ export function buildKanaNode(rule: Rule, kanaText: string): BuildKanaNodeResult
   i=1 あ の末尾から手前にチェック
   */
   const normalizedEntryOutputMap: Map<RuleEntry, string> = new Map();
-  const chainedRules = Array.from(rule.chain());
+  const primitives = rule.primitives;
   for (let i = normalizedKanaText.length; i > 0; i--) {
     const kanaPrefix = normalizedKanaText.substring(0, i);
     const nextNode = kanaNodesWithEnd[i];
-    for (const r of chainedRules) {
+    for (const r of primitives) {
       for (let entry of r.entries) {
         const normalizedEntryOutput = setDefaultFunc(normalizedEntryOutputMap, entry, () =>
-          rule.normalize(entry.output),
+          normalize(entry.output),
         );
         if (kanaPrefix.endsWith(normalizedEntryOutput)) {
           const previousNode = kanaNodesWithEnd[kanaPrefix.length - entry.output.length];

--- a/src/core/committer.test.ts
+++ b/src/core/committer.test.ts
@@ -7,7 +7,7 @@ import {
   loadPresetRuleNicola,
   loadPresetRuleRoman,
 } from "../impl/presets";
-import { build, type Automaton } from "./automaton";
+import { build, type Automaton } from "../impl/buildAutomaton";
 import { InputEvent, InputStroke } from "./inputEvent";
 import { KeyboardState } from "./keyboardState";
 import type { Rule } from "./rule";

--- a/src/core/committer.ts
+++ b/src/core/committer.ts
@@ -361,7 +361,9 @@ function matchOtherEdge(
   if (candidateEdges.length === 0) {
     return { type: "none", keyCount: 0 };
   }
-  // 今回の入力が Rule 内のいずれかの entry の最初の入力に match する
+  // 今回の入力が Rule 内のいずれかの entry の最初の入力に match する。
+  // Rule.entriesByKey/Modifier は interface の契約として「primitives 全体を事前マージした
+  // 結果」を返すので、ここでは合成された全 primitive の entries を一括で走査している。
   const otherMatched = rule.entriesByKey(event.input.key).filter((entry) => {
     const firstStroke = entry.input[0];
     if (firstStroke.kind !== "modifier") {

--- a/src/core/rule.test.ts
+++ b/src/core/rule.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { AndModifier } from "./modifier";
-import { Rule, RuleEntry } from "./rule";
+import { RuleEntry, RulePrimitive } from "./rule";
 import { ModifierStroke, type RuleStroke } from "./ruleStroke";
 import { VirtualKeys } from "./virtualKey";
 
@@ -8,83 +8,91 @@ function makeEntry(key: keyof typeof VirtualKeys, output: string): RuleEntry {
   return new RuleEntry([new ModifierStroke(VirtualKeys[key], AndModifier.empty)], output, [], true);
 }
 
-function makeRule(options: {
+function makePrimitive(options: {
   entries: RuleEntry[];
-  normalize?: (v: string) => string;
   name?: string;
   backspaceStrokes?: readonly RuleStroke[];
-  next?: Rule;
-}): Rule {
-  return new Rule(
+}): RulePrimitive {
+  return new RulePrimitive(
     options.entries,
-    options.normalize ?? ((v) => v),
     options.name ?? "",
     options.backspaceStrokes,
     undefined,
-    options.next,
   );
 }
 
-describe("Rule chain (next)", () => {
-  test("next is stored on the head Rule", () => {
-    const tail = makeRule({ entries: [makeEntry("A", "a")], name: "tail" });
-    const head = makeRule({ entries: [makeEntry("A", "あ")], name: "head", next: tail });
-    expect(head.name).toBe("head");
-    expect(head.next?.name).toBe("tail");
+describe("RulePrimitive", () => {
+  test("primitives getter returns itself", () => {
+    const r = makePrimitive({ entries: [makeEntry("A", "あ")], name: "r1" });
+    expect(r.primitives).toEqual([r]);
   });
 
-  test("entriesByKey walks the chain and returns entries from all rules", () => {
-    const tail = makeRule({ entries: [makeEntry("A", "a")], name: "tail" });
-    const head = makeRule({ entries: [makeEntry("A", "あ")], name: "head", next: tail });
-    const entries = head.entriesByKey(VirtualKeys.A);
-    expect(entries.map((e) => e.output)).toEqual(["あ", "a"]);
+  test("entriesByKey returns own entries", () => {
+    const r = makePrimitive({ entries: [makeEntry("A", "あ")], name: "r1" });
+    const entries = r.entriesByKey(VirtualKeys.A);
+    expect(entries.map((e) => e.output)).toEqual(["あ"]);
+  });
+});
+
+describe("Rule composition via compose()", () => {
+  test("compose returns a Rule whose entriesByKey merges all primitives", () => {
+    const a = makePrimitive({ entries: [makeEntry("A", "あ")], name: "a" });
+    const b = makePrimitive({ entries: [makeEntry("A", "a")], name: "b" });
+    const composed = a.compose(b);
+    expect(composed.entriesByKey(VirtualKeys.A).map((e) => e.output)).toEqual(["あ", "a"]);
   });
 
-  test("entriesByKey returns head entries first (chain order)", () => {
-    const tail = makeRule({ entries: [makeEntry("A", "TAIL")], name: "tail" });
-    const head = makeRule({ entries: [makeEntry("A", "HEAD")], name: "head", next: tail });
-    const entries = head.entriesByKey(VirtualKeys.A);
-    expect(entries.map((e) => e.output)).toEqual(["HEAD", "TAIL"]);
+  test("compose preserves head order in primitives", () => {
+    const a = makePrimitive({ entries: [makeEntry("A", "HEAD")], name: "a" });
+    const b = makePrimitive({ entries: [makeEntry("A", "TAIL")], name: "b" });
+    const composed = a.compose(b);
+    expect(composed.primitives.map((p) => p.name)).toEqual(["a", "b"]);
+    // head (a) の entries が先、tail (b) が後
+    expect(composed.entriesByKey(VirtualKeys.A).map((e) => e.output)).toEqual(["HEAD", "TAIL"]);
   });
 
-  test("normalize composes head and next normalizers in order", () => {
-    const tail = makeRule({
-      entries: [makeEntry("A", "x")],
-      normalize: (v) => v.replace(/o/g, "O"),
-      name: "tail",
-    });
-    const head = makeRule({
-      entries: [makeEntry("A", "x")],
-      normalize: (v) => v.toLowerCase(),
-      name: "head",
-      next: tail,
-    });
-    // head が "HELLO" → "hello"、tail がさらに "hello" → "hellO"
-    expect(head.normalize("HELLO")).toBe("hellO");
-  });
-
-  test("backspaceStrokes uses chain head (next side is ignored)", () => {
-    const headBackspace = new ModifierStroke(VirtualKeys.Digit0, AndModifier.empty);
-    const tailBackspace = new ModifierStroke(VirtualKeys.Digit9, AndModifier.empty);
-    const tail = makeRule({
-      entries: [makeEntry("B", "b")],
-      name: "tail",
-      backspaceStrokes: [tailBackspace],
-    });
-    const head = makeRule({
+  test("head の name/guide/backspaceStrokes が合成全体の代表になる", () => {
+    const headBs = new ModifierStroke(VirtualKeys.Digit0, AndModifier.empty);
+    const tailBs = new ModifierStroke(VirtualKeys.Digit9, AndModifier.empty);
+    const head = makePrimitive({
       entries: [makeEntry("A", "a")],
       name: "head",
-      backspaceStrokes: [headBackspace],
-      next: tail,
+      backspaceStrokes: [headBs],
     });
-    expect(head.backspaceStrokes).toEqual([headBackspace]);
+    const tail = makePrimitive({
+      entries: [makeEntry("B", "b")],
+      name: "tail",
+      backspaceStrokes: [tailBs],
+    });
+    const composed = head.compose(tail);
+    expect(composed.name).toBe("head");
+    expect(composed.backspaceStrokes).toEqual([headBs]);
   });
 
-  test("chain() iterates head-first over all rules in the chain", () => {
-    const r3 = makeRule({ entries: [makeEntry("A", "3")], name: "r3" });
-    const r2 = makeRule({ entries: [makeEntry("A", "2")], name: "r2", next: r3 });
-    const r1 = makeRule({ entries: [makeEntry("A", "1")], name: "r1", next: r2 });
-    const names = Array.from(r1.chain()).map((r) => r.name);
-    expect(names).toEqual(["r1", "r2", "r3"]);
+  test("nested compose は linear な primitives になる", () => {
+    const r1 = makePrimitive({ entries: [makeEntry("A", "1")], name: "r1" });
+    const r2 = makePrimitive({ entries: [makeEntry("A", "2")], name: "r2" });
+    const r3 = makePrimitive({ entries: [makeEntry("A", "3")], name: "r3" });
+    const chained = r1.compose(r2).compose(r3);
+    expect(chained.primitives.map((p) => p.name)).toEqual(["r1", "r2", "r3"]);
+  });
+
+  test("右結合と左結合で同じ primitive 列になる", () => {
+    const r1 = makePrimitive({ entries: [makeEntry("A", "1")], name: "r1" });
+    const r2 = makePrimitive({ entries: [makeEntry("A", "2")], name: "r2" });
+    const r3 = makePrimitive({ entries: [makeEntry("A", "3")], name: "r3" });
+    const leftAssoc = r1.compose(r2).compose(r3);
+    const rightAssoc = r1.compose(r2.compose(r3));
+    expect(leftAssoc.primitives.map((p) => p.name)).toEqual(
+      rightAssoc.primitives.map((p) => p.name),
+    );
+  });
+
+  test("同じ primitive を 2 回 compose すると重複した primitive が並ぶ (仕様)", () => {
+    const r = makePrimitive({ entries: [makeEntry("A", "a")], name: "r" });
+    const composed = r.compose(r);
+    expect(composed.primitives.map((p) => p.name)).toEqual(["r", "r"]);
+    // entries が 2 回並ぶ
+    expect(composed.entriesByKey(VirtualKeys.A).map((e) => e.output)).toEqual(["a", "a"]);
   });
 });

--- a/src/core/rule.ts
+++ b/src/core/rule.ts
@@ -8,7 +8,7 @@ import { type VirtualKey, VirtualKeys } from "./virtualKey";
 export type normalizerFunc = (value: string) => string;
 
 /**
- * 1つの入力定義を表す。T 型は
+ * 1つの入力定義を表す。
  * @property input 受け入れ可能なキー入力列
  * @property output 出力文字列
  * @property nextInput 次の入力として自動入力されるキー入力列
@@ -85,123 +85,176 @@ khi/き
 というルールが有る場合でも、やはりこれで良い。（nk まで打った時点で n/ん は確定できるので）
 nk/ん/k
 */
-export class Rule {
+
+/**
+ * 入力ルールを表す公開 interface。1 つの primitive な定義 (RulePrimitive) か、
+ * 複数の primitive を合成したもの (内部 RuleSet) のいずれかが実装する。
+ *
+ * entriesByKey / entriesByModifier は `primitives` 全体を事前マージした結果を返す契約。
+ * RulePrimitive 実装は自身の entries のみ、合成実装は全 parts の union を返す。
+ */
+export interface Rule {
+  readonly name: string;
+  readonly guide?: KeyboardGuide;
+  readonly backspaceStrokes: readonly RuleStroke[];
+  readonly primitives: readonly RulePrimitive[];
+  entriesByKey(key: VirtualKey): readonly RuleEntry[];
+  entriesByModifier(key: VirtualKey): readonly RuleEntry[];
+  compose(other: Rule): Rule;
+}
+
+/**
+ * 1 つの primitive な入力定義。entries と自身のメタデータ (name, guide,
+ * backspaceStrokes) を持ち、自身の entries に対するキー引きインデックスを
+ * 事前構築する。位置に依存しない再利用可能な定義。
+ *
+ * 2 つの Rule を合成する場合は `a.compose(b)` を使うと内部で RuleSet が生成される。
+ */
+export class RulePrimitive implements Rule {
+  readonly entries: readonly RuleEntry[];
   /**
-   * Rule.backspaceStrokes: 入力方式が「特定のキーストロークを backspace として扱う」
+   * RulePrimitive.backspaceStrokes: 入力方式が「特定のキーストロークを backspace として扱う」
    * ケース (例: naginata 式の U 単独打鍵) を表現するための、現在ノードに依存せず
    * 常に受理される特殊ストローク群。expandPrefixRules や entriesByKey 等の通常入力
    * 経路のキャッシュには含まれない。
    *
    * 省略時のデフォルトは VirtualKeys.Backspace 単独打鍵のみ。明示的に指定された場合は
    * その指定がそのまま使われる (Backspace キーを含めるかどうかは呼び出し側の判断)。
-   *
-   * チェーン化された Rule (next が指定された Rule) では、チェーン先頭 (head) の Rule
-   * の backspaceStrokes が採用される。チェーン末尾側の Rule の backspaceStrokes は無視される。
    */
   readonly backspaceStrokes: readonly RuleStroke[];
+  readonly name: string;
+  readonly guide?: KeyboardGuide;
 
-  // 入力ワードと RuleEntry.output の表記ゆれを吸収する関数 (例: ひらがな⇔カタカナ,
-  // 全角英数⇔半角英数)。これにより "カタカナ" という word が "かたかな" を対象とする
-  // entry にマッチできる。
-  private readonly ownNormalize: normalizerFunc;
-  // この Rule 自身の entries に対するキー引きインデックス。チェーン先の検索に使うため
-  // private だが、同クラス内なら別インスタンスのものも参照できる。
-  private readonly ownEntriesByKey: Map<VirtualKey, RuleEntry[]> = new Map();
-  private readonly ownEntriesByModifier: Map<VirtualKey, RuleEntry[]> = new Map();
-  // チェーン全体を事前マージしたキー引きインデックス。constructor 内で eager に構築され、
-  // 以降変更されない。head 単独の場合は ownEntriesBy* をそのまま参照する。
-  // 入力ホットパス (committer の entriesByKey / entriesByModifier) で毎回走査しないため。
-  private readonly effectiveByKey: Map<VirtualKey, RuleEntry[]>;
-  private readonly effectiveByModifier: Map<VirtualKey, RuleEntry[]>;
+  /** @internal 同ファイル内の RuleSet が合成時に直接マージするため公開している */
+  readonly ownByKey: ReadonlyMap<VirtualKey, readonly RuleEntry[]>;
+  /** @internal */
+  readonly ownByModifier: ReadonlyMap<VirtualKey, readonly RuleEntry[]>;
 
   /**
    * @param entries 入力ルールのエントリ
-   * @param normalize 入力ワードのかな文字を正規化する関数
    * @param name 入力ルールの名前
    * @param backspaceStrokes backspace として扱う RuleStroke 群。
    *                         undefined の場合は VirtualKeys.Backspace 単独打鍵のみが
    *                         デフォルトとして設定される。空配列を渡すと backspace 無効
    * @param guide この Rule に紐づく KeyboardGuide。未指定なら undefined
-   * @param next チェーン上の次の Rule
    */
   constructor(
-    readonly entries: RuleEntry[],
-    normalize: normalizerFunc,
-    readonly name: string = "",
+    entries: RuleEntry[],
+    name = "",
     backspaceStrokes?: readonly RuleStroke[],
-    readonly guide?: KeyboardGuide,
-    readonly next?: Rule,
+    guide?: KeyboardGuide,
   ) {
-    this.ownNormalize = normalize;
     this.entries = expandPrefixRules(entries);
+    this.name = name;
+    this.guide = guide;
     this.backspaceStrokes = backspaceStrokes ?? [
       new ModifierStroke(VirtualKeys.Backspace, AndModifier.empty),
     ];
 
-    // SimultaneousStroke の場合は keys の全要素を登録キーとする
+    const byKey = new Map<VirtualKey, RuleEntry[]>();
+    const byModifier = new Map<VirtualKey, RuleEntry[]>();
     for (const entry of this.entries) {
       const firstStroke = entry.input[0];
+      // SimultaneousStroke の場合は keys の全要素を登録キーとする
       for (const firstInputKey of ruleStrokeKeys(firstStroke)) {
-        setDefault(this.ownEntriesByKey, firstInputKey, []).push(entry);
+        setDefault(byKey, firstInputKey, []).push(entry);
       }
-    }
-    // ModifierStroke のみ requiredModifier を持つ。SimultaneousStroke は対象外。
-    for (const entry of this.entries) {
-      const firstStroke = entry.input[0];
-      if (firstStroke.kind !== "modifier") continue;
-      for (const g of firstStroke.requiredModifier.groups) {
-        for (const modifierKey of g.modifiers) {
-          setDefault(this.ownEntriesByModifier, modifierKey, []).push(entry);
+      // ModifierStroke のみ requiredModifier を持つ。SimultaneousStroke は対象外。
+      if (firstStroke.kind === "modifier") {
+        for (const g of firstStroke.requiredModifier.groups) {
+          for (const modifierKey of g.modifiers) {
+            setDefault(byModifier, modifierKey, []).push(entry);
+          }
         }
       }
     }
-
-    if (next) {
-      this.effectiveByKey = mergeChainMaps(this, (r) => r.ownEntriesByKey);
-      this.effectiveByModifier = mergeChainMaps(this, (r) => r.ownEntriesByModifier);
-    } else {
-      this.effectiveByKey = this.ownEntriesByKey;
-      this.effectiveByModifier = this.ownEntriesByModifier;
-    }
+    this.ownByKey = byKey;
+    this.ownByModifier = byModifier;
   }
 
-  /**
-   * チェーンに含まれる Rule を head から順に返すイテレータ。
-   */
-  *chain(): Iterable<Rule> {
-    yield this;
-    if (this.next !== undefined) {
-      yield* this.next.chain();
-    }
+  get primitives(): readonly RulePrimitive[] {
+    return [this];
   }
 
-  /**
-   * 入力ワードを正規化する。チェーン化された Rule では head から順に合成する。
-   */
-  normalize(v: string): string {
-    const result = this.ownNormalize(v);
-    return this.next ? this.next.normalize(result) : result;
+  entriesByKey(inputKey: VirtualKey): readonly RuleEntry[] {
+    return this.ownByKey.get(inputKey) ?? [];
   }
 
-  entriesByKey(inputKey: VirtualKey): RuleEntry[] {
-    return this.effectiveByKey.get(inputKey) ?? [];
+  entriesByModifier(modifierKey: VirtualKey): readonly RuleEntry[] {
+    return this.ownByModifier.get(modifierKey) ?? [];
   }
 
-  entriesByModifier(modifierKey: VirtualKey): RuleEntry[] {
-    return this.effectiveByModifier.get(modifierKey) ?? [];
+  compose(other: Rule): Rule {
+    return composeRules(this, other);
   }
 }
 
-function mergeChainMaps(
-  head: Rule,
-  // 同クラス内なのでチェーン先の private フィールドにもアクセスできる
-  getMap: (r: Rule) => Map<VirtualKey, RuleEntry[]>,
-): Map<VirtualKey, RuleEntry[]> {
-  const merged = new Map<VirtualKey, RuleEntry[]>();
-  for (const r of head.chain()) {
-    for (const [key, entries] of getMap(r)) {
-      setDefault(merged, key, []).push(...entries);
+/**
+ * 複数の RulePrimitive を合成したルール。head/tail 採用ポリシー (最初の primitive を
+ * 合成全体の代表とする) はここの getter dispatch に閉じ、RulePrimitive 側には非対称性を
+ * 持ち込まない。
+ *
+ * 外部からは直接 `new RuleSet(...)` せず `a.compose(b)` 経由で生成する。
+ */
+class RuleSet implements Rule {
+  private readonly parts: readonly RulePrimitive[];
+  private readonly mergedByKey: ReadonlyMap<VirtualKey, readonly RuleEntry[]>;
+  private readonly mergedByModifier: ReadonlyMap<VirtualKey, readonly RuleEntry[]>;
+
+  constructor(parts: readonly RulePrimitive[]) {
+    if (parts.length === 0) {
+      throw new Error("RuleSet requires at least one primitive");
     }
+    this.parts = parts;
+    const byKey = new Map<VirtualKey, RuleEntry[]>();
+    const byModifier = new Map<VirtualKey, RuleEntry[]>();
+    for (const p of parts) {
+      for (const [key, entries] of p.ownByKey) {
+        setDefault(byKey, key, []).push(...entries);
+      }
+      for (const [modKey, entries] of p.ownByModifier) {
+        setDefault(byModifier, modKey, []).push(...entries);
+      }
+    }
+    this.mergedByKey = byKey;
+    this.mergedByModifier = byModifier;
   }
-  return merged;
+
+  get name(): string {
+    return this.parts[0].name;
+  }
+  get guide(): KeyboardGuide | undefined {
+    return this.parts[0].guide;
+  }
+  get backspaceStrokes(): readonly RuleStroke[] {
+    return this.parts[0].backspaceStrokes;
+  }
+  get primitives(): readonly RulePrimitive[] {
+    return this.parts;
+  }
+
+  entriesByKey(inputKey: VirtualKey): readonly RuleEntry[] {
+    return this.mergedByKey.get(inputKey) ?? [];
+  }
+
+  entriesByModifier(modifierKey: VirtualKey): readonly RuleEntry[] {
+    return this.mergedByModifier.get(modifierKey) ?? [];
+  }
+
+  compose(other: Rule): Rule {
+    return composeRules(this, other);
+  }
+}
+
+/**
+ * 2 つの Rule を合成して新しい Rule を返す。
+ *
+ * - 入力の primitives を linear 化して並べるだけで、入れ子は発生しない
+ *   (RulePrimitive.primitives は [this]、RuleSet.primitives は parts を返すため)。
+ * - 同じ RulePrimitive インスタンスを 2 度合成した場合は重複が並ぶ。重複排除は行わない
+ *   (利用者責任)。
+ */
+function composeRules(a: Rule, b: Rule): Rule {
+  const flattened: RulePrimitive[] = [...a.primitives, ...b.primitives];
+  return new RuleSet(flattened);
 }

--- a/src/impl/alphaNumericRule.ts
+++ b/src/impl/alphaNumericRule.ts
@@ -1,15 +1,13 @@
 import type { KeyboardLayout } from "../core/keyboardLayout";
-import { Rule, RuleEntry } from "../core/rule";
-import { defaultAlphaNumericNormalize } from "./charNormalizer";
+import { RuleEntry, RulePrimitive } from "../core/rule";
 import { loadPresetKeyboardGuideAlphanumeric } from "./presets/keyboardGuideAlphanumeric";
 
-export function newAlphaNumericRuleByLayout(layout: KeyboardLayout): Rule {
+export function newAlphaNumericRuleByLayout(layout: KeyboardLayout): RulePrimitive {
   const entries = Array.from(layout.mapping).map(
     ([key, stroke]) => new RuleEntry([stroke], key, [], false),
   );
-  return new Rule(
+  return new RulePrimitive(
     entries,
-    defaultAlphaNumericNormalize,
     "alphanumeric",
     undefined,
     loadPresetKeyboardGuideAlphanumeric(),

--- a/src/impl/automatonQuery.ts
+++ b/src/impl/automatonQuery.ts
@@ -1,6 +1,6 @@
-import type { StrokeEdge } from "./builderStrokeGraph";
-import type { AutomatonState, InputHistoryEntry } from "./automatonState";
-import type { RuleStroke } from "./ruleStroke";
+import type { AutomatonState, InputHistoryEntry } from "../core/automatonState";
+import type { StrokeEdge } from "../core/builderStrokeGraph";
+import type { RuleStroke } from "../core/ruleStroke";
 
 function inputEntries(state: AutomatonState): InputHistoryEntry[] {
   return state.inputHistory.filter((e): e is InputHistoryEntry => !("back" in e));
@@ -211,3 +211,18 @@ export function getEffectiveLastSucceededInputTime(state: AutomatonState): Date 
   if (!lastSucceededTime) throw new Error("No effective succeeded input found");
   return lastSucceededTime;
 }
+
+/**
+ * backspace を考慮した統計クエリの拡張セット。
+ * 利用者は `build(rule, word).with(backspaceExtension)` で追加できる。
+ */
+export const backspaceExtension = {
+  getEffectiveFailedInputCount,
+  getEffectiveTotalInputCount,
+  getEffectiveFirstSucceededInputTime,
+  getEffectiveLastSucceededInputTime,
+};
+
+export type BackspaceExtensionType = {
+  [K in keyof typeof backspaceExtension]: () => ReturnType<(typeof backspaceExtension)[K]>;
+};

--- a/src/impl/buildAutomaton.ts
+++ b/src/impl/buildAutomaton.ts
@@ -1,0 +1,39 @@
+import { AutomatonImpl } from "../core/automaton";
+import { buildKanaNode } from "../core/builderKanaGraph";
+import { buildStrokeNode } from "../core/builderStrokeGraph";
+import type { normalizerFunc, Rule } from "../core/rule";
+import * as AutomatonQuery from "./automatonQuery";
+import { defaultComposedNormalize } from "./charNormalizer";
+
+export function build(
+  rule: Rule,
+  kanaText: string,
+  normalize: normalizerFunc = defaultComposedNormalize,
+): Automaton {
+  const { endNode, rulesByKanaIndex } = buildKanaNode(rule, kanaText, normalize);
+  const automaton = new AutomatonImpl(kanaText, buildStrokeNode(endNode), rule, rulesByKanaIndex);
+  return automaton.with(baseExtension);
+}
+
+const baseExtension = {
+  getFinishedWord: AutomatonQuery.getFinishedWord,
+  getPendingWord: AutomatonQuery.getPendingWord,
+  getFinishedStroke: AutomatonQuery.getFinishedStroke,
+  getPendingStroke: AutomatonQuery.getPendingStroke,
+  getEffectiveEdges: AutomatonQuery.getEffectiveEdges,
+  isFinished: AutomatonQuery.isFinished,
+  getFirstInputTime: AutomatonQuery.getFirstInputTime,
+  getLastInputTime: AutomatonQuery.getLastInputTime,
+  getFirstSucceededInputTime: AutomatonQuery.getFirstSucceededInputTime,
+  getLastSucceededInputTime: AutomatonQuery.getLastSucceededInputTime,
+  getFailedInputCount: AutomatonQuery.getFailedInputCount,
+  getTotalInputCount: AutomatonQuery.getTotalInputCount,
+  getFinishedRoman: AutomatonQuery.getFinishedRoman,
+  getPendingRoman: AutomatonQuery.getPendingRoman,
+};
+
+export type BaseExtensionType = {
+  [K in keyof typeof baseExtension]: () => ReturnType<(typeof baseExtension)[K]>;
+};
+
+export type Automaton = AutomatonImpl & BaseExtensionType;

--- a/src/impl/builder.test.ts
+++ b/src/impl/builder.test.ts
@@ -19,7 +19,7 @@ ltu	っ
 `,
     loadPresetKeyboardLayoutQwertyJis(),
   );
-  const { startNode, endNode: endKanaNode } = buildKanaNode(rule, "おった");
+  const { startNode, endNode: endKanaNode } = buildKanaNode(rule, "おった", (v) => v);
   expect(startNode.nextEdges[0].entries[0].output).toBe("お");
   const nextNode = startNode.nextEdges[0].next;
   expect(nextNode.nextEdges.length).toBe(2);
@@ -41,7 +41,7 @@ x	あいう
 `,
     loadPresetKeyboardLayoutQwertyJis(),
   );
-  const { startNode, endNode } = buildKanaNode(rule, "あいう");
+  const { startNode, endNode } = buildKanaNode(rule, "あいう", (v) => v);
   expect(startNode.nextEdges.length).toBe(1);
   expect((startNode.nextEdges[0].entries[0].input[0] as ModifierStroke).key).toBe(VirtualKeys.X);
   expect(startNode.nextEdges[0].next).toBe(endNode);

--- a/src/impl/charNormalizer.ts
+++ b/src/impl/charNormalizer.ts
@@ -238,3 +238,15 @@ export function defaultAlphaNumericNormalize(value: string): string {
     })
     .join("");
 }
+
+/**
+ * かな正規化と英数字正規化を合成したデフォルト normalize。
+ * emiel のかな系プリセット (NICOLA, JIS かな, 薙刀式 V15, Roman) は
+ * いずれもこの合成 normalize で期待通り動作する。
+ * `build(rule, text)` の第 3 引数の default に使用される。
+ *
+ * 2 つの normalize は disjoint な文字集合を対象とするため順序依存なし。
+ */
+export function defaultComposedNormalize(value: string): string {
+  return defaultAlphaNumericNormalize(defaultKanaNormalize(value));
+}

--- a/src/impl/jsonRuleLoader.ts
+++ b/src/impl/jsonRuleLoader.ts
@@ -1,10 +1,9 @@
 import * as v from "valibot";
 import { KeyboardGuide } from "../core/keyboardGuide";
 import { AndModifier, ModifierGroup } from "../core/modifier";
-import { Rule, RuleEntry } from "../core/rule";
+import { RuleEntry, RulePrimitive } from "../core/rule";
 import { ModifierStroke, type RuleStroke, SimultaneousStroke } from "../core/ruleStroke";
 import { virtualKeySchema } from "../core/virtualKey";
-import { defaultKanaNormalize } from "./charNormalizer";
 import { jsonKeyboardGuideEntriesSchema } from "./keyboardGuideLoader";
 
 const strokeSchema = v.object({
@@ -112,13 +111,13 @@ function loadEntries(
   return entries;
 }
 
-export function loadJsonRule(jsonRule: unknown, name?: string, next?: Rule): Rule {
+export function loadJsonRule(jsonRule: unknown, name?: string): RulePrimitive {
   if (typeof jsonRule === "string") {
-    return loadJsonRule(JSON.parse(jsonRule), name, next);
+    return loadJsonRule(JSON.parse(jsonRule), name);
   }
   const validated = v.parse(jsonRuleSchema, jsonRule);
   const entries = loadEntries(validated.entries, validated.extendCommonPrefixEntry ?? false);
-  // JSON に backspaces フィールドが無い場合は undefined を渡して Rule 側のデフォルト
+  // JSON に backspaces フィールドが無い場合は undefined を渡して RulePrimitive 側のデフォルト
   // (VirtualKeys.Backspace 単独打鍵) を適用する。空配列を指定した場合は backspace 無効
   const backspaceStrokes: RuleStroke[] | undefined = validated.backspaces?.map((s) =>
     loadStroke(s),
@@ -126,5 +125,5 @@ export function loadJsonRule(jsonRule: unknown, name?: string, next?: Rule): Rul
   const guide = validated.guide
     ? new KeyboardGuide({ entries: validated.guide.entries })
     : undefined;
-  return new Rule(entries, defaultKanaNormalize, name, backspaceStrokes, guide, next);
+  return new RulePrimitive(entries, name, backspaceStrokes, guide);
 }

--- a/src/impl/mozcRuleLoader.ts
+++ b/src/impl/mozcRuleLoader.ts
@@ -1,18 +1,16 @@
 import type { KeyboardLayout } from "../core/keyboardLayout";
-import { Rule, RuleEntry } from "../core/rule";
+import { RuleEntry, RulePrimitive } from "../core/rule";
 import type { RuleStroke } from "../core/ruleStroke";
 import { product } from "../utils/itertools";
-import { defaultKanaNormalize } from "./charNormalizer";
 
 export function loadMozcRule(
   text: string,
   layout: KeyboardLayout,
   name: string = "",
-  next?: Rule,
-): Rule {
+): RulePrimitive {
   /*
-    a	あ	
-    ta	た	
+    a	あ
+    ta	た
     tt	っ	t
     */
   text = text.replace(/\r\n/g, "\n");
@@ -41,7 +39,7 @@ export function loadMozcRule(
       );
     });
   }
-  return new Rule(entries, defaultKanaNormalize, name, undefined, undefined, next);
+  return new RulePrimitive(entries, name, undefined, undefined);
 }
 
 function toStrokesFromChar(layout: KeyboardLayout, key: string): RuleStroke[] {

--- a/src/impl/presets/rules.test.ts
+++ b/src/impl/presets/rules.test.ts
@@ -6,19 +6,21 @@ import {
   loadPresetRuleRoman,
 } from "./index";
 
+// 合成後の Rule 先頭 primitive (head) の entries 数を確認する。
+// head = かな系の primitive、tail = alphanumeric primitive。
 test("load google ime roman rule", () => {
   const rule = loadPresetRuleRoman(loadPresetKeyboardLayoutQwertyJis());
-  expect(rule.entries.length).toBe(324);
+  expect(rule.primitives[0].entries.length).toBe(324);
 });
 
 test("load jis kana rule", () => {
   const rule = loadPresetRuleJisKana(loadPresetKeyboardLayoutQwertyJis());
-  expect(rule.entries.length).toBe(82);
+  expect(rule.primitives[0].entries.length).toBe(82);
 });
 
 test("load nicola rule", () => {
   const rule = loadPresetRuleNicola(loadPresetKeyboardLayoutQwertyJis());
   // 以前は相互モディファイア展開により 1 エントリを 2 エントリに膨らませていたが、
   // SimultaneousStroke として 1 エントリで扱うようになったため件数が減少している
-  expect(rule.entries.length).toBe(95);
+  expect(rule.primitives[0].entries.length).toBe(95);
 });

--- a/src/impl/ruleLoaderWithLayout.ts
+++ b/src/impl/ruleLoaderWithLayout.ts
@@ -9,7 +9,7 @@ export function loadMozcRuleWithLayout(
   layout: KeyboardLayout,
   name: string = "",
 ): Rule {
-  return loadMozcRule(ruleData, layout, name, newAlphaNumericRuleByLayout(layout));
+  return loadMozcRule(ruleData, layout, name).compose(newAlphaNumericRuleByLayout(layout));
 }
 
 export function loadJsonRuleWithLayout(
@@ -17,5 +17,5 @@ export function loadJsonRuleWithLayout(
   layout: KeyboardLayout,
   name: string = "",
 ): Rule {
-  return loadJsonRule(ruleData, name, newAlphaNumericRuleByLayout(layout));
+  return loadJsonRule(ruleData, name).compose(newAlphaNumericRuleByLayout(layout));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export { InputEvent, InputStroke } from "./core/inputEvent";
 export { KeyboardLayout } from "./core/keyboardLayout";
 export { KeyboardState, type KeyboardStateReader } from "./core/keyboardState";
 export { AndModifier, ModifierGroup } from "./core/modifier";
-export { Rule, RuleEntry } from "./core/rule";
+export { type Rule, RulePrimitive, RuleEntry, type normalizerFunc } from "./core/rule";
 export { ModifierStroke, SimultaneousStroke, type RuleStroke } from "./core/ruleStroke";
 export { Selector, type Inputtable } from "./core/selector";
 export { VirtualKey, VirtualKeys } from "./core/virtualKey";
@@ -38,5 +38,11 @@ export { loadJsonKeyboardGuide } from "./impl/keyboardGuideLoader";
 export * from "./impl/presets";
 export * from "./impl/stats";
 
-export { build } from "./core/automaton";
-export type { Automaton, BackspaceExtensionType } from "./core/automaton";
+export {
+  defaultKanaNormalize,
+  defaultAlphaNumericNormalize,
+  defaultComposedNormalize,
+} from "./impl/charNormalizer";
+
+export { build, type Automaton, type BaseExtensionType } from "./impl/buildAutomaton";
+export { backspaceExtension, type BackspaceExtensionType } from "./impl/automatonQuery";


### PR DESCRIPTION
## Summary

- Rule をクラスから interface に変更し、具象 `RulePrimitive` + 内部 `RuleSet` に分離。合成は `a.compose(b)` で行う
- `normalize` 関数を Rule から剥がし、`build(rule, text, normalize?)` の optional 引数に移動。default は `defaultComposedNormalize`
- `build` 関数と `baseExtension` を `src/core/automaton.ts` から `src/impl/buildAutomaton.ts` に移動
- `automatonQuery` を core から impl に完全移動。`AutomatonImpl.back()` は inputHistory 末尾逆走査の inline 実装に置き換え、`withBackspace()` method を削除して `.with(backspaceExtension)` 形式に統一
- `loadJsonRule` / `loadMozcRule` / `newAlphaNumericRuleByLayout` の戻り型を具象 `RulePrimitive` に変更し、`next` 引数を削除

## 設計の背景

PR #21 で Rule クラスに `next` フィールドを追加したが、結果として 1 つのクラスが「primitive 定義」と「チェーンノード」の 2 つの責務を持つようになった。これにより次の問題があった:

- `backspaceStrokes` と `guide` の「チェーン head のみ採用」という採用ポリシーが primitive 定義クラス自身に埋め込まれ、位置依存の挙動がコメントで補足されていた
- `effectiveByKey/Modifier` キャッシュが constructor 時の `next` に依存するため、tail として作った Rule を別 head の下で再利用できない
- builder 側 (builderKanaGraph.ts) は既に `Array.from(rule.chain())` してコレクションとして扱っており、線形連結リスト表現が実態とズレていた
- `normalize` は Rule が保持しているが、実際に呼ばれるのは build 時の 2 箇所のみで runtime ホットパスでは使われない。Rule が所有する pre-normalize 値 (entry.output) に対して post-normalize 値は builder のローカルキャッシュにしか存在せず、「Rule の定義」というより「builder がグラフ生成時に比較用形式に揃えるための道具」だった

これらを解消するため、責務を分離した:

- Rule interface → 単一の公開型。primitive も合成結果も同じ interface を実装
- `RulePrimitive` → 位置に依存しない再利用可能な primitive 定義
- `RuleSet` (非 export) → 複数 primitive を合成した結果。head/tail 採用ポリシーは getter dispatch に閉じる
- `compose(other)` メソッド → 利用者は具象型名を書かずに合成できる
- `normalize` は build の引数に移動 → Rule は「正規化をどうやるか」を知らず、builder がグラフ生成時に必要なだけ使う

さらに後続で `withBackspace()` は `.with()` の糖衣シロップに過ぎず必須ではなかったため削除し、`automatonQuery` を丸ごと impl に移動することで core/impl の分離を clean にした。`AutomatonImpl.back()` は `getEffectiveEdges` への依存を inputHistory 末尾逆走査の inline 実装に置き換え、core 側から query 関数への参照を完全に除去した (早期終了で旧実装より効率的)。

## 検討した代替案

代替案 1: Rule に `parts: Rule[]` field を追加する案

- 新しい型を作らず、Rule クラス 1 つに `parts` field を持たせて合成を表現する
- 利点: クラス数最小、利用者の型名不変
- 欠点: Rule が「primitive 定義」と「合成結果」を兼務しオーバーロード状態に。head/tail 非対称性が Rule 内部に残る
- 却下理由: RuleSet 案の方が役割分離が明確で head/tail 非対称が primitive 側に漏れない

代替案 2: `RuleSet` を公開型として追加する案

- primitive は `Rule`、合成は `RuleSet` で公開上も分離
- 利点: 型レベルで最も明確
- 欠点: 利用者が `Rule` と `RuleSet` の 2 型を理解する必要。preset loader 戻り型が `RuleSet` になり既存利用者の import/型注釈も要変更
- 却下理由: 利用者認知コストが増える。interface `Rule` + 内部具象の形なら利用者は 1 型のみ

代替案 3: normalize を Rule (または RuleSet) に持たせ続ける案

- 現状の挙動をそのまま維持
- 欠点: 「normalize は builder のツール」という観察と合わず、Rule の責務が肥大化
- 却下理由: 責務分離の観点から build 引数の方が素直

代替案 4: charNormalizer を core に移動する案 (build の default normalize 確保のため)

- 欠点: 日本語特化の文字変換テーブルが core に入り汎用性が失われる
- 却下理由: `build` 自体を impl に移動すれば解決するため (採用)

代替案 5: `withBackspace()` を残す案

- 利点: 既存 API の後方互換
- 欠点: `.with(backspaceExtension)` と役割重複。`backspaceExtension` を core に残す必要があり core/impl 分離が汚れる
- 却下理由: 汎用 `.with()` があれば糖衣シロップは不要。削除することで automatonQuery を丸ごと impl に移動できる副次効果も得られる

## Test plan

- [x] pnpm run lint が通る (0 warning / 0 error)
- [x] pnpm run test 全 136 テスト pass
  - rule.test.ts: RulePrimitive / compose / primitives / 入れ子合成 / 重複合成を検証
  - builderKanaGraph.test.ts: 新 signature での build 動作
  - automaton.test.ts: `getCurrentOriginRules` の戻り値型が `RulePrimitive[]` になることに追従、back() の動作を既存テストで確認
  - jsonRuleLoader.test.ts / mozcRuleLoader.test.ts / builder.test.ts: 戻り型 `RulePrimitive` での `.entries` アクセスを維持
  - presets/rules.test.ts: 合成 Rule の `.primitives[0].entries` へ書き換え
- [x] pnpm run build が通る (vite + tsc 型エラーなし)
- [ ] examples/react-keyboardguide の NICOLA / JIS かな / Alphanumeric ガイド表示が動作 (目視)
- [ ] examples/react-backspace で `.with(backspaceExtension)` 経由の miss 表示が動作 (目視)
- [ ] 各プリセット (Roman, NICOLA, JIS かな, 薙刀式 V15) でオートマトン生成と入力が正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)