### PR TITLE
react-backspace example にタブ切り替え3パターンのバックスペース挙動を追加

### DIFF
--- a/examples/react-backspace/src/App.css
+++ b/examples/react-backspace/src/App.css
@@ -40,3 +40,25 @@
 .read-the-docs {
   color: #888;
 }
+
+.tab-bar {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tab-bar button {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  border: 1px solid #646cff;
+  background: transparent;
+  color: inherit;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+.tab-bar button.active {
+  background: #646cff;
+  color: white;
+}

--- a/examples/react-backspace/src/App.tsx
+++ b/examples/react-backspace/src/App.tsx
@@ -1,110 +1,45 @@
-import type { InputStroke, KeyboardLayout } from "emiel";
-import {
-  activate,
-  backspaceExtension,
-  build,
-  detectKeyboardLayout,
-  loadPresetRuleRoman,
-  VirtualKeys,
-} from "emiel";
-import { useEffect, useMemo, useState } from "react";
+import type { KeyboardLayout } from "emiel";
+import { detectKeyboardLayout } from "emiel";
+import { useEffect, useState } from "react";
 import "./App.css";
-import { MissAccumulatingAutomaton } from "./MissAccumulatingAutomaton";
+import { MissAccumulatingApp } from "./MissAccumulatingApp";
+import { MissClearingApp } from "./MissClearingApp";
+import { MissCountingApp } from "./MissCountingApp";
+
+type TabId = "clearing" | "counting" | "accumulating";
+
+const tabs: { id: TabId; label: string }[] = [
+  { id: "clearing", label: "1回 BS で全クリア" },
+  { id: "counting", label: "N回ミス → N回 BS" },
+  { id: "accumulating", label: "BS で入力を戻す" },
+];
 
 function App() {
   const [layout, setLayout] = useState<KeyboardLayout | undefined>();
+  const [activeTab, setActiveTab] = useState<TabId>("clearing");
+
   useEffect(() => {
     detectKeyboardLayout(window).then(setLayout).catch(console.error);
   }, []);
-  return layout ? <Typing layout={layout} /> : <></>;
-}
 
-function Typing(props: { layout: KeyboardLayout }) {
-  const romanRule = useMemo(() => loadPresetRuleRoman(props.layout), [props.layout]);
-  const words = useMemo(() => ["おをひく", "こんとん", "がっこう", "aから@"], []);
-  const [index, setIndex] = useState(0);
-  const [lastInputKey, setLastInputKey] = useState<InputStroke | undefined>();
-
-  const wrappers = useMemo(
-    () =>
-      words.map((w) => new MissAccumulatingAutomaton(build(romanRule, w).with(backspaceExtension))),
-    [romanRule, words],
-  );
-  const wrapper = wrappers[index];
-
-  useEffect(() => {
-    return activate(window, (e) => {
-      setLastInputKey(e.input);
-      const result = wrapper.input(e);
-      if (result.isFinished) {
-        wrapper.reset();
-        setIndex((current) => (current + 1) % words.length);
-      }
-    });
-  }, [wrapper, words]);
+  if (!layout) return <></>;
 
   return (
     <>
-      <h1>
-        <div style={{ display: "flex" }}>
-          <div style={{ color: "gray" }}>{wrapper.getFinishedWord()}</div>
-          <div
-            style={{
-              marginLeft: wrapper.getFinishedWord() ? "0.5rem" : "0",
-            }}
+      <div className="tab-bar">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            className={activeTab === tab.id ? "active" : ""}
+            onClick={() => setActiveTab(tab.id)}
           >
-            {wrapper.getPendingWord()}
-          </div>
-        </div>
-      </h1>
-      <h1>
-        <div style={{ display: "flex" }}>
-          <div style={{ color: "gray" }}>{wrapper.getFinishedRoman()}</div>
-          <div
-            style={{
-              marginLeft: wrapper.getFinishedRoman() ? "0.5rem" : "0",
-              textAlign: "left",
-            }}
-          >
-            {wrapper.getPendingRoman()}
-            <br />
-            <span style={{ color: "yellow" }}>
-              {wrapper.failedInputs
-                .map((f) =>
-                  props.layout
-                    .getCharByKey(
-                      f.input.key,
-                      f.keyboardState.isAnyKeyDowned(VirtualKeys.ShiftLeft, VirtualKeys.ShiftRight),
-                    )
-                    .replace(" ", "_"),
-                )
-                .join("")}
-            </span>
-          </div>
-        </div>
-      </h1>
-      <h2>
-        Key:{" "}
-        <code style={{ border: "1px solid gray", padding: "0.2rem" }}>
-          {lastInputKey ? lastInputKey.key.toString() : ""}
-        </code>
-      </h2>
-      <table style={{ margin: "0 auto", textAlign: "left" }}>
-        <tbody>
-          <tr>
-            <td>成功数</td>
-            <td>{wrapper.getEffectiveEdgesCount()}</td>
-          </tr>
-          <tr>
-            <td>ミス数 (全体)</td>
-            <td>{wrapper.getFailedInputCount()}</td>
-          </tr>
-          <tr>
-            <td>ミス数 (back 除外)</td>
-            <td>{wrapper.getEffectiveFailedInputCount()}</td>
-          </tr>
-        </tbody>
-      </table>
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      {activeTab === "clearing" && <MissClearingApp key="clearing" layout={layout} />}
+      {activeTab === "counting" && <MissCountingApp key="counting" layout={layout} />}
+      {activeTab === "accumulating" && <MissAccumulatingApp key="accumulating" layout={layout} />}
     </>
   );
 }

--- a/examples/react-backspace/src/MissAccumulatingApp.tsx
+++ b/examples/react-backspace/src/MissAccumulatingApp.tsx
@@ -1,0 +1,78 @@
+import type { InputStroke, KeyboardLayout } from "emiel";
+import { activate, backspaceExtension, build, loadPresetRuleRoman, VirtualKeys } from "emiel";
+import { useEffect, useMemo, useState } from "react";
+import { MissAccumulatingAutomaton } from "./MissAccumulatingAutomaton";
+
+export function MissAccumulatingApp(props: { layout: KeyboardLayout }) {
+  const romanRule = useMemo(() => loadPresetRuleRoman(props.layout), [props.layout]);
+  const words = useMemo(() => ["おをひく", "こんとん", "がっこう", "aから@"], []);
+  const [index, setIndex] = useState(0);
+  const [lastInputKey, setLastInputKey] = useState<InputStroke | undefined>();
+
+  const wrappers = useMemo(
+    () =>
+      words.map((w) => new MissAccumulatingAutomaton(build(romanRule, w).with(backspaceExtension))),
+    [romanRule, words],
+  );
+  const wrapper = wrappers[index];
+
+  useEffect(() => {
+    return activate(window, (e) => {
+      setLastInputKey(e.input);
+      const result = wrapper.input(e);
+      if (result.isFinished) {
+        wrapper.reset();
+        setIndex((current) => (current + 1) % words.length);
+      }
+    });
+  }, [wrapper, words]);
+
+  return (
+    <>
+      <h1>
+        <div style={{ display: "flex", justifyContent: "center" }}>
+          <div style={{ color: "gray" }}>{wrapper.getFinishedWord()}</div>
+          <div
+            style={{
+              marginLeft: wrapper.getFinishedWord() ? "0.5rem" : "0",
+            }}
+          >
+            {wrapper.getPendingWord()}
+          </div>
+        </div>
+      </h1>
+      <h1>
+        <div style={{ display: "flex", justifyContent: "center" }}>
+          <div style={{ color: "gray" }}>{wrapper.getFinishedRoman()}</div>
+          <div
+            style={{
+              marginLeft: wrapper.getFinishedRoman() ? "0.5rem" : "0",
+              textAlign: "left",
+            }}
+          >
+            {wrapper.getPendingRoman()}
+            <br />
+            <span style={{ color: "yellow" }}>
+              {wrapper.failedInputs
+                .map((f) =>
+                  props.layout
+                    .getCharByKey(
+                      f.input.key,
+                      f.keyboardState.isAnyKeyDowned(VirtualKeys.ShiftLeft, VirtualKeys.ShiftRight),
+                    )
+                    .replace(" ", "_"),
+                )
+                .join("")}
+            </span>
+          </div>
+        </div>
+      </h1>
+      <h2>
+        Key:{" "}
+        <code style={{ border: "1px solid gray", padding: "0.2rem" }}>
+          {lastInputKey ? lastInputKey.key.toString() : ""}
+        </code>
+      </h2>
+    </>
+  );
+}

--- a/examples/react-backspace/src/MissClearingApp.tsx
+++ b/examples/react-backspace/src/MissClearingApp.tsx
@@ -1,0 +1,77 @@
+import type { InputStroke, KeyboardLayout } from "emiel";
+import { activate, backspaceExtension, build, loadPresetRuleRoman, VirtualKeys } from "emiel";
+import { useEffect, useMemo, useState } from "react";
+import { MissClearingAutomaton } from "./MissClearingAutomaton";
+
+export function MissClearingApp(props: { layout: KeyboardLayout }) {
+  const romanRule = useMemo(() => loadPresetRuleRoman(props.layout), [props.layout]);
+  const words = useMemo(() => ["おをひく", "こんとん", "がっこう", "aから@"], []);
+  const [index, setIndex] = useState(0);
+  const [lastInputKey, setLastInputKey] = useState<InputStroke | undefined>();
+
+  const wrappers = useMemo(
+    () => words.map((w) => new MissClearingAutomaton(build(romanRule, w).with(backspaceExtension))),
+    [romanRule, words],
+  );
+  const wrapper = wrappers[index];
+
+  useEffect(() => {
+    return activate(window, (e) => {
+      setLastInputKey(e.input);
+      const result = wrapper.input(e);
+      if (result.isFinished) {
+        wrapper.reset();
+        setIndex((current) => (current + 1) % words.length);
+      }
+    });
+  }, [wrapper, words]);
+
+  return (
+    <>
+      <h1>
+        <div style={{ display: "flex", justifyContent: "center" }}>
+          <div style={{ color: "gray" }}>{wrapper.getFinishedWord()}</div>
+          <div
+            style={{
+              marginLeft: wrapper.getFinishedWord() ? "0.5rem" : "0",
+            }}
+          >
+            {wrapper.getPendingWord()}
+          </div>
+        </div>
+      </h1>
+      <h1>
+        <div style={{ display: "flex", justifyContent: "center" }}>
+          <div style={{ color: "gray" }}>{wrapper.getFinishedRoman()}</div>
+          <div
+            style={{
+              marginLeft: wrapper.getFinishedRoman() ? "0.5rem" : "0",
+              textAlign: "left",
+            }}
+          >
+            {wrapper.getPendingRoman()}
+            <br />
+            <span style={{ color: "yellow" }}>
+              {wrapper.failedInputs
+                .map((f) =>
+                  props.layout
+                    .getCharByKey(
+                      f.input.key,
+                      f.keyboardState.isAnyKeyDowned(VirtualKeys.ShiftLeft, VirtualKeys.ShiftRight),
+                    )
+                    .replace(" ", "_"),
+                )
+                .join("")}
+            </span>
+          </div>
+        </div>
+      </h1>
+      <h2>
+        Key:{" "}
+        <code style={{ border: "1px solid gray", padding: "0.2rem" }}>
+          {lastInputKey ? lastInputKey.key.toString() : ""}
+        </code>
+      </h2>
+    </>
+  );
+}

--- a/examples/react-backspace/src/MissClearingAutomaton.ts
+++ b/examples/react-backspace/src/MissClearingAutomaton.ts
@@ -1,0 +1,73 @@
+import type { Automaton, BackspaceExtensionType, InputEvent } from "emiel";
+import { InputResult } from "emiel";
+
+export class MissClearingAutomaton {
+  private _failedInputs: InputEvent[] = [];
+  private readonly automaton: Automaton & BackspaceExtensionType;
+
+  constructor(automaton: Automaton & BackspaceExtensionType) {
+    this.automaton = automaton;
+  }
+
+  get failedInputs(): readonly InputEvent[] {
+    return this._failedInputs;
+  }
+
+  input(stroke: InputEvent): InputResult {
+    const [result, apply] = this.automaton.testInput(stroke);
+    if (result.isBack) {
+      if (this._failedInputs.length > 0) {
+        apply();
+        this._failedInputs = [];
+      }
+      return result;
+    }
+    if (result.isIgnored) {
+      return result;
+    }
+    if (result.isFailed) {
+      apply();
+      this._failedInputs = [...this._failedInputs, stroke];
+      return result;
+    }
+    if (this._failedInputs.length > 0) {
+      this._failedInputs = [...this._failedInputs, stroke];
+      return InputResult.FAILED;
+    }
+    apply();
+    return result;
+  }
+
+  reset(): void {
+    this.automaton.reset();
+    this._failedInputs = [];
+  }
+
+  getFinishedWord(): string {
+    return this.automaton.getFinishedWord();
+  }
+
+  getPendingWord(): string {
+    return this.automaton.getPendingWord();
+  }
+
+  getFinishedRoman(): string {
+    return this.automaton.getFinishedRoman();
+  }
+
+  getPendingRoman(): string {
+    return this.automaton.getPendingRoman();
+  }
+
+  getEffectiveEdgesCount(): number {
+    return this.automaton.getEffectiveEdges().length;
+  }
+
+  getFailedInputCount(): number {
+    return this.automaton.getFailedInputCount();
+  }
+
+  getEffectiveFailedInputCount(): number {
+    return this.automaton.getEffectiveFailedInputCount();
+  }
+}

--- a/examples/react-backspace/src/MissCountingApp.tsx
+++ b/examples/react-backspace/src/MissCountingApp.tsx
@@ -1,0 +1,77 @@
+import type { InputStroke, KeyboardLayout } from "emiel";
+import { activate, backspaceExtension, build, loadPresetRuleRoman, VirtualKeys } from "emiel";
+import { useEffect, useMemo, useState } from "react";
+import { MissCountingAutomaton } from "./MissCountingAutomaton";
+
+export function MissCountingApp(props: { layout: KeyboardLayout }) {
+  const romanRule = useMemo(() => loadPresetRuleRoman(props.layout), [props.layout]);
+  const words = useMemo(() => ["おをひく", "こんとん", "がっこう", "aから@"], []);
+  const [index, setIndex] = useState(0);
+  const [lastInputKey, setLastInputKey] = useState<InputStroke | undefined>();
+
+  const wrappers = useMemo(
+    () => words.map((w) => new MissCountingAutomaton(build(romanRule, w).with(backspaceExtension))),
+    [romanRule, words],
+  );
+  const wrapper = wrappers[index];
+
+  useEffect(() => {
+    return activate(window, (e) => {
+      setLastInputKey(e.input);
+      const result = wrapper.input(e);
+      if (result.isFinished) {
+        wrapper.reset();
+        setIndex((current) => (current + 1) % words.length);
+      }
+    });
+  }, [wrapper, words]);
+
+  return (
+    <>
+      <h1>
+        <div style={{ display: "flex", justifyContent: "center" }}>
+          <div style={{ color: "gray" }}>{wrapper.getFinishedWord()}</div>
+          <div
+            style={{
+              marginLeft: wrapper.getFinishedWord() ? "0.5rem" : "0",
+            }}
+          >
+            {wrapper.getPendingWord()}
+          </div>
+        </div>
+      </h1>
+      <h1>
+        <div style={{ display: "flex", justifyContent: "center" }}>
+          <div style={{ color: "gray" }}>{wrapper.getFinishedRoman()}</div>
+          <div
+            style={{
+              marginLeft: wrapper.getFinishedRoman() ? "0.5rem" : "0",
+              textAlign: "left",
+            }}
+          >
+            {wrapper.getPendingRoman()}
+            <br />
+            <span style={{ color: "yellow" }}>
+              {wrapper.failedInputs
+                .map((f) =>
+                  props.layout
+                    .getCharByKey(
+                      f.input.key,
+                      f.keyboardState.isAnyKeyDowned(VirtualKeys.ShiftLeft, VirtualKeys.ShiftRight),
+                    )
+                    .replace(" ", "_"),
+                )
+                .join("")}
+            </span>
+          </div>
+        </div>
+      </h1>
+      <h2>
+        Key:{" "}
+        <code style={{ border: "1px solid gray", padding: "0.2rem" }}>
+          {lastInputKey ? lastInputKey.key.toString() : ""}
+        </code>
+      </h2>
+    </>
+  );
+}

--- a/examples/react-backspace/src/MissCountingAutomaton.ts
+++ b/examples/react-backspace/src/MissCountingAutomaton.ts
@@ -1,0 +1,65 @@
+import type { Automaton, BackspaceExtensionType, InputEvent } from "emiel";
+import { InputResult } from "emiel";
+
+/**
+ * ミスした回数分 backspace を押さないと正常な入力に戻れないゲームルールを実装した Automaton ラッパー。
+ * ミスがない状態で backspace を押しても成功入力は戻さない。
+ */
+export class MissCountingAutomaton {
+  private _failedInputs: InputEvent[] = [];
+  private readonly automaton: Automaton & BackspaceExtensionType;
+
+  constructor(automaton: Automaton & BackspaceExtensionType) {
+    this.automaton = automaton;
+  }
+
+  get failedInputs(): readonly InputEvent[] {
+    return this._failedInputs;
+  }
+
+  input(stroke: InputEvent): InputResult {
+    const [result, apply] = this.automaton.testInput(stroke);
+    if (result.isBack) {
+      if (this._failedInputs.length > 0) {
+        apply();
+        this._failedInputs = this._failedInputs.slice(0, -1);
+      }
+      return result;
+    }
+    if (result.isIgnored) {
+      return result;
+    }
+    if (result.isFailed) {
+      apply();
+      this._failedInputs = [...this._failedInputs, stroke];
+      return result;
+    }
+    if (this._failedInputs.length > 0) {
+      this._failedInputs = [...this._failedInputs, stroke];
+      return InputResult.FAILED;
+    }
+    apply();
+    return result;
+  }
+
+  reset(): void {
+    this.automaton.reset();
+    this._failedInputs = [];
+  }
+
+  getFinishedWord(): string {
+    return this.automaton.getFinishedWord();
+  }
+
+  getPendingWord(): string {
+    return this.automaton.getPendingWord();
+  }
+
+  getFinishedRoman(): string {
+    return this.automaton.getFinishedRoman();
+  }
+
+  getPendingRoman(): string {
+    return this.automaton.getPendingRoman();
+  }
+}


### PR DESCRIPTION
## Summary

- react-backspace example にタブ切り替え UI を追加し、3種のバックスペース挙動を個別に動作確認できるようにした
- MissClearing: ミス状態で backspace 1回押すと全ミスをクリア。成功済み入力は戻さない
- MissCounting: N回ミスしたら N回の backspace が必要。成功済み入力は戻さない
- MissAccumulating: 既存動作。ミスを backspace でクリアした後、さらに backspace で成功入力も巻き戻せる

## 設計の背景

サンプルコードとして各パターンの挙動を比較しやすくするため、共通コンポーネント化による抽象化は避け、各 App と Automaton を独立した自己完結ファイルとして配置した。ファイル名は App と Automaton で対応関係がわかるよう統一した（MissClearing{App,Automaton}, MissCounting{App,Automaton}, MissAccumulating{App,Automaton}）。

## 検討した代替案

- 共通 Typing コンポーネントに factory props で Automaton ラッパーを注入する案: コードの重複は減るが、サンプルコードとしての読みやすさが損なわれるため不採用

## Test plan

- [ ] `pnpm dev` で開発サーバーを起動し各タブを切り替えて動作確認
- [ ] MissClearing: 複数回ミス → backspace 1回で黄色表示が全消え、成功状態で backspace を押しても何も起きない
- [ ] MissCounting: N回ミス → backspace N回で1つずつクリア、成功状態で backspace を押しても何も起きない
- [ ] MissAccumulating: ミスを backspace でクリア後、さらに backspace で成功入力が巻き戻される
- [ ] タブ切り替え時にキーイベントリスナーがリークしていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)