### PR TITLE
キーボードレイアウト 6 種追加と metadata プロパティ導入

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "lint:fix": "oxlint --fix src examples",
     "test": "vitest",
     "fmt": "oxfmt --write src examples",
-    "fmt:check": "oxfmt --check src examples"
+    "fmt:check": "oxfmt --check src examples",
+    "show-layout": "npx tsx scripts/show-layout.ts"
   },
   "devDependencies": {
     "@base2/pretty-print-object": "^1.0.2",

--- a/scripts/show-layout.ts
+++ b/scripts/show-layout.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from "node:fs";
+
+const DEFAULT_PHYSICAL_LAYOUT = "src/assets/physical_keyboard_layouts/us_101.json";
+
+// 表示対象外のキー（修飾キー・機能キー）
+const skipKeys = new Set([
+  "Backspace",
+  "Enter",
+  "ShiftLeft",
+  "ShiftRight",
+  "Space",
+  "CapsLock",
+  "Tab",
+  "LangLeft",
+  "LangRight",
+]);
+
+type Entry = {
+  output: string;
+  input: { key: string; shift: boolean };
+};
+
+type LayoutJson = {
+  metadata?: { name?: string; url?: string };
+  entries: Entry[];
+};
+
+type PhysicalLayoutJson = {
+  keys: string[][];
+  leftMargins: number[];
+  keyWidth?: Record<string, number>;
+};
+
+function parseArgs(argv: string[]): { physicalPath: string; layoutPaths: string[] } {
+  let physicalPath = DEFAULT_PHYSICAL_LAYOUT;
+  const layoutPaths: string[] = [];
+  for (const arg of argv) {
+    if (arg.startsWith("--physical=")) {
+      physicalPath = arg.slice("--physical=".length);
+    } else if (arg === "--physical") {
+      // 次の引数を取る形式は未対応。= 区切りのみサポート
+      throw new Error("Use --physical=<path> form");
+    } else {
+      layoutPaths.push(arg);
+    }
+  }
+  return { physicalPath, layoutPaths };
+}
+
+function showLayout(layoutPath: string, physical: PhysicalLayoutJson): void {
+  const json: LayoutJson = JSON.parse(readFileSync(layoutPath, "utf-8"));
+  const name = json.metadata?.name ?? "";
+
+  // key+shift → output のマップを構築
+  const charMap = new Map<string, string>();
+  for (const entry of json.entries) {
+    charMap.set(`${entry.input.key}:${entry.input.shift}`, entry.output);
+  }
+
+  const header = name ? `${name} (${layoutPath})` : layoutPath;
+  console.log(header);
+  console.log("=".repeat(header.length));
+  console.log();
+
+  // 表示対象の行（最終行の Space 行などはスキップ）
+  const rows = physical.keys.slice(0, 4);
+
+  // unshifted と shifted をそれぞれ表示
+  for (const shifted of [false, true]) {
+    for (let rowIdx = 0; rowIdx < rows.length; rowIdx++) {
+      const indent = " ".repeat(rowIdx);
+      const chars: string[] = [];
+      for (const key of rows[rowIdx]) {
+        if (skipKeys.has(key)) continue;
+        const output = charMap.get(`${key}:${shifted}`);
+        chars.push(output ?? " ");
+      }
+      console.log(indent + chars.join(" "));
+    }
+    console.log();
+  }
+}
+
+function main() {
+  const { physicalPath, layoutPaths } = parseArgs(process.argv.slice(2));
+  if (layoutPaths.length === 0) {
+    console.error(
+      "Usage: pnpm run show-layout [--physical=<path>] <keyboard-layout.json>...",
+    );
+    process.exit(1);
+  }
+
+  const physical: PhysicalLayoutJson = JSON.parse(readFileSync(physicalPath, "utf-8"));
+
+  for (let i = 0; i < layoutPaths.length; i++) {
+    if (i > 0) console.log();
+    showLayout(layoutPaths[i], physical);
+  }
+}
+
+main();

--- a/src/assets/keyboard_layouts/astarte.json
+++ b/src/assets/keyboard_layouts/astarte.json
@@ -1,0 +1,673 @@
+{
+  "metadata": {
+    "name": "ASTARTE配列",
+    "url": "https://neinvalli.hatenablog.com/entry/2018/07/21/185448"
+  },
+  "entries": [
+    {
+      "output": "i",
+      "input": {
+        "key": "A",
+        "shift": false
+      }
+    },
+    {
+      "output": "/",
+      "input": {
+        "key": "B",
+        "shift": false
+      }
+    },
+    {
+      "output": "-",
+      "input": {
+        "key": "C",
+        "shift": false
+      }
+    },
+    {
+      "output": "e",
+      "input": {
+        "key": "D",
+        "shift": false
+      }
+    },
+    {
+      "output": "u",
+      "input": {
+        "key": "E",
+        "shift": false
+      }
+    },
+    {
+      "output": "a",
+      "input": {
+        "key": "F",
+        "shift": false
+      }
+    },
+    {
+      "output": ".",
+      "input": {
+        "key": "G",
+        "shift": false
+      }
+    },
+    {
+      "output": "k",
+      "input": {
+        "key": "H",
+        "shift": false
+      }
+    },
+    {
+      "output": "h",
+      "input": {
+        "key": "I",
+        "shift": false
+      }
+    },
+    {
+      "output": "t",
+      "input": {
+        "key": "J",
+        "shift": false
+      }
+    },
+    {
+      "output": "n",
+      "input": {
+        "key": "K",
+        "shift": false
+      }
+    },
+    {
+      "output": "s",
+      "input": {
+        "key": "L",
+        "shift": false
+      }
+    },
+    {
+      "output": "l",
+      "input": {
+        "key": "M",
+        "shift": false
+      }
+    },
+    {
+      "output": "m",
+      "input": {
+        "key": "N",
+        "shift": false
+      }
+    },
+    {
+      "output": "g",
+      "input": {
+        "key": "O",
+        "shift": false
+      }
+    },
+    {
+      "output": "w",
+      "input": {
+        "key": "P",
+        "shift": false
+      }
+    },
+    {
+      "output": "q",
+      "input": {
+        "key": "Q",
+        "shift": false
+      }
+    },
+    {
+      "output": "y",
+      "input": {
+        "key": "R",
+        "shift": false
+      }
+    },
+    {
+      "output": "o",
+      "input": {
+        "key": "S",
+        "shift": false
+      }
+    },
+    {
+      "output": ",",
+      "input": {
+        "key": "T",
+        "shift": false
+      }
+    },
+    {
+      "output": "d",
+      "input": {
+        "key": "U",
+        "shift": false
+      }
+    },
+    {
+      "output": "c",
+      "input": {
+        "key": "V",
+        "shift": false
+      }
+    },
+    {
+      "output": "p",
+      "input": {
+        "key": "W",
+        "shift": false
+      }
+    },
+    {
+      "output": "x",
+      "input": {
+        "key": "X",
+        "shift": false
+      }
+    },
+    {
+      "output": "j",
+      "input": {
+        "key": "Y",
+        "shift": false
+      }
+    },
+    {
+      "output": "z",
+      "input": {
+        "key": "Z",
+        "shift": false
+      }
+    },
+    {
+      "output": "I",
+      "input": {
+        "key": "A",
+        "shift": true
+      }
+    },
+    {
+      "output": "?",
+      "input": {
+        "key": "B",
+        "shift": true
+      }
+    },
+    {
+      "output": "_",
+      "input": {
+        "key": "C",
+        "shift": true
+      }
+    },
+    {
+      "output": "E",
+      "input": {
+        "key": "D",
+        "shift": true
+      }
+    },
+    {
+      "output": "U",
+      "input": {
+        "key": "E",
+        "shift": true
+      }
+    },
+    {
+      "output": "A",
+      "input": {
+        "key": "F",
+        "shift": true
+      }
+    },
+    {
+      "output": ">",
+      "input": {
+        "key": "G",
+        "shift": true
+      }
+    },
+    {
+      "output": "K",
+      "input": {
+        "key": "H",
+        "shift": true
+      }
+    },
+    {
+      "output": "H",
+      "input": {
+        "key": "I",
+        "shift": true
+      }
+    },
+    {
+      "output": "T",
+      "input": {
+        "key": "J",
+        "shift": true
+      }
+    },
+    {
+      "output": "N",
+      "input": {
+        "key": "K",
+        "shift": true
+      }
+    },
+    {
+      "output": "S",
+      "input": {
+        "key": "L",
+        "shift": true
+      }
+    },
+    {
+      "output": "L",
+      "input": {
+        "key": "M",
+        "shift": true
+      }
+    },
+    {
+      "output": "M",
+      "input": {
+        "key": "N",
+        "shift": true
+      }
+    },
+    {
+      "output": "G",
+      "input": {
+        "key": "O",
+        "shift": true
+      }
+    },
+    {
+      "output": "W",
+      "input": {
+        "key": "P",
+        "shift": true
+      }
+    },
+    {
+      "output": "Q",
+      "input": {
+        "key": "Q",
+        "shift": true
+      }
+    },
+    {
+      "output": "Y",
+      "input": {
+        "key": "R",
+        "shift": true
+      }
+    },
+    {
+      "output": "O",
+      "input": {
+        "key": "S",
+        "shift": true
+      }
+    },
+    {
+      "output": "<",
+      "input": {
+        "key": "T",
+        "shift": true
+      }
+    },
+    {
+      "output": "D",
+      "input": {
+        "key": "U",
+        "shift": true
+      }
+    },
+    {
+      "output": "C",
+      "input": {
+        "key": "V",
+        "shift": true
+      }
+    },
+    {
+      "output": "P",
+      "input": {
+        "key": "W",
+        "shift": true
+      }
+    },
+    {
+      "output": "X",
+      "input": {
+        "key": "X",
+        "shift": true
+      }
+    },
+    {
+      "output": "J",
+      "input": {
+        "key": "Y",
+        "shift": true
+      }
+    },
+    {
+      "output": "Z",
+      "input": {
+        "key": "Z",
+        "shift": true
+      }
+    },
+    {
+      "output": "`",
+      "input": {
+        "key": "Backquote",
+        "shift": false
+      }
+    },
+    {
+      "output": "1",
+      "input": {
+        "key": "Digit1",
+        "shift": false
+      }
+    },
+    {
+      "output": "2",
+      "input": {
+        "key": "Digit2",
+        "shift": false
+      }
+    },
+    {
+      "output": "3",
+      "input": {
+        "key": "Digit3",
+        "shift": false
+      }
+    },
+    {
+      "output": "4",
+      "input": {
+        "key": "Digit4",
+        "shift": false
+      }
+    },
+    {
+      "output": "5",
+      "input": {
+        "key": "Digit5",
+        "shift": false
+      }
+    },
+    {
+      "output": "6",
+      "input": {
+        "key": "Digit6",
+        "shift": false
+      }
+    },
+    {
+      "output": "7",
+      "input": {
+        "key": "Digit7",
+        "shift": false
+      }
+    },
+    {
+      "output": "8",
+      "input": {
+        "key": "Digit8",
+        "shift": false
+      }
+    },
+    {
+      "output": "9",
+      "input": {
+        "key": "Digit9",
+        "shift": false
+      }
+    },
+    {
+      "output": "0",
+      "input": {
+        "key": "Digit0",
+        "shift": false
+      }
+    },
+    {
+      "output": "~",
+      "input": {
+        "key": "Backquote",
+        "shift": true
+      }
+    },
+    {
+      "output": "!",
+      "input": {
+        "key": "Digit1",
+        "shift": true
+      }
+    },
+    {
+      "output": "@",
+      "input": {
+        "key": "Digit2",
+        "shift": true
+      }
+    },
+    {
+      "output": "#",
+      "input": {
+        "key": "Digit3",
+        "shift": true
+      }
+    },
+    {
+      "output": "$",
+      "input": {
+        "key": "Digit4",
+        "shift": true
+      }
+    },
+    {
+      "output": "%",
+      "input": {
+        "key": "Digit5",
+        "shift": true
+      }
+    },
+    {
+      "output": "^",
+      "input": {
+        "key": "Digit6",
+        "shift": true
+      }
+    },
+    {
+      "output": "&",
+      "input": {
+        "key": "Digit7",
+        "shift": true
+      }
+    },
+    {
+      "output": "*",
+      "input": {
+        "key": "Digit8",
+        "shift": true
+      }
+    },
+    {
+      "output": "(",
+      "input": {
+        "key": "Digit9",
+        "shift": true
+      }
+    },
+    {
+      "output": ")",
+      "input": {
+        "key": "Digit0",
+        "shift": true
+      }
+    },
+    {
+      "output": ";",
+      "input": {
+        "key": "Minus",
+        "shift": false
+      }
+    },
+    {
+      "output": "=",
+      "input": {
+        "key": "Equal",
+        "shift": false
+      }
+    },
+    {
+      "output": "[",
+      "input": {
+        "key": "BracketLeft",
+        "shift": false
+      }
+    },
+    {
+      "output": "]",
+      "input": {
+        "key": "BracketRight",
+        "shift": false
+      }
+    },
+    {
+      "output": "r",
+      "input": {
+        "key": "Semicolon",
+        "shift": false
+      }
+    },
+    {
+      "output": "'",
+      "input": {
+        "key": "Quote",
+        "shift": false
+      }
+    },
+    {
+      "output": "\\",
+      "input": {
+        "key": "Backslash",
+        "shift": false
+      }
+    },
+    {
+      "output": "f",
+      "input": {
+        "key": "Comma",
+        "shift": false
+      }
+    },
+    {
+      "output": "b",
+      "input": {
+        "key": "Period",
+        "shift": false
+      }
+    },
+    {
+      "output": "v",
+      "input": {
+        "key": "Slash",
+        "shift": false
+      }
+    },
+    {
+      "output": ":",
+      "input": {
+        "key": "Minus",
+        "shift": true
+      }
+    },
+    {
+      "output": "+",
+      "input": {
+        "key": "Equal",
+        "shift": true
+      }
+    },
+    {
+      "output": "{",
+      "input": {
+        "key": "BracketLeft",
+        "shift": true
+      }
+    },
+    {
+      "output": "}",
+      "input": {
+        "key": "BracketRight",
+        "shift": true
+      }
+    },
+    {
+      "output": "R",
+      "input": {
+        "key": "Semicolon",
+        "shift": true
+      }
+    },
+    {
+      "output": "\"",
+      "input": {
+        "key": "Quote",
+        "shift": true
+      }
+    },
+    {
+      "output": "|",
+      "input": {
+        "key": "Backslash",
+        "shift": true
+      }
+    },
+    {
+      "output": "F",
+      "input": {
+        "key": "Comma",
+        "shift": true
+      }
+    },
+    {
+      "output": "B",
+      "input": {
+        "key": "Period",
+        "shift": true
+      }
+    },
+    {
+      "output": "V",
+      "input": {
+        "key": "Slash",
+        "shift": true
+      }
+    },
+    {
+      "output": " ",
+      "input": {
+        "key": "Space",
+        "shift": false
+      }
+    }
+  ]
+}

--- a/src/assets/keyboard_layouts/colemak.json
+++ b/src/assets/keyboard_layouts/colemak.json
@@ -1,0 +1,673 @@
+{
+  "metadata": {
+    "name": "Colemak",
+    "url": "https://colemak.com/"
+  },
+  "entries": [
+    {
+      "output": "a",
+      "input": {
+        "key": "A",
+        "shift": false
+      }
+    },
+    {
+      "output": "b",
+      "input": {
+        "key": "B",
+        "shift": false
+      }
+    },
+    {
+      "output": "c",
+      "input": {
+        "key": "C",
+        "shift": false
+      }
+    },
+    {
+      "output": "s",
+      "input": {
+        "key": "D",
+        "shift": false
+      }
+    },
+    {
+      "output": "f",
+      "input": {
+        "key": "E",
+        "shift": false
+      }
+    },
+    {
+      "output": "t",
+      "input": {
+        "key": "F",
+        "shift": false
+      }
+    },
+    {
+      "output": "d",
+      "input": {
+        "key": "G",
+        "shift": false
+      }
+    },
+    {
+      "output": "h",
+      "input": {
+        "key": "H",
+        "shift": false
+      }
+    },
+    {
+      "output": "u",
+      "input": {
+        "key": "I",
+        "shift": false
+      }
+    },
+    {
+      "output": "n",
+      "input": {
+        "key": "J",
+        "shift": false
+      }
+    },
+    {
+      "output": "e",
+      "input": {
+        "key": "K",
+        "shift": false
+      }
+    },
+    {
+      "output": "i",
+      "input": {
+        "key": "L",
+        "shift": false
+      }
+    },
+    {
+      "output": "m",
+      "input": {
+        "key": "M",
+        "shift": false
+      }
+    },
+    {
+      "output": "k",
+      "input": {
+        "key": "N",
+        "shift": false
+      }
+    },
+    {
+      "output": "y",
+      "input": {
+        "key": "O",
+        "shift": false
+      }
+    },
+    {
+      "output": ";",
+      "input": {
+        "key": "P",
+        "shift": false
+      }
+    },
+    {
+      "output": "q",
+      "input": {
+        "key": "Q",
+        "shift": false
+      }
+    },
+    {
+      "output": "p",
+      "input": {
+        "key": "R",
+        "shift": false
+      }
+    },
+    {
+      "output": "r",
+      "input": {
+        "key": "S",
+        "shift": false
+      }
+    },
+    {
+      "output": "g",
+      "input": {
+        "key": "T",
+        "shift": false
+      }
+    },
+    {
+      "output": "l",
+      "input": {
+        "key": "U",
+        "shift": false
+      }
+    },
+    {
+      "output": "v",
+      "input": {
+        "key": "V",
+        "shift": false
+      }
+    },
+    {
+      "output": "w",
+      "input": {
+        "key": "W",
+        "shift": false
+      }
+    },
+    {
+      "output": "x",
+      "input": {
+        "key": "X",
+        "shift": false
+      }
+    },
+    {
+      "output": "j",
+      "input": {
+        "key": "Y",
+        "shift": false
+      }
+    },
+    {
+      "output": "z",
+      "input": {
+        "key": "Z",
+        "shift": false
+      }
+    },
+    {
+      "output": "A",
+      "input": {
+        "key": "A",
+        "shift": true
+      }
+    },
+    {
+      "output": "B",
+      "input": {
+        "key": "B",
+        "shift": true
+      }
+    },
+    {
+      "output": "C",
+      "input": {
+        "key": "C",
+        "shift": true
+      }
+    },
+    {
+      "output": "S",
+      "input": {
+        "key": "D",
+        "shift": true
+      }
+    },
+    {
+      "output": "F",
+      "input": {
+        "key": "E",
+        "shift": true
+      }
+    },
+    {
+      "output": "T",
+      "input": {
+        "key": "F",
+        "shift": true
+      }
+    },
+    {
+      "output": "D",
+      "input": {
+        "key": "G",
+        "shift": true
+      }
+    },
+    {
+      "output": "H",
+      "input": {
+        "key": "H",
+        "shift": true
+      }
+    },
+    {
+      "output": "U",
+      "input": {
+        "key": "I",
+        "shift": true
+      }
+    },
+    {
+      "output": "N",
+      "input": {
+        "key": "J",
+        "shift": true
+      }
+    },
+    {
+      "output": "E",
+      "input": {
+        "key": "K",
+        "shift": true
+      }
+    },
+    {
+      "output": "I",
+      "input": {
+        "key": "L",
+        "shift": true
+      }
+    },
+    {
+      "output": "M",
+      "input": {
+        "key": "M",
+        "shift": true
+      }
+    },
+    {
+      "output": "K",
+      "input": {
+        "key": "N",
+        "shift": true
+      }
+    },
+    {
+      "output": "Y",
+      "input": {
+        "key": "O",
+        "shift": true
+      }
+    },
+    {
+      "output": ":",
+      "input": {
+        "key": "P",
+        "shift": true
+      }
+    },
+    {
+      "output": "Q",
+      "input": {
+        "key": "Q",
+        "shift": true
+      }
+    },
+    {
+      "output": "P",
+      "input": {
+        "key": "R",
+        "shift": true
+      }
+    },
+    {
+      "output": "R",
+      "input": {
+        "key": "S",
+        "shift": true
+      }
+    },
+    {
+      "output": "G",
+      "input": {
+        "key": "T",
+        "shift": true
+      }
+    },
+    {
+      "output": "L",
+      "input": {
+        "key": "U",
+        "shift": true
+      }
+    },
+    {
+      "output": "V",
+      "input": {
+        "key": "V",
+        "shift": true
+      }
+    },
+    {
+      "output": "W",
+      "input": {
+        "key": "W",
+        "shift": true
+      }
+    },
+    {
+      "output": "X",
+      "input": {
+        "key": "X",
+        "shift": true
+      }
+    },
+    {
+      "output": "J",
+      "input": {
+        "key": "Y",
+        "shift": true
+      }
+    },
+    {
+      "output": "Z",
+      "input": {
+        "key": "Z",
+        "shift": true
+      }
+    },
+    {
+      "output": "`",
+      "input": {
+        "key": "Backquote",
+        "shift": false
+      }
+    },
+    {
+      "output": "1",
+      "input": {
+        "key": "Digit1",
+        "shift": false
+      }
+    },
+    {
+      "output": "2",
+      "input": {
+        "key": "Digit2",
+        "shift": false
+      }
+    },
+    {
+      "output": "3",
+      "input": {
+        "key": "Digit3",
+        "shift": false
+      }
+    },
+    {
+      "output": "4",
+      "input": {
+        "key": "Digit4",
+        "shift": false
+      }
+    },
+    {
+      "output": "5",
+      "input": {
+        "key": "Digit5",
+        "shift": false
+      }
+    },
+    {
+      "output": "6",
+      "input": {
+        "key": "Digit6",
+        "shift": false
+      }
+    },
+    {
+      "output": "7",
+      "input": {
+        "key": "Digit7",
+        "shift": false
+      }
+    },
+    {
+      "output": "8",
+      "input": {
+        "key": "Digit8",
+        "shift": false
+      }
+    },
+    {
+      "output": "9",
+      "input": {
+        "key": "Digit9",
+        "shift": false
+      }
+    },
+    {
+      "output": "0",
+      "input": {
+        "key": "Digit0",
+        "shift": false
+      }
+    },
+    {
+      "output": "~",
+      "input": {
+        "key": "Backquote",
+        "shift": true
+      }
+    },
+    {
+      "output": "!",
+      "input": {
+        "key": "Digit1",
+        "shift": true
+      }
+    },
+    {
+      "output": "@",
+      "input": {
+        "key": "Digit2",
+        "shift": true
+      }
+    },
+    {
+      "output": "#",
+      "input": {
+        "key": "Digit3",
+        "shift": true
+      }
+    },
+    {
+      "output": "$",
+      "input": {
+        "key": "Digit4",
+        "shift": true
+      }
+    },
+    {
+      "output": "%",
+      "input": {
+        "key": "Digit5",
+        "shift": true
+      }
+    },
+    {
+      "output": "^",
+      "input": {
+        "key": "Digit6",
+        "shift": true
+      }
+    },
+    {
+      "output": "&",
+      "input": {
+        "key": "Digit7",
+        "shift": true
+      }
+    },
+    {
+      "output": "*",
+      "input": {
+        "key": "Digit8",
+        "shift": true
+      }
+    },
+    {
+      "output": "(",
+      "input": {
+        "key": "Digit9",
+        "shift": true
+      }
+    },
+    {
+      "output": ")",
+      "input": {
+        "key": "Digit0",
+        "shift": true
+      }
+    },
+    {
+      "output": "-",
+      "input": {
+        "key": "Minus",
+        "shift": false
+      }
+    },
+    {
+      "output": "=",
+      "input": {
+        "key": "Equal",
+        "shift": false
+      }
+    },
+    {
+      "output": "[",
+      "input": {
+        "key": "BracketLeft",
+        "shift": false
+      }
+    },
+    {
+      "output": "]",
+      "input": {
+        "key": "BracketRight",
+        "shift": false
+      }
+    },
+    {
+      "output": "o",
+      "input": {
+        "key": "Semicolon",
+        "shift": false
+      }
+    },
+    {
+      "output": "'",
+      "input": {
+        "key": "Quote",
+        "shift": false
+      }
+    },
+    {
+      "output": "\\",
+      "input": {
+        "key": "Backslash",
+        "shift": false
+      }
+    },
+    {
+      "output": ",",
+      "input": {
+        "key": "Comma",
+        "shift": false
+      }
+    },
+    {
+      "output": ".",
+      "input": {
+        "key": "Period",
+        "shift": false
+      }
+    },
+    {
+      "output": "/",
+      "input": {
+        "key": "Slash",
+        "shift": false
+      }
+    },
+    {
+      "output": "_",
+      "input": {
+        "key": "Minus",
+        "shift": true
+      }
+    },
+    {
+      "output": "+",
+      "input": {
+        "key": "Equal",
+        "shift": true
+      }
+    },
+    {
+      "output": "{",
+      "input": {
+        "key": "BracketLeft",
+        "shift": true
+      }
+    },
+    {
+      "output": "}",
+      "input": {
+        "key": "BracketRight",
+        "shift": true
+      }
+    },
+    {
+      "output": "O",
+      "input": {
+        "key": "Semicolon",
+        "shift": true
+      }
+    },
+    {
+      "output": "\"",
+      "input": {
+        "key": "Quote",
+        "shift": true
+      }
+    },
+    {
+      "output": "|",
+      "input": {
+        "key": "Backslash",
+        "shift": true
+      }
+    },
+    {
+      "output": "<",
+      "input": {
+        "key": "Comma",
+        "shift": true
+      }
+    },
+    {
+      "output": ">",
+      "input": {
+        "key": "Period",
+        "shift": true
+      }
+    },
+    {
+      "output": "?",
+      "input": {
+        "key": "Slash",
+        "shift": true
+      }
+    },
+    {
+      "output": " ",
+      "input": {
+        "key": "Space",
+        "shift": false
+      }
+    }
+  ]
+}

--- a/src/assets/keyboard_layouts/colemak_dh.json
+++ b/src/assets/keyboard_layouts/colemak_dh.json
@@ -1,0 +1,673 @@
+{
+  "metadata": {
+    "name": "Colemak-DH",
+    "url": "https://colemakmods.github.io/mod-dh/"
+  },
+  "entries": [
+    {
+      "output": "a",
+      "input": {
+        "key": "A",
+        "shift": false
+      }
+    },
+    {
+      "output": "v",
+      "input": {
+        "key": "B",
+        "shift": false
+      }
+    },
+    {
+      "output": "c",
+      "input": {
+        "key": "C",
+        "shift": false
+      }
+    },
+    {
+      "output": "s",
+      "input": {
+        "key": "D",
+        "shift": false
+      }
+    },
+    {
+      "output": "f",
+      "input": {
+        "key": "E",
+        "shift": false
+      }
+    },
+    {
+      "output": "t",
+      "input": {
+        "key": "F",
+        "shift": false
+      }
+    },
+    {
+      "output": "g",
+      "input": {
+        "key": "G",
+        "shift": false
+      }
+    },
+    {
+      "output": "m",
+      "input": {
+        "key": "H",
+        "shift": false
+      }
+    },
+    {
+      "output": "u",
+      "input": {
+        "key": "I",
+        "shift": false
+      }
+    },
+    {
+      "output": "n",
+      "input": {
+        "key": "J",
+        "shift": false
+      }
+    },
+    {
+      "output": "e",
+      "input": {
+        "key": "K",
+        "shift": false
+      }
+    },
+    {
+      "output": "i",
+      "input": {
+        "key": "L",
+        "shift": false
+      }
+    },
+    {
+      "output": "h",
+      "input": {
+        "key": "M",
+        "shift": false
+      }
+    },
+    {
+      "output": "k",
+      "input": {
+        "key": "N",
+        "shift": false
+      }
+    },
+    {
+      "output": "y",
+      "input": {
+        "key": "O",
+        "shift": false
+      }
+    },
+    {
+      "output": ";",
+      "input": {
+        "key": "P",
+        "shift": false
+      }
+    },
+    {
+      "output": "q",
+      "input": {
+        "key": "Q",
+        "shift": false
+      }
+    },
+    {
+      "output": "p",
+      "input": {
+        "key": "R",
+        "shift": false
+      }
+    },
+    {
+      "output": "r",
+      "input": {
+        "key": "S",
+        "shift": false
+      }
+    },
+    {
+      "output": "b",
+      "input": {
+        "key": "T",
+        "shift": false
+      }
+    },
+    {
+      "output": "l",
+      "input": {
+        "key": "U",
+        "shift": false
+      }
+    },
+    {
+      "output": "d",
+      "input": {
+        "key": "V",
+        "shift": false
+      }
+    },
+    {
+      "output": "w",
+      "input": {
+        "key": "W",
+        "shift": false
+      }
+    },
+    {
+      "output": "x",
+      "input": {
+        "key": "X",
+        "shift": false
+      }
+    },
+    {
+      "output": "j",
+      "input": {
+        "key": "Y",
+        "shift": false
+      }
+    },
+    {
+      "output": "z",
+      "input": {
+        "key": "Z",
+        "shift": false
+      }
+    },
+    {
+      "output": "A",
+      "input": {
+        "key": "A",
+        "shift": true
+      }
+    },
+    {
+      "output": "V",
+      "input": {
+        "key": "B",
+        "shift": true
+      }
+    },
+    {
+      "output": "C",
+      "input": {
+        "key": "C",
+        "shift": true
+      }
+    },
+    {
+      "output": "S",
+      "input": {
+        "key": "D",
+        "shift": true
+      }
+    },
+    {
+      "output": "F",
+      "input": {
+        "key": "E",
+        "shift": true
+      }
+    },
+    {
+      "output": "T",
+      "input": {
+        "key": "F",
+        "shift": true
+      }
+    },
+    {
+      "output": "G",
+      "input": {
+        "key": "G",
+        "shift": true
+      }
+    },
+    {
+      "output": "M",
+      "input": {
+        "key": "H",
+        "shift": true
+      }
+    },
+    {
+      "output": "U",
+      "input": {
+        "key": "I",
+        "shift": true
+      }
+    },
+    {
+      "output": "N",
+      "input": {
+        "key": "J",
+        "shift": true
+      }
+    },
+    {
+      "output": "E",
+      "input": {
+        "key": "K",
+        "shift": true
+      }
+    },
+    {
+      "output": "I",
+      "input": {
+        "key": "L",
+        "shift": true
+      }
+    },
+    {
+      "output": "H",
+      "input": {
+        "key": "M",
+        "shift": true
+      }
+    },
+    {
+      "output": "K",
+      "input": {
+        "key": "N",
+        "shift": true
+      }
+    },
+    {
+      "output": "Y",
+      "input": {
+        "key": "O",
+        "shift": true
+      }
+    },
+    {
+      "output": ":",
+      "input": {
+        "key": "P",
+        "shift": true
+      }
+    },
+    {
+      "output": "Q",
+      "input": {
+        "key": "Q",
+        "shift": true
+      }
+    },
+    {
+      "output": "P",
+      "input": {
+        "key": "R",
+        "shift": true
+      }
+    },
+    {
+      "output": "R",
+      "input": {
+        "key": "S",
+        "shift": true
+      }
+    },
+    {
+      "output": "B",
+      "input": {
+        "key": "T",
+        "shift": true
+      }
+    },
+    {
+      "output": "L",
+      "input": {
+        "key": "U",
+        "shift": true
+      }
+    },
+    {
+      "output": "D",
+      "input": {
+        "key": "V",
+        "shift": true
+      }
+    },
+    {
+      "output": "W",
+      "input": {
+        "key": "W",
+        "shift": true
+      }
+    },
+    {
+      "output": "X",
+      "input": {
+        "key": "X",
+        "shift": true
+      }
+    },
+    {
+      "output": "J",
+      "input": {
+        "key": "Y",
+        "shift": true
+      }
+    },
+    {
+      "output": "Z",
+      "input": {
+        "key": "Z",
+        "shift": true
+      }
+    },
+    {
+      "output": "`",
+      "input": {
+        "key": "Backquote",
+        "shift": false
+      }
+    },
+    {
+      "output": "1",
+      "input": {
+        "key": "Digit1",
+        "shift": false
+      }
+    },
+    {
+      "output": "2",
+      "input": {
+        "key": "Digit2",
+        "shift": false
+      }
+    },
+    {
+      "output": "3",
+      "input": {
+        "key": "Digit3",
+        "shift": false
+      }
+    },
+    {
+      "output": "4",
+      "input": {
+        "key": "Digit4",
+        "shift": false
+      }
+    },
+    {
+      "output": "5",
+      "input": {
+        "key": "Digit5",
+        "shift": false
+      }
+    },
+    {
+      "output": "6",
+      "input": {
+        "key": "Digit6",
+        "shift": false
+      }
+    },
+    {
+      "output": "7",
+      "input": {
+        "key": "Digit7",
+        "shift": false
+      }
+    },
+    {
+      "output": "8",
+      "input": {
+        "key": "Digit8",
+        "shift": false
+      }
+    },
+    {
+      "output": "9",
+      "input": {
+        "key": "Digit9",
+        "shift": false
+      }
+    },
+    {
+      "output": "0",
+      "input": {
+        "key": "Digit0",
+        "shift": false
+      }
+    },
+    {
+      "output": "~",
+      "input": {
+        "key": "Backquote",
+        "shift": true
+      }
+    },
+    {
+      "output": "!",
+      "input": {
+        "key": "Digit1",
+        "shift": true
+      }
+    },
+    {
+      "output": "@",
+      "input": {
+        "key": "Digit2",
+        "shift": true
+      }
+    },
+    {
+      "output": "#",
+      "input": {
+        "key": "Digit3",
+        "shift": true
+      }
+    },
+    {
+      "output": "$",
+      "input": {
+        "key": "Digit4",
+        "shift": true
+      }
+    },
+    {
+      "output": "%",
+      "input": {
+        "key": "Digit5",
+        "shift": true
+      }
+    },
+    {
+      "output": "^",
+      "input": {
+        "key": "Digit6",
+        "shift": true
+      }
+    },
+    {
+      "output": "&",
+      "input": {
+        "key": "Digit7",
+        "shift": true
+      }
+    },
+    {
+      "output": "*",
+      "input": {
+        "key": "Digit8",
+        "shift": true
+      }
+    },
+    {
+      "output": "(",
+      "input": {
+        "key": "Digit9",
+        "shift": true
+      }
+    },
+    {
+      "output": ")",
+      "input": {
+        "key": "Digit0",
+        "shift": true
+      }
+    },
+    {
+      "output": "-",
+      "input": {
+        "key": "Minus",
+        "shift": false
+      }
+    },
+    {
+      "output": "=",
+      "input": {
+        "key": "Equal",
+        "shift": false
+      }
+    },
+    {
+      "output": "[",
+      "input": {
+        "key": "BracketLeft",
+        "shift": false
+      }
+    },
+    {
+      "output": "]",
+      "input": {
+        "key": "BracketRight",
+        "shift": false
+      }
+    },
+    {
+      "output": "o",
+      "input": {
+        "key": "Semicolon",
+        "shift": false
+      }
+    },
+    {
+      "output": "'",
+      "input": {
+        "key": "Quote",
+        "shift": false
+      }
+    },
+    {
+      "output": "\\",
+      "input": {
+        "key": "Backslash",
+        "shift": false
+      }
+    },
+    {
+      "output": ",",
+      "input": {
+        "key": "Comma",
+        "shift": false
+      }
+    },
+    {
+      "output": ".",
+      "input": {
+        "key": "Period",
+        "shift": false
+      }
+    },
+    {
+      "output": "/",
+      "input": {
+        "key": "Slash",
+        "shift": false
+      }
+    },
+    {
+      "output": "_",
+      "input": {
+        "key": "Minus",
+        "shift": true
+      }
+    },
+    {
+      "output": "+",
+      "input": {
+        "key": "Equal",
+        "shift": true
+      }
+    },
+    {
+      "output": "{",
+      "input": {
+        "key": "BracketLeft",
+        "shift": true
+      }
+    },
+    {
+      "output": "}",
+      "input": {
+        "key": "BracketRight",
+        "shift": true
+      }
+    },
+    {
+      "output": "O",
+      "input": {
+        "key": "Semicolon",
+        "shift": true
+      }
+    },
+    {
+      "output": "\"",
+      "input": {
+        "key": "Quote",
+        "shift": true
+      }
+    },
+    {
+      "output": "|",
+      "input": {
+        "key": "Backslash",
+        "shift": true
+      }
+    },
+    {
+      "output": "<",
+      "input": {
+        "key": "Comma",
+        "shift": true
+      }
+    },
+    {
+      "output": ">",
+      "input": {
+        "key": "Period",
+        "shift": true
+      }
+    },
+    {
+      "output": "?",
+      "input": {
+        "key": "Slash",
+        "shift": true
+      }
+    },
+    {
+      "output": " ",
+      "input": {
+        "key": "Space",
+        "shift": false
+      }
+    }
+  ]
+}

--- a/src/assets/keyboard_layouts/dvorak.json
+++ b/src/assets/keyboard_layouts/dvorak.json
@@ -1,100 +1,673 @@
 {
-  "name": "DVORAK",
+  "metadata": {
+    "name": "DVORAK",
+    "url": "https://en.wikipedia.org/wiki/Dvorak_keyboard_layout"
+  },
   "entries": [
-    { "output": "a", "input": { "key": "A", "shift": false } },
-    { "output": "x", "input": { "key": "B", "shift": false } },
-    { "output": "j", "input": { "key": "C", "shift": false } },
-    { "output": "e", "input": { "key": "D", "shift": false } },
-    { "output": ".", "input": { "key": "E", "shift": false } },
-    { "output": "u", "input": { "key": "F", "shift": false } },
-    { "output": "i", "input": { "key": "G", "shift": false } },
-    { "output": "d", "input": { "key": "H", "shift": false } },
-    { "output": "c", "input": { "key": "I", "shift": false } },
-    { "output": "h", "input": { "key": "J", "shift": false } },
-    { "output": "t", "input": { "key": "K", "shift": false } },
-    { "output": "n", "input": { "key": "L", "shift": false } },
-    { "output": "m", "input": { "key": "M", "shift": false } },
-    { "output": "b", "input": { "key": "N", "shift": false } },
-    { "output": "r", "input": { "key": "O", "shift": false } },
-    { "output": "l", "input": { "key": "P", "shift": false } },
-    { "output": "'", "input": { "key": "Q", "shift": false } },
-    { "output": "p", "input": { "key": "R", "shift": false } },
-    { "output": "o", "input": { "key": "S", "shift": false } },
-    { "output": "y", "input": { "key": "T", "shift": false } },
-    { "output": "g", "input": { "key": "U", "shift": false } },
-    { "output": "k", "input": { "key": "V", "shift": false } },
-    { "output": ",", "input": { "key": "W", "shift": false } },
-    { "output": "q", "input": { "key": "X", "shift": false } },
-    { "output": "f", "input": { "key": "Y", "shift": false } },
-    { "output": ";", "input": { "key": "Z", "shift": false } },
-    { "output": "A", "input": { "key": "A", "shift": true } },
-    { "output": "X", "input": { "key": "B", "shift": true } },
-    { "output": "J", "input": { "key": "C", "shift": true } },
-    { "output": "E", "input": { "key": "D", "shift": true } },
-    { "output": ">", "input": { "key": "E", "shift": true } },
-    { "output": "U", "input": { "key": "F", "shift": true } },
-    { "output": "I", "input": { "key": "G", "shift": true } },
-    { "output": "D", "input": { "key": "H", "shift": true } },
-    { "output": "C", "input": { "key": "I", "shift": true } },
-    { "output": "H", "input": { "key": "J", "shift": true } },
-    { "output": "T", "input": { "key": "K", "shift": true } },
-    { "output": "N", "input": { "key": "L", "shift": true } },
-    { "output": "M", "input": { "key": "M", "shift": true } },
-    { "output": "B", "input": { "key": "N", "shift": true } },
-    { "output": "R", "input": { "key": "O", "shift": true } },
-    { "output": "L", "input": { "key": "P", "shift": true } },
-    { "output": "\"", "input": { "key": "Q", "shift": true } },
-    { "output": "P", "input": { "key": "R", "shift": true } },
-    { "output": "O", "input": { "key": "S", "shift": true } },
-    { "output": "Y", "input": { "key": "T", "shift": true } },
-    { "output": "G", "input": { "key": "U", "shift": true } },
-    { "output": "K", "input": { "key": "V", "shift": true } },
-    { "output": "<", "input": { "key": "W", "shift": true } },
-    { "output": "Q", "input": { "key": "X", "shift": true } },
-    { "output": "F", "input": { "key": "Y", "shift": true } },
-    { "output": ":", "input": { "key": "Z", "shift": true } },
-    { "output": "`", "input": { "key": "Backquote", "shift": false } },
-    { "output": "1", "input": { "key": "Digit1", "shift": false } },
-    { "output": "2", "input": { "key": "Digit2", "shift": false } },
-    { "output": "3", "input": { "key": "Digit3", "shift": false } },
-    { "output": "4", "input": { "key": "Digit4", "shift": false } },
-    { "output": "5", "input": { "key": "Digit5", "shift": false } },
-    { "output": "6", "input": { "key": "Digit6", "shift": false } },
-    { "output": "7", "input": { "key": "Digit7", "shift": false } },
-    { "output": "8", "input": { "key": "Digit8", "shift": false } },
-    { "output": "9", "input": { "key": "Digit9", "shift": false } },
-    { "output": "0", "input": { "key": "Digit0", "shift": false } },
-    { "output": "~", "input": { "key": "Backquote", "shift": true } },
-    { "output": "!", "input": { "key": "Digit1", "shift": true } },
-    { "output": "@", "input": { "key": "Digit2", "shift": true } },
-    { "output": "#", "input": { "key": "Digit3", "shift": true } },
-    { "output": "$", "input": { "key": "Digit4", "shift": true } },
-    { "output": "%", "input": { "key": "Digit5", "shift": true } },
-    { "output": "^", "input": { "key": "Digit6", "shift": true } },
-    { "output": "&", "input": { "key": "Digit7", "shift": true } },
-    { "output": "*", "input": { "key": "Digit8", "shift": true } },
-    { "output": "(", "input": { "key": "Digit9", "shift": true } },
-    { "output": ")", "input": { "key": "Digit0", "shift": true } },
-    { "output": "[", "input": { "key": "Minus", "shift": false } },
-    { "output": "]", "input": { "key": "Equal", "shift": false } },
-    { "output": "/", "input": { "key": "BracketLeft", "shift": false } },
-    { "output": "=", "input": { "key": "BracketRight", "shift": false } },
-    { "output": "s", "input": { "key": "Semicolon", "shift": false } },
-    { "output": "-", "input": { "key": "Quote", "shift": false } },
-    { "output": "\\", "input": { "key": "Backslash", "shift": false } },
-    { "output": "w", "input": { "key": "Comma", "shift": false } },
-    { "output": "v", "input": { "key": "Period", "shift": false } },
-    { "output": "z", "input": { "key": "Slash", "shift": false } },
-    { "output": "{", "input": { "key": "Minus", "shift": true } },
-    { "output": "}", "input": { "key": "Equal", "shift": true } },
-    { "output": "?", "input": { "key": "BracketLeft", "shift": true } },
-    { "output": "+", "input": { "key": "BracketRight", "shift": true } },
-    { "output": "S", "input": { "key": "Semicolon", "shift": true } },
-    { "output": "_", "input": { "key": "Quote", "shift": true } },
-    { "output": "|", "input": { "key": "Backslash", "shift": true } },
-    { "output": "W", "input": { "key": "Comma", "shift": true } },
-    { "output": "V", "input": { "key": "Period", "shift": true } },
-    { "output": "Z", "input": { "key": "Slash", "shift": true } },
-    { "output": " ", "input": { "key": "Space", "shift": false } }
+    {
+      "output": "a",
+      "input": {
+        "key": "A",
+        "shift": false
+      }
+    },
+    {
+      "output": "x",
+      "input": {
+        "key": "B",
+        "shift": false
+      }
+    },
+    {
+      "output": "j",
+      "input": {
+        "key": "C",
+        "shift": false
+      }
+    },
+    {
+      "output": "e",
+      "input": {
+        "key": "D",
+        "shift": false
+      }
+    },
+    {
+      "output": ".",
+      "input": {
+        "key": "E",
+        "shift": false
+      }
+    },
+    {
+      "output": "u",
+      "input": {
+        "key": "F",
+        "shift": false
+      }
+    },
+    {
+      "output": "i",
+      "input": {
+        "key": "G",
+        "shift": false
+      }
+    },
+    {
+      "output": "d",
+      "input": {
+        "key": "H",
+        "shift": false
+      }
+    },
+    {
+      "output": "c",
+      "input": {
+        "key": "I",
+        "shift": false
+      }
+    },
+    {
+      "output": "h",
+      "input": {
+        "key": "J",
+        "shift": false
+      }
+    },
+    {
+      "output": "t",
+      "input": {
+        "key": "K",
+        "shift": false
+      }
+    },
+    {
+      "output": "n",
+      "input": {
+        "key": "L",
+        "shift": false
+      }
+    },
+    {
+      "output": "m",
+      "input": {
+        "key": "M",
+        "shift": false
+      }
+    },
+    {
+      "output": "b",
+      "input": {
+        "key": "N",
+        "shift": false
+      }
+    },
+    {
+      "output": "r",
+      "input": {
+        "key": "O",
+        "shift": false
+      }
+    },
+    {
+      "output": "l",
+      "input": {
+        "key": "P",
+        "shift": false
+      }
+    },
+    {
+      "output": "'",
+      "input": {
+        "key": "Q",
+        "shift": false
+      }
+    },
+    {
+      "output": "p",
+      "input": {
+        "key": "R",
+        "shift": false
+      }
+    },
+    {
+      "output": "o",
+      "input": {
+        "key": "S",
+        "shift": false
+      }
+    },
+    {
+      "output": "y",
+      "input": {
+        "key": "T",
+        "shift": false
+      }
+    },
+    {
+      "output": "g",
+      "input": {
+        "key": "U",
+        "shift": false
+      }
+    },
+    {
+      "output": "k",
+      "input": {
+        "key": "V",
+        "shift": false
+      }
+    },
+    {
+      "output": ",",
+      "input": {
+        "key": "W",
+        "shift": false
+      }
+    },
+    {
+      "output": "q",
+      "input": {
+        "key": "X",
+        "shift": false
+      }
+    },
+    {
+      "output": "f",
+      "input": {
+        "key": "Y",
+        "shift": false
+      }
+    },
+    {
+      "output": ";",
+      "input": {
+        "key": "Z",
+        "shift": false
+      }
+    },
+    {
+      "output": "A",
+      "input": {
+        "key": "A",
+        "shift": true
+      }
+    },
+    {
+      "output": "X",
+      "input": {
+        "key": "B",
+        "shift": true
+      }
+    },
+    {
+      "output": "J",
+      "input": {
+        "key": "C",
+        "shift": true
+      }
+    },
+    {
+      "output": "E",
+      "input": {
+        "key": "D",
+        "shift": true
+      }
+    },
+    {
+      "output": ">",
+      "input": {
+        "key": "E",
+        "shift": true
+      }
+    },
+    {
+      "output": "U",
+      "input": {
+        "key": "F",
+        "shift": true
+      }
+    },
+    {
+      "output": "I",
+      "input": {
+        "key": "G",
+        "shift": true
+      }
+    },
+    {
+      "output": "D",
+      "input": {
+        "key": "H",
+        "shift": true
+      }
+    },
+    {
+      "output": "C",
+      "input": {
+        "key": "I",
+        "shift": true
+      }
+    },
+    {
+      "output": "H",
+      "input": {
+        "key": "J",
+        "shift": true
+      }
+    },
+    {
+      "output": "T",
+      "input": {
+        "key": "K",
+        "shift": true
+      }
+    },
+    {
+      "output": "N",
+      "input": {
+        "key": "L",
+        "shift": true
+      }
+    },
+    {
+      "output": "M",
+      "input": {
+        "key": "M",
+        "shift": true
+      }
+    },
+    {
+      "output": "B",
+      "input": {
+        "key": "N",
+        "shift": true
+      }
+    },
+    {
+      "output": "R",
+      "input": {
+        "key": "O",
+        "shift": true
+      }
+    },
+    {
+      "output": "L",
+      "input": {
+        "key": "P",
+        "shift": true
+      }
+    },
+    {
+      "output": "\"",
+      "input": {
+        "key": "Q",
+        "shift": true
+      }
+    },
+    {
+      "output": "P",
+      "input": {
+        "key": "R",
+        "shift": true
+      }
+    },
+    {
+      "output": "O",
+      "input": {
+        "key": "S",
+        "shift": true
+      }
+    },
+    {
+      "output": "Y",
+      "input": {
+        "key": "T",
+        "shift": true
+      }
+    },
+    {
+      "output": "G",
+      "input": {
+        "key": "U",
+        "shift": true
+      }
+    },
+    {
+      "output": "K",
+      "input": {
+        "key": "V",
+        "shift": true
+      }
+    },
+    {
+      "output": "<",
+      "input": {
+        "key": "W",
+        "shift": true
+      }
+    },
+    {
+      "output": "Q",
+      "input": {
+        "key": "X",
+        "shift": true
+      }
+    },
+    {
+      "output": "F",
+      "input": {
+        "key": "Y",
+        "shift": true
+      }
+    },
+    {
+      "output": ":",
+      "input": {
+        "key": "Z",
+        "shift": true
+      }
+    },
+    {
+      "output": "`",
+      "input": {
+        "key": "Backquote",
+        "shift": false
+      }
+    },
+    {
+      "output": "1",
+      "input": {
+        "key": "Digit1",
+        "shift": false
+      }
+    },
+    {
+      "output": "2",
+      "input": {
+        "key": "Digit2",
+        "shift": false
+      }
+    },
+    {
+      "output": "3",
+      "input": {
+        "key": "Digit3",
+        "shift": false
+      }
+    },
+    {
+      "output": "4",
+      "input": {
+        "key": "Digit4",
+        "shift": false
+      }
+    },
+    {
+      "output": "5",
+      "input": {
+        "key": "Digit5",
+        "shift": false
+      }
+    },
+    {
+      "output": "6",
+      "input": {
+        "key": "Digit6",
+        "shift": false
+      }
+    },
+    {
+      "output": "7",
+      "input": {
+        "key": "Digit7",
+        "shift": false
+      }
+    },
+    {
+      "output": "8",
+      "input": {
+        "key": "Digit8",
+        "shift": false
+      }
+    },
+    {
+      "output": "9",
+      "input": {
+        "key": "Digit9",
+        "shift": false
+      }
+    },
+    {
+      "output": "0",
+      "input": {
+        "key": "Digit0",
+        "shift": false
+      }
+    },
+    {
+      "output": "~",
+      "input": {
+        "key": "Backquote",
+        "shift": true
+      }
+    },
+    {
+      "output": "!",
+      "input": {
+        "key": "Digit1",
+        "shift": true
+      }
+    },
+    {
+      "output": "@",
+      "input": {
+        "key": "Digit2",
+        "shift": true
+      }
+    },
+    {
+      "output": "#",
+      "input": {
+        "key": "Digit3",
+        "shift": true
+      }
+    },
+    {
+      "output": "$",
+      "input": {
+        "key": "Digit4",
+        "shift": true
+      }
+    },
+    {
+      "output": "%",
+      "input": {
+        "key": "Digit5",
+        "shift": true
+      }
+    },
+    {
+      "output": "^",
+      "input": {
+        "key": "Digit6",
+        "shift": true
+      }
+    },
+    {
+      "output": "&",
+      "input": {
+        "key": "Digit7",
+        "shift": true
+      }
+    },
+    {
+      "output": "*",
+      "input": {
+        "key": "Digit8",
+        "shift": true
+      }
+    },
+    {
+      "output": "(",
+      "input": {
+        "key": "Digit9",
+        "shift": true
+      }
+    },
+    {
+      "output": ")",
+      "input": {
+        "key": "Digit0",
+        "shift": true
+      }
+    },
+    {
+      "output": "[",
+      "input": {
+        "key": "Minus",
+        "shift": false
+      }
+    },
+    {
+      "output": "]",
+      "input": {
+        "key": "Equal",
+        "shift": false
+      }
+    },
+    {
+      "output": "/",
+      "input": {
+        "key": "BracketLeft",
+        "shift": false
+      }
+    },
+    {
+      "output": "=",
+      "input": {
+        "key": "BracketRight",
+        "shift": false
+      }
+    },
+    {
+      "output": "s",
+      "input": {
+        "key": "Semicolon",
+        "shift": false
+      }
+    },
+    {
+      "output": "-",
+      "input": {
+        "key": "Quote",
+        "shift": false
+      }
+    },
+    {
+      "output": "\\",
+      "input": {
+        "key": "Backslash",
+        "shift": false
+      }
+    },
+    {
+      "output": "w",
+      "input": {
+        "key": "Comma",
+        "shift": false
+      }
+    },
+    {
+      "output": "v",
+      "input": {
+        "key": "Period",
+        "shift": false
+      }
+    },
+    {
+      "output": "z",
+      "input": {
+        "key": "Slash",
+        "shift": false
+      }
+    },
+    {
+      "output": "{",
+      "input": {
+        "key": "Minus",
+        "shift": true
+      }
+    },
+    {
+      "output": "}",
+      "input": {
+        "key": "Equal",
+        "shift": true
+      }
+    },
+    {
+      "output": "?",
+      "input": {
+        "key": "BracketLeft",
+        "shift": true
+      }
+    },
+    {
+      "output": "+",
+      "input": {
+        "key": "BracketRight",
+        "shift": true
+      }
+    },
+    {
+      "output": "S",
+      "input": {
+        "key": "Semicolon",
+        "shift": true
+      }
+    },
+    {
+      "output": "_",
+      "input": {
+        "key": "Quote",
+        "shift": true
+      }
+    },
+    {
+      "output": "|",
+      "input": {
+        "key": "Backslash",
+        "shift": true
+      }
+    },
+    {
+      "output": "W",
+      "input": {
+        "key": "Comma",
+        "shift": true
+      }
+    },
+    {
+      "output": "V",
+      "input": {
+        "key": "Period",
+        "shift": true
+      }
+    },
+    {
+      "output": "Z",
+      "input": {
+        "key": "Slash",
+        "shift": true
+      }
+    },
+    {
+      "output": " ",
+      "input": {
+        "key": "Space",
+        "shift": false
+      }
+    }
   ]
 }

--- a/src/assets/keyboard_layouts/eucalyn.json
+++ b/src/assets/keyboard_layouts/eucalyn.json
@@ -1,0 +1,673 @@
+{
+  "metadata": {
+    "name": "Eucalyn配列",
+    "url": "https://eucalyn.hatenadiary.jp/entry/about-eucalyn-layout"
+  },
+  "entries": [
+    {
+      "output": "a",
+      "input": {
+        "key": "A",
+        "shift": false
+      }
+    },
+    {
+      "output": "f",
+      "input": {
+        "key": "B",
+        "shift": false
+      }
+    },
+    {
+      "output": "c",
+      "input": {
+        "key": "C",
+        "shift": false
+      }
+    },
+    {
+      "output": "e",
+      "input": {
+        "key": "D",
+        "shift": false
+      }
+    },
+    {
+      "output": ",",
+      "input": {
+        "key": "E",
+        "shift": false
+      }
+    },
+    {
+      "output": "i",
+      "input": {
+        "key": "F",
+        "shift": false
+      }
+    },
+    {
+      "output": "u",
+      "input": {
+        "key": "G",
+        "shift": false
+      }
+    },
+    {
+      "output": "g",
+      "input": {
+        "key": "H",
+        "shift": false
+      }
+    },
+    {
+      "output": "d",
+      "input": {
+        "key": "I",
+        "shift": false
+      }
+    },
+    {
+      "output": "t",
+      "input": {
+        "key": "J",
+        "shift": false
+      }
+    },
+    {
+      "output": "k",
+      "input": {
+        "key": "K",
+        "shift": false
+      }
+    },
+    {
+      "output": "s",
+      "input": {
+        "key": "L",
+        "shift": false
+      }
+    },
+    {
+      "output": "h",
+      "input": {
+        "key": "M",
+        "shift": false
+      }
+    },
+    {
+      "output": "b",
+      "input": {
+        "key": "N",
+        "shift": false
+      }
+    },
+    {
+      "output": "y",
+      "input": {
+        "key": "O",
+        "shift": false
+      }
+    },
+    {
+      "output": "p",
+      "input": {
+        "key": "P",
+        "shift": false
+      }
+    },
+    {
+      "output": "q",
+      "input": {
+        "key": "Q",
+        "shift": false
+      }
+    },
+    {
+      "output": ".",
+      "input": {
+        "key": "R",
+        "shift": false
+      }
+    },
+    {
+      "output": "o",
+      "input": {
+        "key": "S",
+        "shift": false
+      }
+    },
+    {
+      "output": ";",
+      "input": {
+        "key": "T",
+        "shift": false
+      }
+    },
+    {
+      "output": "r",
+      "input": {
+        "key": "U",
+        "shift": false
+      }
+    },
+    {
+      "output": "v",
+      "input": {
+        "key": "V",
+        "shift": false
+      }
+    },
+    {
+      "output": "w",
+      "input": {
+        "key": "W",
+        "shift": false
+      }
+    },
+    {
+      "output": "x",
+      "input": {
+        "key": "X",
+        "shift": false
+      }
+    },
+    {
+      "output": "m",
+      "input": {
+        "key": "Y",
+        "shift": false
+      }
+    },
+    {
+      "output": "z",
+      "input": {
+        "key": "Z",
+        "shift": false
+      }
+    },
+    {
+      "output": "A",
+      "input": {
+        "key": "A",
+        "shift": true
+      }
+    },
+    {
+      "output": "F",
+      "input": {
+        "key": "B",
+        "shift": true
+      }
+    },
+    {
+      "output": "C",
+      "input": {
+        "key": "C",
+        "shift": true
+      }
+    },
+    {
+      "output": "E",
+      "input": {
+        "key": "D",
+        "shift": true
+      }
+    },
+    {
+      "output": "<",
+      "input": {
+        "key": "E",
+        "shift": true
+      }
+    },
+    {
+      "output": "I",
+      "input": {
+        "key": "F",
+        "shift": true
+      }
+    },
+    {
+      "output": "U",
+      "input": {
+        "key": "G",
+        "shift": true
+      }
+    },
+    {
+      "output": "G",
+      "input": {
+        "key": "H",
+        "shift": true
+      }
+    },
+    {
+      "output": "D",
+      "input": {
+        "key": "I",
+        "shift": true
+      }
+    },
+    {
+      "output": "T",
+      "input": {
+        "key": "J",
+        "shift": true
+      }
+    },
+    {
+      "output": "K",
+      "input": {
+        "key": "K",
+        "shift": true
+      }
+    },
+    {
+      "output": "S",
+      "input": {
+        "key": "L",
+        "shift": true
+      }
+    },
+    {
+      "output": "H",
+      "input": {
+        "key": "M",
+        "shift": true
+      }
+    },
+    {
+      "output": "B",
+      "input": {
+        "key": "N",
+        "shift": true
+      }
+    },
+    {
+      "output": "Y",
+      "input": {
+        "key": "O",
+        "shift": true
+      }
+    },
+    {
+      "output": "P",
+      "input": {
+        "key": "P",
+        "shift": true
+      }
+    },
+    {
+      "output": "Q",
+      "input": {
+        "key": "Q",
+        "shift": true
+      }
+    },
+    {
+      "output": ">",
+      "input": {
+        "key": "R",
+        "shift": true
+      }
+    },
+    {
+      "output": "O",
+      "input": {
+        "key": "S",
+        "shift": true
+      }
+    },
+    {
+      "output": ":",
+      "input": {
+        "key": "T",
+        "shift": true
+      }
+    },
+    {
+      "output": "R",
+      "input": {
+        "key": "U",
+        "shift": true
+      }
+    },
+    {
+      "output": "V",
+      "input": {
+        "key": "V",
+        "shift": true
+      }
+    },
+    {
+      "output": "W",
+      "input": {
+        "key": "W",
+        "shift": true
+      }
+    },
+    {
+      "output": "X",
+      "input": {
+        "key": "X",
+        "shift": true
+      }
+    },
+    {
+      "output": "M",
+      "input": {
+        "key": "Y",
+        "shift": true
+      }
+    },
+    {
+      "output": "Z",
+      "input": {
+        "key": "Z",
+        "shift": true
+      }
+    },
+    {
+      "output": "`",
+      "input": {
+        "key": "Backquote",
+        "shift": false
+      }
+    },
+    {
+      "output": "1",
+      "input": {
+        "key": "Digit1",
+        "shift": false
+      }
+    },
+    {
+      "output": "2",
+      "input": {
+        "key": "Digit2",
+        "shift": false
+      }
+    },
+    {
+      "output": "3",
+      "input": {
+        "key": "Digit3",
+        "shift": false
+      }
+    },
+    {
+      "output": "4",
+      "input": {
+        "key": "Digit4",
+        "shift": false
+      }
+    },
+    {
+      "output": "5",
+      "input": {
+        "key": "Digit5",
+        "shift": false
+      }
+    },
+    {
+      "output": "6",
+      "input": {
+        "key": "Digit6",
+        "shift": false
+      }
+    },
+    {
+      "output": "7",
+      "input": {
+        "key": "Digit7",
+        "shift": false
+      }
+    },
+    {
+      "output": "8",
+      "input": {
+        "key": "Digit8",
+        "shift": false
+      }
+    },
+    {
+      "output": "9",
+      "input": {
+        "key": "Digit9",
+        "shift": false
+      }
+    },
+    {
+      "output": "0",
+      "input": {
+        "key": "Digit0",
+        "shift": false
+      }
+    },
+    {
+      "output": "~",
+      "input": {
+        "key": "Backquote",
+        "shift": true
+      }
+    },
+    {
+      "output": "!",
+      "input": {
+        "key": "Digit1",
+        "shift": true
+      }
+    },
+    {
+      "output": "@",
+      "input": {
+        "key": "Digit2",
+        "shift": true
+      }
+    },
+    {
+      "output": "#",
+      "input": {
+        "key": "Digit3",
+        "shift": true
+      }
+    },
+    {
+      "output": "$",
+      "input": {
+        "key": "Digit4",
+        "shift": true
+      }
+    },
+    {
+      "output": "%",
+      "input": {
+        "key": "Digit5",
+        "shift": true
+      }
+    },
+    {
+      "output": "^",
+      "input": {
+        "key": "Digit6",
+        "shift": true
+      }
+    },
+    {
+      "output": "&",
+      "input": {
+        "key": "Digit7",
+        "shift": true
+      }
+    },
+    {
+      "output": "*",
+      "input": {
+        "key": "Digit8",
+        "shift": true
+      }
+    },
+    {
+      "output": "(",
+      "input": {
+        "key": "Digit9",
+        "shift": true
+      }
+    },
+    {
+      "output": ")",
+      "input": {
+        "key": "Digit0",
+        "shift": true
+      }
+    },
+    {
+      "output": "-",
+      "input": {
+        "key": "Minus",
+        "shift": false
+      }
+    },
+    {
+      "output": "=",
+      "input": {
+        "key": "Equal",
+        "shift": false
+      }
+    },
+    {
+      "output": "[",
+      "input": {
+        "key": "BracketLeft",
+        "shift": false
+      }
+    },
+    {
+      "output": "]",
+      "input": {
+        "key": "BracketRight",
+        "shift": false
+      }
+    },
+    {
+      "output": "n",
+      "input": {
+        "key": "Semicolon",
+        "shift": false
+      }
+    },
+    {
+      "output": "'",
+      "input": {
+        "key": "Quote",
+        "shift": false
+      }
+    },
+    {
+      "output": "\\",
+      "input": {
+        "key": "Backslash",
+        "shift": false
+      }
+    },
+    {
+      "output": "j",
+      "input": {
+        "key": "Comma",
+        "shift": false
+      }
+    },
+    {
+      "output": "l",
+      "input": {
+        "key": "Period",
+        "shift": false
+      }
+    },
+    {
+      "output": "/",
+      "input": {
+        "key": "Slash",
+        "shift": false
+      }
+    },
+    {
+      "output": "_",
+      "input": {
+        "key": "Minus",
+        "shift": true
+      }
+    },
+    {
+      "output": "+",
+      "input": {
+        "key": "Equal",
+        "shift": true
+      }
+    },
+    {
+      "output": "{",
+      "input": {
+        "key": "BracketLeft",
+        "shift": true
+      }
+    },
+    {
+      "output": "}",
+      "input": {
+        "key": "BracketRight",
+        "shift": true
+      }
+    },
+    {
+      "output": "N",
+      "input": {
+        "key": "Semicolon",
+        "shift": true
+      }
+    },
+    {
+      "output": "\"",
+      "input": {
+        "key": "Quote",
+        "shift": true
+      }
+    },
+    {
+      "output": "|",
+      "input": {
+        "key": "Backslash",
+        "shift": true
+      }
+    },
+    {
+      "output": "J",
+      "input": {
+        "key": "Comma",
+        "shift": true
+      }
+    },
+    {
+      "output": "L",
+      "input": {
+        "key": "Period",
+        "shift": true
+      }
+    },
+    {
+      "output": "?",
+      "input": {
+        "key": "Slash",
+        "shift": true
+      }
+    },
+    {
+      "output": " ",
+      "input": {
+        "key": "Space",
+        "shift": false
+      }
+    }
+  ]
+}

--- a/src/assets/keyboard_layouts/onishi.json
+++ b/src/assets/keyboard_layouts/onishi.json
@@ -1,0 +1,673 @@
+{
+  "metadata": {
+    "name": "大西配列",
+    "url": "https://o24.works/layout/"
+  },
+  "entries": [
+    {
+      "output": "e",
+      "input": {
+        "key": "A",
+        "shift": false
+      }
+    },
+    {
+      "output": ";",
+      "input": {
+        "key": "B",
+        "shift": false
+      }
+    },
+    {
+      "output": "c",
+      "input": {
+        "key": "C",
+        "shift": false
+      }
+    },
+    {
+      "output": "a",
+      "input": {
+        "key": "D",
+        "shift": false
+      }
+    },
+    {
+      "output": "u",
+      "input": {
+        "key": "E",
+        "shift": false
+      }
+    },
+    {
+      "output": "o",
+      "input": {
+        "key": "F",
+        "shift": false
+      }
+    },
+    {
+      "output": "-",
+      "input": {
+        "key": "G",
+        "shift": false
+      }
+    },
+    {
+      "output": "k",
+      "input": {
+        "key": "H",
+        "shift": false
+      }
+    },
+    {
+      "output": "r",
+      "input": {
+        "key": "I",
+        "shift": false
+      }
+    },
+    {
+      "output": "t",
+      "input": {
+        "key": "J",
+        "shift": false
+      }
+    },
+    {
+      "output": "n",
+      "input": {
+        "key": "K",
+        "shift": false
+      }
+    },
+    {
+      "output": "s",
+      "input": {
+        "key": "L",
+        "shift": false
+      }
+    },
+    {
+      "output": "d",
+      "input": {
+        "key": "M",
+        "shift": false
+      }
+    },
+    {
+      "output": "g",
+      "input": {
+        "key": "N",
+        "shift": false
+      }
+    },
+    {
+      "output": "y",
+      "input": {
+        "key": "O",
+        "shift": false
+      }
+    },
+    {
+      "output": "p",
+      "input": {
+        "key": "P",
+        "shift": false
+      }
+    },
+    {
+      "output": "q",
+      "input": {
+        "key": "Q",
+        "shift": false
+      }
+    },
+    {
+      "output": ",",
+      "input": {
+        "key": "R",
+        "shift": false
+      }
+    },
+    {
+      "output": "i",
+      "input": {
+        "key": "S",
+        "shift": false
+      }
+    },
+    {
+      "output": ".",
+      "input": {
+        "key": "T",
+        "shift": false
+      }
+    },
+    {
+      "output": "w",
+      "input": {
+        "key": "U",
+        "shift": false
+      }
+    },
+    {
+      "output": "v",
+      "input": {
+        "key": "V",
+        "shift": false
+      }
+    },
+    {
+      "output": "l",
+      "input": {
+        "key": "W",
+        "shift": false
+      }
+    },
+    {
+      "output": "x",
+      "input": {
+        "key": "X",
+        "shift": false
+      }
+    },
+    {
+      "output": "f",
+      "input": {
+        "key": "Y",
+        "shift": false
+      }
+    },
+    {
+      "output": "z",
+      "input": {
+        "key": "Z",
+        "shift": false
+      }
+    },
+    {
+      "output": "E",
+      "input": {
+        "key": "A",
+        "shift": true
+      }
+    },
+    {
+      "output": ":",
+      "input": {
+        "key": "B",
+        "shift": true
+      }
+    },
+    {
+      "output": "C",
+      "input": {
+        "key": "C",
+        "shift": true
+      }
+    },
+    {
+      "output": "A",
+      "input": {
+        "key": "D",
+        "shift": true
+      }
+    },
+    {
+      "output": "U",
+      "input": {
+        "key": "E",
+        "shift": true
+      }
+    },
+    {
+      "output": "O",
+      "input": {
+        "key": "F",
+        "shift": true
+      }
+    },
+    {
+      "output": "_",
+      "input": {
+        "key": "G",
+        "shift": true
+      }
+    },
+    {
+      "output": "K",
+      "input": {
+        "key": "H",
+        "shift": true
+      }
+    },
+    {
+      "output": "R",
+      "input": {
+        "key": "I",
+        "shift": true
+      }
+    },
+    {
+      "output": "T",
+      "input": {
+        "key": "J",
+        "shift": true
+      }
+    },
+    {
+      "output": "N",
+      "input": {
+        "key": "K",
+        "shift": true
+      }
+    },
+    {
+      "output": "S",
+      "input": {
+        "key": "L",
+        "shift": true
+      }
+    },
+    {
+      "output": "D",
+      "input": {
+        "key": "M",
+        "shift": true
+      }
+    },
+    {
+      "output": "G",
+      "input": {
+        "key": "N",
+        "shift": true
+      }
+    },
+    {
+      "output": "Y",
+      "input": {
+        "key": "O",
+        "shift": true
+      }
+    },
+    {
+      "output": "P",
+      "input": {
+        "key": "P",
+        "shift": true
+      }
+    },
+    {
+      "output": "Q",
+      "input": {
+        "key": "Q",
+        "shift": true
+      }
+    },
+    {
+      "output": "<",
+      "input": {
+        "key": "R",
+        "shift": true
+      }
+    },
+    {
+      "output": "I",
+      "input": {
+        "key": "S",
+        "shift": true
+      }
+    },
+    {
+      "output": ">",
+      "input": {
+        "key": "T",
+        "shift": true
+      }
+    },
+    {
+      "output": "W",
+      "input": {
+        "key": "U",
+        "shift": true
+      }
+    },
+    {
+      "output": "V",
+      "input": {
+        "key": "V",
+        "shift": true
+      }
+    },
+    {
+      "output": "L",
+      "input": {
+        "key": "W",
+        "shift": true
+      }
+    },
+    {
+      "output": "X",
+      "input": {
+        "key": "X",
+        "shift": true
+      }
+    },
+    {
+      "output": "F",
+      "input": {
+        "key": "Y",
+        "shift": true
+      }
+    },
+    {
+      "output": "Z",
+      "input": {
+        "key": "Z",
+        "shift": true
+      }
+    },
+    {
+      "output": "`",
+      "input": {
+        "key": "Backquote",
+        "shift": false
+      }
+    },
+    {
+      "output": "1",
+      "input": {
+        "key": "Digit1",
+        "shift": false
+      }
+    },
+    {
+      "output": "2",
+      "input": {
+        "key": "Digit2",
+        "shift": false
+      }
+    },
+    {
+      "output": "3",
+      "input": {
+        "key": "Digit3",
+        "shift": false
+      }
+    },
+    {
+      "output": "4",
+      "input": {
+        "key": "Digit4",
+        "shift": false
+      }
+    },
+    {
+      "output": "5",
+      "input": {
+        "key": "Digit5",
+        "shift": false
+      }
+    },
+    {
+      "output": "6",
+      "input": {
+        "key": "Digit6",
+        "shift": false
+      }
+    },
+    {
+      "output": "7",
+      "input": {
+        "key": "Digit7",
+        "shift": false
+      }
+    },
+    {
+      "output": "8",
+      "input": {
+        "key": "Digit8",
+        "shift": false
+      }
+    },
+    {
+      "output": "9",
+      "input": {
+        "key": "Digit9",
+        "shift": false
+      }
+    },
+    {
+      "output": "0",
+      "input": {
+        "key": "Digit0",
+        "shift": false
+      }
+    },
+    {
+      "output": "~",
+      "input": {
+        "key": "Backquote",
+        "shift": true
+      }
+    },
+    {
+      "output": "!",
+      "input": {
+        "key": "Digit1",
+        "shift": true
+      }
+    },
+    {
+      "output": "@",
+      "input": {
+        "key": "Digit2",
+        "shift": true
+      }
+    },
+    {
+      "output": "#",
+      "input": {
+        "key": "Digit3",
+        "shift": true
+      }
+    },
+    {
+      "output": "$",
+      "input": {
+        "key": "Digit4",
+        "shift": true
+      }
+    },
+    {
+      "output": "%",
+      "input": {
+        "key": "Digit5",
+        "shift": true
+      }
+    },
+    {
+      "output": "^",
+      "input": {
+        "key": "Digit6",
+        "shift": true
+      }
+    },
+    {
+      "output": "&",
+      "input": {
+        "key": "Digit7",
+        "shift": true
+      }
+    },
+    {
+      "output": "*",
+      "input": {
+        "key": "Digit8",
+        "shift": true
+      }
+    },
+    {
+      "output": "(",
+      "input": {
+        "key": "Digit9",
+        "shift": true
+      }
+    },
+    {
+      "output": ")",
+      "input": {
+        "key": "Digit0",
+        "shift": true
+      }
+    },
+    {
+      "output": "-",
+      "input": {
+        "key": "Minus",
+        "shift": false
+      }
+    },
+    {
+      "output": "=",
+      "input": {
+        "key": "Equal",
+        "shift": false
+      }
+    },
+    {
+      "output": "[",
+      "input": {
+        "key": "BracketLeft",
+        "shift": false
+      }
+    },
+    {
+      "output": "]",
+      "input": {
+        "key": "BracketRight",
+        "shift": false
+      }
+    },
+    {
+      "output": "h",
+      "input": {
+        "key": "Semicolon",
+        "shift": false
+      }
+    },
+    {
+      "output": "'",
+      "input": {
+        "key": "Quote",
+        "shift": false
+      }
+    },
+    {
+      "output": "\\",
+      "input": {
+        "key": "Backslash",
+        "shift": false
+      }
+    },
+    {
+      "output": "m",
+      "input": {
+        "key": "Comma",
+        "shift": false
+      }
+    },
+    {
+      "output": "j",
+      "input": {
+        "key": "Period",
+        "shift": false
+      }
+    },
+    {
+      "output": "b",
+      "input": {
+        "key": "Slash",
+        "shift": false
+      }
+    },
+    {
+      "output": "_",
+      "input": {
+        "key": "Minus",
+        "shift": true
+      }
+    },
+    {
+      "output": "+",
+      "input": {
+        "key": "Equal",
+        "shift": true
+      }
+    },
+    {
+      "output": "{",
+      "input": {
+        "key": "BracketLeft",
+        "shift": true
+      }
+    },
+    {
+      "output": "}",
+      "input": {
+        "key": "BracketRight",
+        "shift": true
+      }
+    },
+    {
+      "output": "H",
+      "input": {
+        "key": "Semicolon",
+        "shift": true
+      }
+    },
+    {
+      "output": "\"",
+      "input": {
+        "key": "Quote",
+        "shift": true
+      }
+    },
+    {
+      "output": "|",
+      "input": {
+        "key": "Backslash",
+        "shift": true
+      }
+    },
+    {
+      "output": "M",
+      "input": {
+        "key": "Comma",
+        "shift": true
+      }
+    },
+    {
+      "output": "J",
+      "input": {
+        "key": "Period",
+        "shift": true
+      }
+    },
+    {
+      "output": "B",
+      "input": {
+        "key": "Slash",
+        "shift": true
+      }
+    },
+    {
+      "output": " ",
+      "input": {
+        "key": "Space",
+        "shift": false
+      }
+    }
+  ]
+}

--- a/src/assets/keyboard_layouts/qwerty_jis.json
+++ b/src/assets/keyboard_layouts/qwerty_jis.json
@@ -1,5 +1,5 @@
 {
-  "name": "QWERTY JIS",
+  "metadata": { "name": "QWERTY JIS", "url": "" },
   "entries": [
     { "output": "a", "input": { "key": "A", "shift": false } },
     { "output": "b", "input": { "key": "B", "shift": false } },

--- a/src/assets/keyboard_layouts/qwerty_us.json
+++ b/src/assets/keyboard_layouts/qwerty_us.json
@@ -1,5 +1,5 @@
 {
-  "name": "QWERTY US",
+  "metadata": { "name": "QWERTY US", "url": "" },
   "entries": [
     { "output": "a", "input": { "key": "A", "shift": false } },
     { "output": "b", "input": { "key": "B", "shift": false } },

--- a/src/assets/keyboard_layouts/tomisuke_jis.json
+++ b/src/assets/keyboard_layouts/tomisuke_jis.json
@@ -1,0 +1,701 @@
+{
+  "metadata": {
+    "name": "Tomisuke配列 (JIS)",
+    "url": "https://tomisuke.com/tomisuke-keyboard-layout/"
+  },
+  "entries": [
+    {
+      "output": "a",
+      "input": {
+        "key": "A",
+        "shift": false
+      }
+    },
+    {
+      "output": "q",
+      "input": {
+        "key": "B",
+        "shift": false
+      }
+    },
+    {
+      "output": "v",
+      "input": {
+        "key": "C",
+        "shift": false
+      }
+    },
+    {
+      "output": "e",
+      "input": {
+        "key": "D",
+        "shift": false
+      }
+    },
+    {
+      "output": ".",
+      "input": {
+        "key": "E",
+        "shift": false
+      }
+    },
+    {
+      "output": "i",
+      "input": {
+        "key": "F",
+        "shift": false
+      }
+    },
+    {
+      "output": "u",
+      "input": {
+        "key": "G",
+        "shift": false
+      }
+    },
+    {
+      "output": "g",
+      "input": {
+        "key": "H",
+        "shift": false
+      }
+    },
+    {
+      "output": "d",
+      "input": {
+        "key": "I",
+        "shift": false
+      }
+    },
+    {
+      "output": "n",
+      "input": {
+        "key": "J",
+        "shift": false
+      }
+    },
+    {
+      "output": "t",
+      "input": {
+        "key": "K",
+        "shift": false
+      }
+    },
+    {
+      "output": "s",
+      "input": {
+        "key": "L",
+        "shift": false
+      }
+    },
+    {
+      "output": "h",
+      "input": {
+        "key": "M",
+        "shift": false
+      }
+    },
+    {
+      "output": "j",
+      "input": {
+        "key": "N",
+        "shift": false
+      }
+    },
+    {
+      "output": "y",
+      "input": {
+        "key": "O",
+        "shift": false
+      }
+    },
+    {
+      "output": "p",
+      "input": {
+        "key": "P",
+        "shift": false
+      }
+    },
+    {
+      "output": "1",
+      "input": {
+        "key": "Q",
+        "shift": false
+      }
+    },
+    {
+      "output": "-",
+      "input": {
+        "key": "R",
+        "shift": false
+      }
+    },
+    {
+      "output": "o",
+      "input": {
+        "key": "S",
+        "shift": false
+      }
+    },
+    {
+      "output": ";",
+      "input": {
+        "key": "T",
+        "shift": false
+      }
+    },
+    {
+      "output": "r",
+      "input": {
+        "key": "U",
+        "shift": false
+      }
+    },
+    {
+      "output": "w",
+      "input": {
+        "key": "V",
+        "shift": false
+      }
+    },
+    {
+      "output": ",",
+      "input": {
+        "key": "W",
+        "shift": false
+      }
+    },
+    {
+      "output": "c",
+      "input": {
+        "key": "X",
+        "shift": false
+      }
+    },
+    {
+      "output": "l",
+      "input": {
+        "key": "Y",
+        "shift": false
+      }
+    },
+    {
+      "output": "x",
+      "input": {
+        "key": "Z",
+        "shift": false
+      }
+    },
+    {
+      "output": "A",
+      "input": {
+        "key": "A",
+        "shift": true
+      }
+    },
+    {
+      "output": "Q",
+      "input": {
+        "key": "B",
+        "shift": true
+      }
+    },
+    {
+      "output": "V",
+      "input": {
+        "key": "C",
+        "shift": true
+      }
+    },
+    {
+      "output": "E",
+      "input": {
+        "key": "D",
+        "shift": true
+      }
+    },
+    {
+      "output": ">",
+      "input": {
+        "key": "E",
+        "shift": true
+      }
+    },
+    {
+      "output": "I",
+      "input": {
+        "key": "F",
+        "shift": true
+      }
+    },
+    {
+      "output": "U",
+      "input": {
+        "key": "G",
+        "shift": true
+      }
+    },
+    {
+      "output": "G",
+      "input": {
+        "key": "H",
+        "shift": true
+      }
+    },
+    {
+      "output": "D",
+      "input": {
+        "key": "I",
+        "shift": true
+      }
+    },
+    {
+      "output": "N",
+      "input": {
+        "key": "J",
+        "shift": true
+      }
+    },
+    {
+      "output": "T",
+      "input": {
+        "key": "K",
+        "shift": true
+      }
+    },
+    {
+      "output": "S",
+      "input": {
+        "key": "L",
+        "shift": true
+      }
+    },
+    {
+      "output": "H",
+      "input": {
+        "key": "M",
+        "shift": true
+      }
+    },
+    {
+      "output": "J",
+      "input": {
+        "key": "N",
+        "shift": true
+      }
+    },
+    {
+      "output": "Y",
+      "input": {
+        "key": "O",
+        "shift": true
+      }
+    },
+    {
+      "output": "P",
+      "input": {
+        "key": "P",
+        "shift": true
+      }
+    },
+    {
+      "output": "!",
+      "input": {
+        "key": "Q",
+        "shift": true
+      }
+    },
+    {
+      "output": "=",
+      "input": {
+        "key": "R",
+        "shift": true
+      }
+    },
+    {
+      "output": "O",
+      "input": {
+        "key": "S",
+        "shift": true
+      }
+    },
+    {
+      "output": "+",
+      "input": {
+        "key": "T",
+        "shift": true
+      }
+    },
+    {
+      "output": "R",
+      "input": {
+        "key": "U",
+        "shift": true
+      }
+    },
+    {
+      "output": "W",
+      "input": {
+        "key": "V",
+        "shift": true
+      }
+    },
+    {
+      "output": "<",
+      "input": {
+        "key": "W",
+        "shift": true
+      }
+    },
+    {
+      "output": "C",
+      "input": {
+        "key": "X",
+        "shift": true
+      }
+    },
+    {
+      "output": "L",
+      "input": {
+        "key": "Y",
+        "shift": true
+      }
+    },
+    {
+      "output": "X",
+      "input": {
+        "key": "Z",
+        "shift": true
+      }
+    },
+    {
+      "output": "`",
+      "input": {
+        "key": "Backquote",
+        "shift": false
+      }
+    },
+    {
+      "output": "@",
+      "input": {
+        "key": "Digit1",
+        "shift": false
+      }
+    },
+    {
+      "output": "2",
+      "input": {
+        "key": "Digit2",
+        "shift": false
+      }
+    },
+    {
+      "output": "3",
+      "input": {
+        "key": "Digit3",
+        "shift": false
+      }
+    },
+    {
+      "output": "4",
+      "input": {
+        "key": "Digit4",
+        "shift": false
+      }
+    },
+    {
+      "output": "5",
+      "input": {
+        "key": "Digit5",
+        "shift": false
+      }
+    },
+    {
+      "output": "6",
+      "input": {
+        "key": "Digit6",
+        "shift": false
+      }
+    },
+    {
+      "output": "7",
+      "input": {
+        "key": "Digit7",
+        "shift": false
+      }
+    },
+    {
+      "output": "8",
+      "input": {
+        "key": "Digit8",
+        "shift": false
+      }
+    },
+    {
+      "output": "9",
+      "input": {
+        "key": "Digit9",
+        "shift": false
+      }
+    },
+    {
+      "output": "0",
+      "input": {
+        "key": "Digit0",
+        "shift": false
+      }
+    },
+    {
+      "output": "~",
+      "input": {
+        "key": "Backquote",
+        "shift": true
+      }
+    },
+    {
+      "output": "`",
+      "input": {
+        "key": "Digit1",
+        "shift": true
+      }
+    },
+    {
+      "output": "\"",
+      "input": {
+        "key": "Digit2",
+        "shift": true
+      }
+    },
+    {
+      "output": "#",
+      "input": {
+        "key": "Digit3",
+        "shift": true
+      }
+    },
+    {
+      "output": "$",
+      "input": {
+        "key": "Digit4",
+        "shift": true
+      }
+    },
+    {
+      "output": "%",
+      "input": {
+        "key": "Digit5",
+        "shift": true
+      }
+    },
+    {
+      "output": "&",
+      "input": {
+        "key": "Digit6",
+        "shift": true
+      }
+    },
+    {
+      "output": "",
+      "input": {
+        "key": "Digit7",
+        "shift": true
+      }
+    },
+    {
+      "output": "(",
+      "input": {
+        "key": "Digit8",
+        "shift": true
+      }
+    },
+    {
+      "output": ")",
+      "input": {
+        "key": "Digit9",
+        "shift": true
+      }
+    },
+    {
+      "output": "",
+      "input": {
+        "key": "Digit0",
+        "shift": true
+      }
+    },
+    {
+      "output": "]",
+      "input": {
+        "key": "Minus",
+        "shift": false
+      }
+    },
+    {
+      "output": "^",
+      "input": {
+        "key": "Equal",
+        "shift": false
+      }
+    },
+    {
+      "output": "[",
+      "input": {
+        "key": "BracketLeft",
+        "shift": false
+      }
+    },
+    {
+      "output": "\\",
+      "input": {
+        "key": "BracketRight",
+        "shift": false
+      }
+    },
+    {
+      "output": "k",
+      "input": {
+        "key": "Semicolon",
+        "shift": false
+      }
+    },
+    {
+      "output": "f",
+      "input": {
+        "key": "Quote",
+        "shift": false
+      }
+    },
+    {
+      "output": ":",
+      "input": {
+        "key": "Backslash",
+        "shift": false
+      }
+    },
+    {
+      "output": "m",
+      "input": {
+        "key": "Comma",
+        "shift": false
+      }
+    },
+    {
+      "output": "b",
+      "input": {
+        "key": "Period",
+        "shift": false
+      }
+    },
+    {
+      "output": "z",
+      "input": {
+        "key": "Slash",
+        "shift": false
+      }
+    },
+    {
+      "output": "_",
+      "input": {
+        "key": "Minus",
+        "shift": true
+      }
+    },
+    {
+      "output": "+",
+      "input": {
+        "key": "Equal",
+        "shift": true
+      }
+    },
+    {
+      "output": "{",
+      "input": {
+        "key": "BracketLeft",
+        "shift": true
+      }
+    },
+    {
+      "output": "_",
+      "input": {
+        "key": "BracketRight",
+        "shift": true
+      }
+    },
+    {
+      "output": "K",
+      "input": {
+        "key": "Semicolon",
+        "shift": true
+      }
+    },
+    {
+      "output": "F",
+      "input": {
+        "key": "Quote",
+        "shift": true
+      }
+    },
+    {
+      "output": "*",
+      "input": {
+        "key": "Backslash",
+        "shift": true
+      }
+    },
+    {
+      "output": "M",
+      "input": {
+        "key": "Comma",
+        "shift": true
+      }
+    },
+    {
+      "output": "B",
+      "input": {
+        "key": "Period",
+        "shift": true
+      }
+    },
+    {
+      "output": "Z",
+      "input": {
+        "key": "Slash",
+        "shift": true
+      }
+    },
+    {
+      "output": " ",
+      "input": {
+        "key": "Space",
+        "shift": false
+      }
+    },
+    {
+      "output": "/",
+      "input": {
+        "key": "JpnRo",
+        "shift": false
+      }
+    },
+    {
+      "output": "?",
+      "input": {
+        "key": "JpnRo",
+        "shift": true
+      }
+    },
+    {
+      "output": "\\",
+      "input": {
+        "key": "JpnYen",
+        "shift": false
+      }
+    },
+    {
+      "output": "|",
+      "input": {
+        "key": "JpnYen",
+        "shift": true
+      }
+    }
+  ]
+}

--- a/src/assets/rules/jis_kana.json
+++ b/src/assets/rules/jis_kana.json
@@ -1,4 +1,8 @@
 {
+  "metadata": {
+    "name": "JIS かな入力",
+    "url": ""
+  },
   "entries": [
     {
       "input": [

--- a/src/assets/rules/naginatashiki_v15.json
+++ b/src/assets/rules/naginatashiki_v15.json
@@ -1,690 +1,1348 @@
 {
-  "backspaces": [{ "keys": ["U"] }],
+  "metadata": {
+    "name": "薙刀式 v15",
+    "url": "https://oookaworks.seesaa.net/article/500180437.html"
+  },
+  "backspaces": [
+    {
+      "keys": ["U"]
+    }
+  ],
   "entries": [
     {
-      "input": [{ "keys": ["Q"] }],
+      "input": [
+        {
+          "keys": ["Q"]
+        }
+      ],
       "output": "ヴ"
     },
     {
-      "input": [{ "keys": ["W"] }],
+      "input": [
+        {
+          "keys": ["W"]
+        }
+      ],
       "output": "き"
     },
     {
-      "input": [{ "keys": ["E"] }],
+      "input": [
+        {
+          "keys": ["E"]
+        }
+      ],
       "output": "て"
     },
     {
-      "input": [{ "keys": ["R"] }],
+      "input": [
+        {
+          "keys": ["R"]
+        }
+      ],
       "output": "し"
     },
     {
-      "input": [{ "keys": ["I"] }],
+      "input": [
+        {
+          "keys": ["I"]
+        }
+      ],
       "output": "る"
     },
     {
-      "input": [{ "keys": ["O"] }],
+      "input": [
+        {
+          "keys": ["O"]
+        }
+      ],
       "output": "す"
     },
     {
-      "input": [{ "keys": ["P"] }],
+      "input": [
+        {
+          "keys": ["P"]
+        }
+      ],
       "output": "へ"
     },
     {
-      "input": [{ "keys": ["A"] }],
+      "input": [
+        {
+          "keys": ["A"]
+        }
+      ],
       "output": "ろ"
     },
     {
-      "input": [{ "keys": ["S"] }],
+      "input": [
+        {
+          "keys": ["S"]
+        }
+      ],
       "output": "け"
     },
     {
-      "input": [{ "keys": ["D"] }],
+      "input": [
+        {
+          "keys": ["D"]
+        }
+      ],
       "output": "と"
     },
     {
-      "input": [{ "keys": ["F"] }],
+      "input": [
+        {
+          "keys": ["F"]
+        }
+      ],
       "output": "か"
     },
     {
-      "input": [{ "keys": ["G"] }],
+      "input": [
+        {
+          "keys": ["G"]
+        }
+      ],
       "output": "っ"
     },
     {
-      "input": [{ "keys": ["H"] }],
+      "input": [
+        {
+          "keys": ["H"]
+        }
+      ],
       "output": "く"
     },
     {
-      "input": [{ "keys": ["J"] }],
+      "input": [
+        {
+          "keys": ["J"]
+        }
+      ],
       "output": "あ"
     },
     {
-      "input": [{ "keys": ["K"] }],
+      "input": [
+        {
+          "keys": ["K"]
+        }
+      ],
       "output": "い"
     },
     {
-      "input": [{ "keys": ["L"] }],
+      "input": [
+        {
+          "keys": ["L"]
+        }
+      ],
       "output": "う"
     },
     {
-      "input": [{ "keys": ["Semicolon"] }],
+      "input": [
+        {
+          "keys": ["Semicolon"]
+        }
+      ],
       "output": "ー"
     },
     {
-      "input": [{ "keys": ["Z"] }],
+      "input": [
+        {
+          "keys": ["Z"]
+        }
+      ],
       "output": "ほ"
     },
     {
-      "input": [{ "keys": ["X"] }],
+      "input": [
+        {
+          "keys": ["X"]
+        }
+      ],
       "output": "ひ"
     },
     {
-      "input": [{ "keys": ["C"] }],
+      "input": [
+        {
+          "keys": ["C"]
+        }
+      ],
       "output": "は"
     },
     {
-      "input": [{ "keys": ["V"] }],
+      "input": [
+        {
+          "keys": ["V"]
+        }
+      ],
       "output": "こ"
     },
     {
-      "input": [{ "keys": ["B"] }],
+      "input": [
+        {
+          "keys": ["B"]
+        }
+      ],
       "output": "そ"
     },
     {
-      "input": [{ "keys": ["N"] }],
+      "input": [
+        {
+          "keys": ["N"]
+        }
+      ],
       "output": "た"
     },
     {
-      "input": [{ "keys": ["M"] }],
+      "input": [
+        {
+          "keys": ["M"]
+        }
+      ],
       "output": "な"
     },
     {
-      "input": [{ "keys": ["Comma"] }],
+      "input": [
+        {
+          "keys": ["Comma"]
+        }
+      ],
       "output": "ん"
     },
     {
-      "input": [{ "keys": ["Period"] }],
+      "input": [
+        {
+          "keys": ["Period"]
+        }
+      ],
       "output": "ら"
     },
     {
-      "input": [{ "keys": ["Slash"] }],
+      "input": [
+        {
+          "keys": ["Slash"]
+        }
+      ],
       "output": "れ"
     },
     {
-      "input": [{ "keys": ["W"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["W"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "ぬ"
     },
     {
-      "input": [{ "keys": ["E"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["E"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "り"
     },
     {
-      "input": [{ "keys": ["R"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["R"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "ね"
     },
     {
-      "input": [{ "keys": ["U"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["U"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "さ"
     },
     {
-      "input": [{ "keys": ["I"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["I"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "よ"
     },
     {
-      "input": [{ "keys": ["O"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["O"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "え"
     },
     {
-      "input": [{ "keys": ["P"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["P"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "ゆ"
     },
     {
-      "input": [{ "keys": ["A"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["A"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "せ"
     },
     {
-      "input": [{ "keys": ["S"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["S"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "め"
     },
     {
-      "input": [{ "keys": ["D"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["D"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "に"
     },
     {
-      "input": [{ "keys": ["F"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["F"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "ま"
     },
     {
-      "input": [{ "keys": ["G"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["G"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "ち"
     },
     {
-      "input": [{ "keys": ["H"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["H"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "や"
     },
     {
-      "input": [{ "keys": ["J"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["J"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "の"
     },
     {
-      "input": [{ "keys": ["K"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["K"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "も"
     },
     {
-      "input": [{ "keys": ["L"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["L"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "つ"
     },
     {
-      "input": [{ "keys": ["Semicolon"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["Semicolon"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "ふ"
     },
     {
-      "input": [{ "keys": ["C"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["C"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "を"
     },
     {
-      "input": [{ "keys": ["V"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["V"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "、"
     },
     {
-      "input": [{ "keys": ["B"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["B"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "み"
     },
     {
-      "input": [{ "keys": ["N"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["N"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "お"
     },
     {
-      "input": [{ "keys": ["M"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["M"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "。"
     },
     {
-      "input": [{ "keys": ["Comma"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["Comma"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "む"
     },
     {
-      "input": [{ "keys": ["Period"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["Period"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "わ"
     },
     {
-      "input": [{ "keys": ["W", "J"] }],
+      "input": [
+        {
+          "keys": ["W", "J"]
+        }
+      ],
       "output": "ぎ"
     },
     {
-      "input": [{ "keys": ["E", "J"] }],
+      "input": [
+        {
+          "keys": ["E", "J"]
+        }
+      ],
       "output": "で"
     },
     {
-      "input": [{ "keys": ["R", "J"] }],
+      "input": [
+        {
+          "keys": ["R", "J"]
+        }
+      ],
       "output": "じ"
     },
     {
-      "input": [{ "keys": ["S", "J"] }],
+      "input": [
+        {
+          "keys": ["S", "J"]
+        }
+      ],
       "output": "げ"
     },
     {
-      "input": [{ "keys": ["D", "J"] }],
+      "input": [
+        {
+          "keys": ["D", "J"]
+        }
+      ],
       "output": "ど"
     },
     {
-      "input": [{ "keys": ["F", "J"] }],
+      "input": [
+        {
+          "keys": ["F", "J"]
+        }
+      ],
       "output": "が"
     },
     {
-      "input": [{ "keys": ["Z", "J"] }],
+      "input": [
+        {
+          "keys": ["Z", "J"]
+        }
+      ],
       "output": "ぼ"
     },
     {
-      "input": [{ "keys": ["X", "J"] }],
+      "input": [
+        {
+          "keys": ["X", "J"]
+        }
+      ],
       "output": "び"
     },
     {
-      "input": [{ "keys": ["C", "J"] }],
+      "input": [
+        {
+          "keys": ["C", "J"]
+        }
+      ],
       "output": "ば"
     },
     {
-      "input": [{ "keys": ["V", "J"] }],
+      "input": [
+        {
+          "keys": ["V", "J"]
+        }
+      ],
       "output": "ご"
     },
     {
-      "input": [{ "keys": ["B", "J"] }],
+      "input": [
+        {
+          "keys": ["B", "J"]
+        }
+      ],
       "output": "ぞ"
     },
     {
-      "input": [{ "keys": ["O", "F"] }],
+      "input": [
+        {
+          "keys": ["O", "F"]
+        }
+      ],
       "output": "ず"
     },
     {
-      "input": [{ "keys": ["H", "F"] }],
+      "input": [
+        {
+          "keys": ["H", "F"]
+        }
+      ],
       "output": "ぐ"
     },
     {
-      "input": [{ "keys": ["N", "F"] }],
+      "input": [
+        {
+          "keys": ["N", "F"]
+        }
+      ],
       "output": "だ"
     },
     {
-      "input": [{ "keys": ["A", "J"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["A", "J"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "ぜ"
     },
     {
-      "input": [{ "keys": ["G", "J"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["G", "J"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "ぢ"
     },
     {
-      "input": [{ "keys": ["U", "F"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["U", "F"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "ざ"
     },
     {
-      "input": [{ "keys": ["L", "F"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["L", "F"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "づ"
     },
     {
-      "input": [{ "keys": ["Semicolon", "F"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["Semicolon", "F"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "ぶ"
     },
     {
-      "input": [{ "keys": ["Z", "M"] }],
+      "input": [
+        {
+          "keys": ["Z", "M"]
+        }
+      ],
       "output": "ぽ"
     },
     {
-      "input": [{ "keys": ["X", "M"] }],
+      "input": [
+        {
+          "keys": ["X", "M"]
+        }
+      ],
       "output": "ぴ"
     },
     {
-      "input": [{ "keys": ["C", "M"] }],
+      "input": [
+        {
+          "keys": ["C", "M"]
+        }
+      ],
       "output": "ぱ"
     },
     {
-      "input": [{ "keys": ["P", "V"] }],
+      "input": [
+        {
+          "keys": ["P", "V"]
+        }
+      ],
       "output": "ぺ"
     },
     {
-      "input": [{ "keys": ["V", "Semicolon"], "modifiers": [["Space"]] }],
+      "input": [
+        {
+          "keys": ["V", "Semicolon"],
+          "modifiers": [["Space"]]
+        }
+      ],
       "output": "ぷ"
     },
     {
       "comment": "小書き：ゃゅょぁぃぅぇぉゎ"
     },
     {
-      "input": [{ "keys": ["Q", "H"] }],
+      "input": [
+        {
+          "keys": ["Q", "H"]
+        }
+      ],
       "output": "ゃ"
     },
     {
-      "input": [{ "keys": ["Q", "P"] }],
+      "input": [
+        {
+          "keys": ["Q", "P"]
+        }
+      ],
       "output": "ゅ"
     },
     {
-      "input": [{ "keys": ["Q", "I"] }],
+      "input": [
+        {
+          "keys": ["Q", "I"]
+        }
+      ],
       "output": "ょ"
     },
     {
-      "input": [{ "keys": ["Q", "J"] }],
+      "input": [
+        {
+          "keys": ["Q", "J"]
+        }
+      ],
       "output": "ぁ"
     },
     {
-      "input": [{ "keys": ["Q", "K"] }],
+      "input": [
+        {
+          "keys": ["Q", "K"]
+        }
+      ],
       "output": "ぃ"
     },
     {
-      "input": [{ "keys": ["Q", "L"] }],
+      "input": [
+        {
+          "keys": ["Q", "L"]
+        }
+      ],
       "output": "ぅ"
     },
     {
-      "input": [{ "keys": ["Q", "O"] }],
+      "input": [
+        {
+          "keys": ["Q", "O"]
+        }
+      ],
       "output": "ぇ"
     },
     {
-      "input": [{ "keys": ["Q", "N"] }],
+      "input": [
+        {
+          "keys": ["Q", "N"]
+        }
+      ],
       "output": "ぉ"
     },
     {
-      "input": [{ "keys": ["Q", "Period"] }],
+      "input": [
+        {
+          "keys": ["Q", "Period"]
+        }
+      ],
       "output": "ゎ"
     },
     {
       "comment": "拗音：きゃきゅきょ"
     },
     {
-      "input": [{ "keys": ["W", "H"] }],
+      "input": [
+        {
+          "keys": ["W", "H"]
+        }
+      ],
       "output": "きゃ"
     },
     {
-      "input": [{ "keys": ["W", "P"] }],
+      "input": [
+        {
+          "keys": ["W", "P"]
+        }
+      ],
       "output": "きゅ"
     },
     {
-      "input": [{ "keys": ["W", "I"] }],
+      "input": [
+        {
+          "keys": ["W", "I"]
+        }
+      ],
       "output": "きょ"
     },
     {
       "comment": "拗音：ぎゃぎゅぎょ"
     },
     {
-      "input": [{ "keys": ["W", "J", "H"] }],
+      "input": [
+        {
+          "keys": ["W", "J", "H"]
+        }
+      ],
       "output": "ぎゃ"
     },
     {
-      "input": [{ "keys": ["W", "J", "P"] }],
+      "input": [
+        {
+          "keys": ["W", "J", "P"]
+        }
+      ],
       "output": "ぎゅ"
     },
     {
-      "input": [{ "keys": ["W", "J", "I"] }],
+      "input": [
+        {
+          "keys": ["W", "J", "I"]
+        }
+      ],
       "output": "ぎょ"
     },
     {
       "comment": "拗音：しゃしゅしょ"
     },
     {
-      "input": [{ "keys": ["R", "H"] }],
+      "input": [
+        {
+          "keys": ["R", "H"]
+        }
+      ],
       "output": "しゃ"
     },
     {
-      "input": [{ "keys": ["R", "P"] }],
+      "input": [
+        {
+          "keys": ["R", "P"]
+        }
+      ],
       "output": "しゅ"
     },
     {
-      "input": [{ "keys": ["R", "I"] }],
+      "input": [
+        {
+          "keys": ["R", "I"]
+        }
+      ],
       "output": "しょ"
     },
     {
       "comment": "拗音：じゃじゅじょ"
     },
     {
-      "input": [{ "keys": ["R", "J", "H"] }],
+      "input": [
+        {
+          "keys": ["R", "J", "H"]
+        }
+      ],
       "output": "じゃ"
     },
     {
-      "input": [{ "keys": ["R", "J", "P"] }],
+      "input": [
+        {
+          "keys": ["R", "J", "P"]
+        }
+      ],
       "output": "じゅ"
     },
     {
-      "input": [{ "keys": ["R", "J", "I"] }],
+      "input": [
+        {
+          "keys": ["R", "J", "I"]
+        }
+      ],
       "output": "じょ"
     },
     {
       "comment": "拗音：ちゃちゅちょ"
     },
     {
-      "input": [{ "keys": ["G", "H"] }],
+      "input": [
+        {
+          "keys": ["G", "H"]
+        }
+      ],
       "output": "ちゃ"
     },
     {
-      "input": [{ "keys": ["G", "P"] }],
+      "input": [
+        {
+          "keys": ["G", "P"]
+        }
+      ],
       "output": "ちゅ"
     },
     {
-      "input": [{ "keys": ["G", "I"] }],
+      "input": [
+        {
+          "keys": ["G", "I"]
+        }
+      ],
       "output": "ちょ"
     },
     {
       "comment": "拗音：ぢゃぢゅぢょ"
     },
     {
-      "input": [{ "keys": ["G", "J", "H"] }],
+      "input": [
+        {
+          "keys": ["G", "J", "H"]
+        }
+      ],
       "output": "ぢゃ"
     },
     {
-      "input": [{ "keys": ["G", "J", "P"] }],
+      "input": [
+        {
+          "keys": ["G", "J", "P"]
+        }
+      ],
       "output": "ぢゅ"
     },
     {
-      "input": [{ "keys": ["G", "J", "I"] }],
+      "input": [
+        {
+          "keys": ["G", "J", "I"]
+        }
+      ],
       "output": "ぢょ"
     },
     {
       "comment": "拗音：にゃにゅにょ"
     },
     {
-      "input": [{ "keys": ["D", "H"] }],
+      "input": [
+        {
+          "keys": ["D", "H"]
+        }
+      ],
       "output": "にゃ"
     },
     {
-      "input": [{ "keys": ["D", "P"] }],
+      "input": [
+        {
+          "keys": ["D", "P"]
+        }
+      ],
       "output": "にゅ"
     },
     {
-      "input": [{ "keys": ["D", "I"] }],
+      "input": [
+        {
+          "keys": ["D", "I"]
+        }
+      ],
       "output": "にょ"
     },
     {
       "comment": "拗音：ひゃひゅひょ"
     },
     {
-      "input": [{ "keys": ["X", "H"] }],
+      "input": [
+        {
+          "keys": ["X", "H"]
+        }
+      ],
       "output": "ひゃ"
     },
     {
-      "input": [{ "keys": ["X", "P"] }],
+      "input": [
+        {
+          "keys": ["X", "P"]
+        }
+      ],
       "output": "ひゅ"
     },
     {
-      "input": [{ "keys": ["X", "I"] }],
+      "input": [
+        {
+          "keys": ["X", "I"]
+        }
+      ],
       "output": "ひょ"
     },
     {
       "comment": "拗音：びゃびゅびょ"
     },
     {
-      "input": [{ "keys": ["X", "J", "H"] }],
+      "input": [
+        {
+          "keys": ["X", "J", "H"]
+        }
+      ],
       "output": "びゃ"
     },
     {
-      "input": [{ "keys": ["X", "J", "P"] }],
+      "input": [
+        {
+          "keys": ["X", "J", "P"]
+        }
+      ],
       "output": "びゅ"
     },
     {
-      "input": [{ "keys": ["X", "J", "I"] }],
+      "input": [
+        {
+          "keys": ["X", "J", "I"]
+        }
+      ],
       "output": "びょ"
     },
     {
       "comment": "拗音：ぴゃぴゅぴょ"
     },
     {
-      "input": [{ "keys": ["X", "M", "H"] }],
+      "input": [
+        {
+          "keys": ["X", "M", "H"]
+        }
+      ],
       "output": "ぴゃ"
     },
     {
-      "input": [{ "keys": ["X", "M", "P"] }],
+      "input": [
+        {
+          "keys": ["X", "M", "P"]
+        }
+      ],
       "output": "ぴゅ"
     },
     {
-      "input": [{ "keys": ["X", "M", "I"] }],
+      "input": [
+        {
+          "keys": ["X", "M", "I"]
+        }
+      ],
       "output": "ぴょ"
     },
     {
       "comment": "拗音：みゃみゅみょ"
     },
     {
-      "input": [{ "keys": ["B", "H"] }],
+      "input": [
+        {
+          "keys": ["B", "H"]
+        }
+      ],
       "output": "みゃ"
     },
     {
-      "input": [{ "keys": ["B", "P"] }],
+      "input": [
+        {
+          "keys": ["B", "P"]
+        }
+      ],
       "output": "みゅ"
     },
     {
-      "input": [{ "keys": ["B", "I"] }],
+      "input": [
+        {
+          "keys": ["B", "I"]
+        }
+      ],
       "output": "みょ"
     },
     {
       "comment": "拗音：りゃりゅりょ"
     },
     {
-      "input": [{ "keys": ["E", "H"] }],
+      "input": [
+        {
+          "keys": ["E", "H"]
+        }
+      ],
       "output": "りゃ"
     },
     {
-      "input": [{ "keys": ["E", "P"] }],
+      "input": [
+        {
+          "keys": ["E", "P"]
+        }
+      ],
       "output": "りゅ"
     },
     {
-      "input": [{ "keys": ["E", "I"] }],
+      "input": [
+        {
+          "keys": ["E", "I"]
+        }
+      ],
       "output": "りょ"
     },
     {
       "comment": "外来語：てぃてゅ"
     },
     {
-      "input": [{ "keys": ["E", "M", "K"] }],
+      "input": [
+        {
+          "keys": ["E", "M", "K"]
+        }
+      ],
       "output": "てぃ"
     },
     {
-      "input": [{ "keys": ["E", "M", "P"] }],
+      "input": [
+        {
+          "keys": ["E", "M", "P"]
+        }
+      ],
       "output": "てゅ"
     },
     {
       "comment": "外来語：でぃでゅ"
     },
     {
-      "input": [{ "keys": ["E", "J", "K"] }],
+      "input": [
+        {
+          "keys": ["E", "J", "K"]
+        }
+      ],
       "output": "でぃ"
     },
     {
-      "input": [{ "keys": ["E", "J", "P"] }],
+      "input": [
+        {
+          "keys": ["E", "J", "P"]
+        }
+      ],
       "output": "でゅ"
     },
     {
       "comment": "外来語：とぅしぇちぇ"
     },
     {
-      "input": [{ "keys": ["D", "M", "L"] }],
+      "input": [
+        {
+          "keys": ["D", "M", "L"]
+        }
+      ],
       "output": "とぅ"
     },
     {
-      "input": [{ "keys": ["R", "M", "O"] }],
+      "input": [
+        {
+          "keys": ["R", "M", "O"]
+        }
+      ],
       "output": "しぇ"
     },
     {
-      "input": [{ "keys": ["G", "M", "O"] }],
+      "input": [
+        {
+          "keys": ["G", "M", "O"]
+        }
+      ],
       "output": "ちぇ"
     },
     {
       "comment": "外来語：どぅじぇぢぇ"
     },
     {
-      "input": [{ "keys": ["D", "J", "L"] }],
+      "input": [
+        {
+          "keys": ["D", "J", "L"]
+        }
+      ],
       "output": "どぅ"
     },
     {
-      "input": [{ "keys": ["R", "J", "O"] }],
+      "input": [
+        {
+          "keys": ["R", "J", "O"]
+        }
+      ],
       "output": "じぇ"
     },
     {
-      "input": [{ "keys": ["G", "J", "O"] }],
+      "input": [
+        {
+          "keys": ["G", "J", "O"]
+        }
+      ],
       "output": "ぢぇ"
     },
     {
       "comment": "外来語：つぁうぃうぇうぉいぇ"
     },
     {
-      "input": [{ "keys": ["V", "J", "L"] }],
+      "input": [
+        {
+          "keys": ["V", "J", "L"]
+        }
+      ],
       "output": "つぁ"
     },
     {
-      "input": [{ "keys": ["V", "L", "K"] }],
+      "input": [
+        {
+          "keys": ["V", "L", "K"]
+        }
+      ],
       "output": "うぃ"
     },
     {
-      "input": [{ "keys": ["V", "L", "O"] }],
+      "input": [
+        {
+          "keys": ["V", "L", "O"]
+        }
+      ],
       "output": "うぇ"
     },
     {
-      "input": [{ "keys": ["V", "L", "N"] }],
+      "input": [
+        {
+          "keys": ["V", "L", "N"]
+        }
+      ],
       "output": "うぉ"
     },
     {
-      "input": [{ "keys": ["V", "K", "O"] }],
+      "input": [
+        {
+          "keys": ["V", "K", "O"]
+        }
+      ],
       "output": "いぇ"
     },
     {
       "comment": "外来語：ふぁふぃふぇふぉふゅ"
     },
     {
-      "input": [{ "keys": ["Semicolon", "V", "J"] }],
+      "input": [
+        {
+          "keys": ["Semicolon", "V", "J"]
+        }
+      ],
       "output": "ふぁ"
     },
     {
-      "input": [{ "keys": ["Semicolon", "V", "K"] }],
+      "input": [
+        {
+          "keys": ["Semicolon", "V", "K"]
+        }
+      ],
       "output": "ふぃ"
     },
     {
-      "input": [{ "keys": ["Semicolon", "V", "I"] }],
+      "input": [
+        {
+          "keys": ["Semicolon", "V", "I"]
+        }
+      ],
       "output": "ふぇ"
     },
     {
-      "input": [{ "keys": ["Semicolon", "V", "N"] }],
+      "input": [
+        {
+          "keys": ["Semicolon", "V", "N"]
+        }
+      ],
       "output": "ふぉ"
     },
     {
-      "input": [{ "keys": ["Semicolon", "V", "P"] }],
+      "input": [
+        {
+          "keys": ["Semicolon", "V", "P"]
+        }
+      ],
       "output": "ふゅ"
     },
     {
       "comment": "外来語：ヴァヴィヴェヴォヴュ"
     },
     {
-      "input": [{ "keys": ["Q", "M", "J"] }],
+      "input": [
+        {
+          "keys": ["Q", "M", "J"]
+        }
+      ],
       "output": "ヴぁ"
     },
     {
-      "input": [{ "keys": ["Q", "M", "K"] }],
+      "input": [
+        {
+          "keys": ["Q", "M", "K"]
+        }
+      ],
       "output": "ヴぃ"
     },
     {
-      "input": [{ "keys": ["Q", "M", "I"] }],
+      "input": [
+        {
+          "keys": ["Q", "M", "I"]
+        }
+      ],
       "output": "ヴぇ"
     },
     {
-      "input": [{ "keys": ["Q", "M", "N"] }],
+      "input": [
+        {
+          "keys": ["Q", "M", "N"]
+        }
+      ],
       "output": "ヴぉ"
     },
     {
-      "input": [{ "keys": ["Q", "M", "P"] }],
+      "input": [
+        {
+          "keys": ["Q", "M", "P"]
+        }
+      ],
       "output": "ヴゅ"
     },
     {
       "comment": "外来語：クァクィクェクォクヮ"
     },
     {
-      "input": [{ "keys": ["H", "V", "J"] }],
+      "input": [
+        {
+          "keys": ["H", "V", "J"]
+        }
+      ],
       "output": "くぁ"
     },
     {
-      "input": [{ "keys": ["H", "V", "K"] }],
+      "input": [
+        {
+          "keys": ["H", "V", "K"]
+        }
+      ],
       "output": "くぃ"
     },
     {
-      "input": [{ "keys": ["H", "V", "O"] }],
+      "input": [
+        {
+          "keys": ["H", "V", "O"]
+        }
+      ],
       "output": "くぇ"
     },
     {
-      "input": [{ "keys": ["H", "V", "N"] }],
+      "input": [
+        {
+          "keys": ["H", "V", "N"]
+        }
+      ],
       "output": "くぉ"
     },
     {
-      "input": [{ "keys": ["H", "V", "Period"] }],
+      "input": [
+        {
+          "keys": ["H", "V", "Period"]
+        }
+      ],
       "output": "くゎ"
     },
     {
       "comment": "外来語：グァグィグェグォグヮ"
     },
     {
-      "input": [{ "keys": ["H", "F", "J"] }],
+      "input": [
+        {
+          "keys": ["H", "F", "J"]
+        }
+      ],
       "output": "ぐぁ"
     },
     {
-      "input": [{ "keys": ["H", "F", "K"] }],
+      "input": [
+        {
+          "keys": ["H", "F", "K"]
+        }
+      ],
       "output": "ぐぃ"
     },
     {
-      "input": [{ "keys": ["H", "F", "O"] }],
+      "input": [
+        {
+          "keys": ["H", "F", "O"]
+        }
+      ],
       "output": "ぐぇ"
     },
     {
-      "input": [{ "keys": ["H", "F", "N"] }],
+      "input": [
+        {
+          "keys": ["H", "F", "N"]
+        }
+      ],
       "output": "ぐぉ"
     },
     {
-      "input": [{ "keys": ["H", "F", "Period"] }],
+      "input": [
+        {
+          "keys": ["H", "F", "Period"]
+        }
+      ],
       "output": "ぐゎ"
     }
   ]

--- a/src/assets/rules/nicola.json
+++ b/src/assets/rules/nicola.json
@@ -1,4 +1,8 @@
 {
+  "metadata": {
+    "name": "NICOLA (親指シフト)",
+    "url": "https://ja.wikipedia.org/wiki/%E8%A6%AA%E6%8C%87%E3%82%B7%E3%83%95%E3%83%88#NICOLA%E8%A6%8F%E6%A0%BC"
+  },
   "entries": [
     {
       "input": [

--- a/src/core/automaton.test.ts
+++ b/src/core/automaton.test.ts
@@ -418,7 +418,7 @@ describe("Automaton getCurrentOriginRules with chained rule", () => {
     // 先頭 ("A") は alphanumeric rule の edge だけがある
     const atStart = automaton.getCurrentOriginRules();
     expect(atStart).toHaveLength(1);
-    expect(atStart[0].name).toBe("alphanumeric");
+    expect(atStart[0].metadata.name).toBe("alphanumeric");
   });
 
   test("origin rule switches after typing through ascii portion", () => {
@@ -435,7 +435,7 @@ describe("Automaton getCurrentOriginRules with chained rule", () => {
     // 次は "あ" の位置: ローマ字 rule (head) の edge が使われる
     expect(atKana).toHaveLength(1);
     // head rule (ローマ字) は name が空の可能性があるため、alphanumeric でないことで確認
-    expect(atKana[0].name).not.toBe("alphanumeric");
+    expect(atKana[0].metadata.name).not.toBe("alphanumeric");
   });
 
   test("returns empty when past the end of the word", () => {

--- a/src/core/builderKanaGraph.ts
+++ b/src/core/builderKanaGraph.ts
@@ -155,7 +155,7 @@ export function buildKanaNode(
 
   // 初期ノードから遷移する候補がない場合はオートマトン生成に失敗したらエラーを返す
   if (kanaNodes[0].nextEdges.length === 0) {
-    throw new Error(`Rule ${rule.name} can't generate an automaton for "${kanaText}"`);
+    throw new Error(`Rule ${rule.metadata.name} can't generate an automaton for "${kanaText}"`);
   }
   return {
     startNode: kanaNodes[0],

--- a/src/core/keyboardLayout.ts
+++ b/src/core/keyboardLayout.ts
@@ -1,4 +1,6 @@
 import { setDefault } from "../utils/map";
+import type { Metadata } from "./metadata";
+import { emptyMetadata } from "./metadata";
 import { AndModifier, ModifierGroup } from "./modifier";
 import { ModifierStroke } from "./ruleStroke";
 import type { VirtualKey } from "./virtualKey";
@@ -7,16 +9,10 @@ export class KeyboardLayout {
   readonly strokesByChar: Map<string, ModifierStroke[]>;
   private readonly charByStroke: Map<string, string>;
   private readonly charByStrokeWithoutShift: Map<string, string>;
-  /**
-   *
-   * @param name キーボードレイアウトの名前
-   * @param mapping [output, stroke] の配列。例：["A", ModifierStroke(VirtualKeys.A, shift, [])]
-   * @param shiftKeys
-   */
   constructor(
-    readonly name: string,
-    readonly mapping: [string, ModifierStroke][],
-    readonly shiftKeys: VirtualKey[],
+    readonly metadata: Metadata = emptyMetadata(),
+    readonly mapping: [string, ModifierStroke][] = [],
+    readonly shiftKeys: VirtualKey[] = [],
   ) {
     this.strokesByChar = new Map();
     this.charByStroke = new Map();

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -1,0 +1,8 @@
+export type Metadata = {
+  name: string;
+  url: string;
+};
+
+export function emptyMetadata(): Metadata {
+  return { name: "", url: "" };
+}

--- a/src/core/rule.test.ts
+++ b/src/core/rule.test.ts
@@ -15,7 +15,7 @@ function makePrimitive(options: {
 }): RulePrimitive {
   return new RulePrimitive(
     options.entries,
-    options.name ?? "",
+    { name: options.name ?? "", url: "" },
     options.backspaceStrokes,
     undefined,
   );
@@ -46,7 +46,7 @@ describe("Rule composition via compose()", () => {
     const a = makePrimitive({ entries: [makeEntry("A", "HEAD")], name: "a" });
     const b = makePrimitive({ entries: [makeEntry("A", "TAIL")], name: "b" });
     const composed = a.compose(b);
-    expect(composed.primitives.map((p) => p.name)).toEqual(["a", "b"]);
+    expect(composed.primitives.map((p) => p.metadata.name)).toEqual(["a", "b"]);
     // head (a) の entries が先、tail (b) が後
     expect(composed.entriesByKey(VirtualKeys.A).map((e) => e.output)).toEqual(["HEAD", "TAIL"]);
   });
@@ -65,7 +65,7 @@ describe("Rule composition via compose()", () => {
       backspaceStrokes: [tailBs],
     });
     const composed = head.compose(tail);
-    expect(composed.name).toBe("head");
+    expect(composed.metadata.name).toBe("head");
     expect(composed.backspaceStrokes).toEqual([headBs]);
   });
 
@@ -74,7 +74,7 @@ describe("Rule composition via compose()", () => {
     const r2 = makePrimitive({ entries: [makeEntry("A", "2")], name: "r2" });
     const r3 = makePrimitive({ entries: [makeEntry("A", "3")], name: "r3" });
     const chained = r1.compose(r2).compose(r3);
-    expect(chained.primitives.map((p) => p.name)).toEqual(["r1", "r2", "r3"]);
+    expect(chained.primitives.map((p) => p.metadata.name)).toEqual(["r1", "r2", "r3"]);
   });
 
   test("右結合と左結合で同じ primitive 列になる", () => {
@@ -83,15 +83,15 @@ describe("Rule composition via compose()", () => {
     const r3 = makePrimitive({ entries: [makeEntry("A", "3")], name: "r3" });
     const leftAssoc = r1.compose(r2).compose(r3);
     const rightAssoc = r1.compose(r2.compose(r3));
-    expect(leftAssoc.primitives.map((p) => p.name)).toEqual(
-      rightAssoc.primitives.map((p) => p.name),
+    expect(leftAssoc.primitives.map((p) => p.metadata.name)).toEqual(
+      rightAssoc.primitives.map((p) => p.metadata.name),
     );
   });
 
   test("同じ primitive を 2 回 compose すると重複した primitive が並ぶ (仕様)", () => {
     const r = makePrimitive({ entries: [makeEntry("A", "a")], name: "r" });
     const composed = r.compose(r);
-    expect(composed.primitives.map((p) => p.name)).toEqual(["r", "r"]);
+    expect(composed.primitives.map((p) => p.metadata.name)).toEqual(["r", "r"]);
     // entries が 2 回並ぶ
     expect(composed.entriesByKey(VirtualKeys.A).map((e) => e.output)).toEqual(["a", "a"]);
   });

--- a/src/core/rule.ts
+++ b/src/core/rule.ts
@@ -1,5 +1,7 @@
 import { setDefault } from "../utils/map";
 import type { KeyboardGuide } from "./keyboardGuide";
+import type { Metadata } from "./metadata";
+import { emptyMetadata } from "./metadata";
 import { AndModifier } from "./modifier";
 import { expandPrefixRules } from "./ruleExtender";
 import { ModifierStroke, ruleStrokeKeys, type RuleStroke } from "./ruleStroke";
@@ -94,7 +96,7 @@ nk/ん/k
  * RulePrimitive 実装は自身の entries のみ、合成実装は全 parts の union を返す。
  */
 export interface Rule {
-  readonly name: string;
+  readonly metadata: Metadata;
   readonly guide?: KeyboardGuide;
   readonly backspaceStrokes: readonly RuleStroke[];
   readonly primitives: readonly RulePrimitive[];
@@ -122,7 +124,7 @@ export class RulePrimitive implements Rule {
    * その指定がそのまま使われる (Backspace キーを含めるかどうかは呼び出し側の判断)。
    */
   readonly backspaceStrokes: readonly RuleStroke[];
-  readonly name: string;
+  readonly metadata: Metadata;
   readonly guide?: KeyboardGuide;
 
   /** @internal 同ファイル内の RuleSet が合成時に直接マージするため公開している */
@@ -130,22 +132,14 @@ export class RulePrimitive implements Rule {
   /** @internal */
   readonly ownByModifier: ReadonlyMap<VirtualKey, readonly RuleEntry[]>;
 
-  /**
-   * @param entries 入力ルールのエントリ
-   * @param name 入力ルールの名前
-   * @param backspaceStrokes backspace として扱う RuleStroke 群。
-   *                         undefined の場合は VirtualKeys.Backspace 単独打鍵のみが
-   *                         デフォルトとして設定される。空配列を渡すと backspace 無効
-   * @param guide この Rule に紐づく KeyboardGuide。未指定なら undefined
-   */
   constructor(
     entries: RuleEntry[],
-    name = "",
+    metadata: Metadata = emptyMetadata(),
     backspaceStrokes?: readonly RuleStroke[],
     guide?: KeyboardGuide,
   ) {
     this.entries = expandPrefixRules(entries);
-    this.name = name;
+    this.metadata = metadata;
     this.guide = guide;
     this.backspaceStrokes = backspaceStrokes ?? [
       new ModifierStroke(VirtualKeys.Backspace, AndModifier.empty),
@@ -220,8 +214,8 @@ class RuleSet implements Rule {
     this.mergedByModifier = byModifier;
   }
 
-  get name(): string {
-    return this.parts[0].name;
+  get metadata(): Metadata {
+    return this.parts[0].metadata;
   }
   get guide(): KeyboardGuide | undefined {
     return this.parts[0].guide;

--- a/src/impl/alphaNumericRule.ts
+++ b/src/impl/alphaNumericRule.ts
@@ -8,7 +8,7 @@ export function newAlphaNumericRuleByLayout(layout: KeyboardLayout): RulePrimiti
   );
   return new RulePrimitive(
     entries,
-    "alphanumeric",
+    { name: "alphanumeric", url: "" },
     undefined,
     loadPresetKeyboardGuideAlphanumeric(),
   );

--- a/src/impl/jsonRuleLoader.ts
+++ b/src/impl/jsonRuleLoader.ts
@@ -1,5 +1,7 @@
 import * as v from "valibot";
 import { KeyboardGuide } from "../core/keyboardGuide";
+import type { Metadata } from "../core/metadata";
+import { emptyMetadata } from "../core/metadata";
 import { AndModifier, ModifierGroup } from "../core/modifier";
 import { RuleEntry, RulePrimitive } from "../core/rule";
 import { ModifierStroke, type RuleStroke, SimultaneousStroke } from "../core/ruleStroke";
@@ -31,15 +33,15 @@ const commentOnlyEntrySchema = v.object({
 
 const entrySchema = v.union([entryWithInputSchema, commentOnlyEntrySchema]);
 
-// Note: このスキーマには `name` フィールドを意図的に含めていない。
-// Rule.name は現状「エラーメッセージ/デバッグ出力の識別子」「テスト検証」
-// 「UI 表示ラベル候補」の複数用途に兼用されており、identifier と label の
-// 責務が曖昧なまま JSON に埋め込むと以下の問題が生じるため:
-//   - 国際化時に JSON 固定の名前を表示名として使えない
-//   - 同一 JSON を別名で派生させたい場合に柔軟性が落ちる
-//   - プラットフォーム運用時に name 衝突の扱いがスキーマに紛れ込む
-// 名前は呼び出し側 (loadJsonRule の引数) が用途に応じて指定する設計とする。
+const metadataSchema = v.optional(
+  v.object({
+    name: v.optional(v.string()),
+    url: v.optional(v.string()),
+  }),
+);
+
 export const jsonRuleSchema = v.object({
+  metadata: metadataSchema,
   // 全エントリに対するデフォルトの共通プレフィックス拡張設定
   extendCommonPrefixEntry: v.optional(v.boolean()),
   entries: v.array(entrySchema),
@@ -119,9 +121,12 @@ function loadEntries(
   return entries;
 }
 
-export function loadJsonRule(jsonRule: unknown, name?: string): RulePrimitive {
+export function loadJsonRule(
+  jsonRule: unknown,
+  metadata: Metadata = emptyMetadata(),
+): RulePrimitive {
   if (typeof jsonRule === "string") {
-    return loadJsonRule(JSON.parse(jsonRule), name);
+    return loadJsonRule(JSON.parse(jsonRule), metadata);
   }
   const validated = v.parse(jsonRuleSchema, jsonRule);
   const entries = loadEntries(validated.entries, validated.extendCommonPrefixEntry ?? false);
@@ -133,5 +138,10 @@ export function loadJsonRule(jsonRule: unknown, name?: string): RulePrimitive {
   const guide = validated.guide
     ? new KeyboardGuide({ entries: validated.guide.entries })
     : undefined;
-  return new RulePrimitive(entries, name, backspaceStrokes, guide);
+  // パラメータの metadata が空なら JSON 内の metadata を使用
+  const resolvedMetadata: Metadata = {
+    name: metadata.name || validated.metadata?.name || "",
+    url: metadata.url || validated.metadata?.url || "",
+  };
+  return new RulePrimitive(entries, resolvedMetadata, backspaceStrokes, guide);
 }

--- a/src/impl/keyboardLayoutLoader.test.ts
+++ b/src/impl/keyboardLayoutLoader.test.ts
@@ -2,31 +2,31 @@ import * as v from "valibot";
 import { describe, expect, test } from "vitest";
 import { loadJsonKeyboardLayout } from "./keyboardLayoutLoader";
 
-test("valid keyboard layout", () => {
+test("valid keyboard layout with metadata", () => {
   const layout = loadJsonKeyboardLayout({
-    name: "test",
+    metadata: { name: "test", url: "https://example.com" },
     entries: [{ output: "a", input: { key: "A", shift: false } }],
   });
-  expect(layout.name).toBe("test");
+  expect(layout.metadata.name).toBe("test");
+  expect(layout.metadata.url).toBe("https://example.com");
+});
+
+test("metadata is optional", () => {
+  const layout = loadJsonKeyboardLayout({
+    entries: [{ output: "a", input: { key: "A", shift: false } }],
+  });
+  expect(layout.metadata.name).toBe("");
+  expect(layout.metadata.url).toBe("");
 });
 
 describe("validation errors", () => {
-  test("name is missing", () => {
-    expect(() =>
-      loadJsonKeyboardLayout({
-        entries: [{ output: "a", input: { key: "A", shift: false } }],
-      }),
-    ).toThrow(v.ValiError);
-  });
-
   test("entries is missing", () => {
-    expect(() => loadJsonKeyboardLayout({ name: "test" })).toThrow(v.ValiError);
+    expect(() => loadJsonKeyboardLayout({ metadata: { name: "test" } })).toThrow(v.ValiError);
   });
 
   test("shift is not a boolean", () => {
     expect(() =>
       loadJsonKeyboardLayout({
-        name: "test",
         entries: [{ output: "a", input: { key: "A", shift: "yes" } }],
       }),
     ).toThrow(v.ValiError);
@@ -35,13 +35,12 @@ describe("validation errors", () => {
   test("unknown virtual key", () => {
     expect(() =>
       loadJsonKeyboardLayout({
-        name: "test",
         entries: [{ output: "a", input: { key: "InvalidKey", shift: false } }],
       }),
     ).toThrow(v.ValiError);
   });
 
   test("JSON string with invalid data", () => {
-    expect(() => loadJsonKeyboardLayout('{"name": 123}')).toThrow(v.ValiError);
+    expect(() => loadJsonKeyboardLayout('{"metadata": {"name": 123}}')).toThrow(v.ValiError);
   });
 });

--- a/src/impl/keyboardLayoutLoader.ts
+++ b/src/impl/keyboardLayoutLoader.ts
@@ -4,9 +4,15 @@ import { AndModifier, ModifierGroup } from "../core/modifier";
 import { ModifierStroke } from "../core/ruleStroke";
 import { VirtualKeys, virtualKeySchema } from "../core/virtualKey";
 
+const metadataSchema = v.optional(
+  v.object({
+    name: v.optional(v.string()),
+    url: v.optional(v.string()),
+  }),
+);
+
 const jsonKeyboardLayoutSchema = v.object({
-  // レイアウト名（例: "QWERTY JIS"）
-  name: v.string(),
+  metadata: metadataSchema,
   entries: v.array(
     v.object({
       // キー押下で出力される文字
@@ -36,7 +42,11 @@ export function loadJsonKeyboardLayout(jsonLayout: unknown): KeyboardLayout {
       entry.output,
     ),
   ]);
-  return new KeyboardLayout(validated.name, strokes, shiftModifier.groups[0].modifiers);
+  const metadata = {
+    name: validated.metadata?.name ?? "",
+    url: validated.metadata?.url ?? "",
+  };
+  return new KeyboardLayout(metadata, strokes, shiftModifier.groups[0].modifiers);
 }
 
 const shiftModifier = new AndModifier(

--- a/src/impl/mozcRuleLoader.ts
+++ b/src/impl/mozcRuleLoader.ts
@@ -1,4 +1,6 @@
 import type { KeyboardLayout } from "../core/keyboardLayout";
+import type { Metadata } from "../core/metadata";
+import { emptyMetadata } from "../core/metadata";
 import { RuleEntry, RulePrimitive } from "../core/rule";
 import type { RuleStroke } from "../core/ruleStroke";
 import { product } from "../utils/itertools";
@@ -6,7 +8,7 @@ import { product } from "../utils/itertools";
 export function loadMozcRule(
   text: string,
   layout: KeyboardLayout,
-  name: string = "",
+  metadata: Metadata = emptyMetadata(),
 ): RulePrimitive {
   /*
     a	あ
@@ -39,7 +41,7 @@ export function loadMozcRule(
       );
     });
   }
-  return new RulePrimitive(entries, name, undefined, undefined);
+  return new RulePrimitive(entries, metadata, undefined, undefined);
 }
 
 function toStrokesFromChar(layout: KeyboardLayout, key: string): RuleStroke[] {

--- a/src/impl/presets/index.ts
+++ b/src/impl/presets/index.ts
@@ -2,10 +2,16 @@ export { loadPresetKeyboardGuideAlphanumeric } from "./keyboardGuideAlphanumeric
 export { loadPresetPhysicalKeyboardLayoutJis106 } from "./physicalKeyboardLayoutJis106";
 export { loadPresetPhysicalKeyboardLayoutUs101 } from "./physicalKeyboardLayoutUs101";
 export { loadPresetPhysicalKeyboardLayoutUsHhkb } from "./physicalKeyboardLayoutUsHhkb";
+export { loadPresetKeyboardLayoutAstarte } from "./keyboardLayoutAstarte";
+export { loadPresetKeyboardLayoutColemak } from "./keyboardLayoutColemak";
+export { loadPresetKeyboardLayoutColemakDh } from "./keyboardLayoutColemakDh";
 export { loadPresetKeyboardLayoutDvorak } from "./keyboardLayoutDvorak";
+export { loadPresetKeyboardLayoutEucalyn } from "./keyboardLayoutEucalyn";
 export { findMatchedKeyboardLayout } from "./keyboardLayoutFinder";
+export { loadPresetKeyboardLayoutOnishi } from "./keyboardLayoutOnishi";
 export { loadPresetKeyboardLayoutQwertyJis } from "./keyboardLayoutQwertyJis";
 export { loadPresetKeyboardLayoutQwertyUs } from "./keyboardLayoutQwertyUs";
+export { loadPresetKeyboardLayoutTomisukeJis } from "./keyboardLayoutTomisukeJis";
 export { loadPresetRuleJisKana } from "./ruleJisKana";
 export { loadPresetRuleNaginatashikiV15 } from "./ruleNaginatashikiV15";
 export { loadPresetRuleNicola } from "./ruleNicola";

--- a/src/impl/presets/keyboardLayout.test.ts
+++ b/src/impl/presets/keyboardLayout.test.ts
@@ -3,7 +3,7 @@ import { VirtualKeys } from "../../core/virtualKey";
 import { findMatchedKeyboardLayout } from "./index";
 
 test("empty", () => {
-  expect(findMatchedKeyboardLayout(new Map()).name).toBe("QWERTY JIS");
+  expect(findMatchedKeyboardLayout(new Map()).metadata.name).toBe("QWERTY JIS");
 });
 
 test("dvorak", () => {
@@ -13,7 +13,7 @@ test("dvorak", () => {
         [VirtualKeys.A, "a"],
         [VirtualKeys.F, "u"],
       ]),
-    ).name,
+    ).metadata.name,
   ).toBe("DVORAK");
 });
 
@@ -24,7 +24,7 @@ test("qwerty us", () => {
         [VirtualKeys.A, "a"],
         [VirtualKeys.BracketLeft, "["],
       ]),
-    ).name,
+    ).metadata.name,
   ).toBe("QWERTY US");
 });
 
@@ -35,6 +35,6 @@ test("qwerty jis", () => {
         [VirtualKeys.A, "a"],
         [VirtualKeys.BracketLeft, "@"],
       ]),
-    ).name,
+    ).metadata.name,
   ).toBe("QWERTY JIS");
 });

--- a/src/impl/presets/keyboardLayoutAstarte.ts
+++ b/src/impl/presets/keyboardLayoutAstarte.ts
@@ -1,0 +1,6 @@
+import astarte from "../../assets/keyboard_layouts/astarte.json";
+import { loadJsonKeyboardLayout } from "../keyboardLayoutLoader";
+
+export function loadPresetKeyboardLayoutAstarte() {
+  return loadJsonKeyboardLayout(astarte);
+}

--- a/src/impl/presets/keyboardLayoutColemak.ts
+++ b/src/impl/presets/keyboardLayoutColemak.ts
@@ -1,0 +1,6 @@
+import colemak from "../../assets/keyboard_layouts/colemak.json";
+import { loadJsonKeyboardLayout } from "../keyboardLayoutLoader";
+
+export function loadPresetKeyboardLayoutColemak() {
+  return loadJsonKeyboardLayout(colemak);
+}

--- a/src/impl/presets/keyboardLayoutColemakDh.ts
+++ b/src/impl/presets/keyboardLayoutColemakDh.ts
@@ -1,0 +1,6 @@
+import colemakDh from "../../assets/keyboard_layouts/colemak_dh.json";
+import { loadJsonKeyboardLayout } from "../keyboardLayoutLoader";
+
+export function loadPresetKeyboardLayoutColemakDh() {
+  return loadJsonKeyboardLayout(colemakDh);
+}

--- a/src/impl/presets/keyboardLayoutEucalyn.ts
+++ b/src/impl/presets/keyboardLayoutEucalyn.ts
@@ -1,0 +1,6 @@
+import eucalyn from "../../assets/keyboard_layouts/eucalyn.json";
+import { loadJsonKeyboardLayout } from "../keyboardLayoutLoader";
+
+export function loadPresetKeyboardLayoutEucalyn() {
+  return loadJsonKeyboardLayout(eucalyn);
+}

--- a/src/impl/presets/keyboardLayoutFinder.ts
+++ b/src/impl/presets/keyboardLayoutFinder.ts
@@ -1,8 +1,14 @@
 import type { KeyboardLayout } from "../../core/keyboardLayout";
 import type { VirtualKey } from "../../core/virtualKey";
+import { loadPresetKeyboardLayoutAstarte } from "./keyboardLayoutAstarte";
+import { loadPresetKeyboardLayoutColemak } from "./keyboardLayoutColemak";
+import { loadPresetKeyboardLayoutColemakDh } from "./keyboardLayoutColemakDh";
 import { loadPresetKeyboardLayoutDvorak } from "./keyboardLayoutDvorak";
+import { loadPresetKeyboardLayoutEucalyn } from "./keyboardLayoutEucalyn";
+import { loadPresetKeyboardLayoutOnishi } from "./keyboardLayoutOnishi";
 import { loadPresetKeyboardLayoutQwertyJis } from "./keyboardLayoutQwertyJis";
 import { loadPresetKeyboardLayoutQwertyUs } from "./keyboardLayoutQwertyUs";
+import { loadPresetKeyboardLayoutTomisukeJis } from "./keyboardLayoutTomisukeJis";
 
 /**
  * 実際に入力されたキーと文字のマッピングから、キーボードレイアウトを推定する。
@@ -16,6 +22,12 @@ export function findMatchedKeyboardLayout(keyToCharMap: Map<VirtualKey, string>)
     loadPresetKeyboardLayoutQwertyJis,
     loadPresetKeyboardLayoutQwertyUs,
     loadPresetKeyboardLayoutDvorak,
+    loadPresetKeyboardLayoutColemak,
+    loadPresetKeyboardLayoutColemakDh,
+    loadPresetKeyboardLayoutOnishi,
+    loadPresetKeyboardLayoutEucalyn,
+    loadPresetKeyboardLayoutAstarte,
+    loadPresetKeyboardLayoutTomisukeJis,
   ]) {
     const layout = layoutLoader();
     if (

--- a/src/impl/presets/keyboardLayoutOnishi.ts
+++ b/src/impl/presets/keyboardLayoutOnishi.ts
@@ -1,0 +1,6 @@
+import onishi from "../../assets/keyboard_layouts/onishi.json";
+import { loadJsonKeyboardLayout } from "../keyboardLayoutLoader";
+
+export function loadPresetKeyboardLayoutOnishi() {
+  return loadJsonKeyboardLayout(onishi);
+}

--- a/src/impl/presets/keyboardLayoutTomisukeJis.ts
+++ b/src/impl/presets/keyboardLayoutTomisukeJis.ts
@@ -1,0 +1,6 @@
+import tomisukeJis from "../../assets/keyboard_layouts/tomisuke_jis.json";
+import { loadJsonKeyboardLayout } from "../keyboardLayoutLoader";
+
+export function loadPresetKeyboardLayoutTomisukeJis() {
+  return loadJsonKeyboardLayout(tomisukeJis);
+}

--- a/src/impl/ruleLoaderWithLayout.ts
+++ b/src/impl/ruleLoaderWithLayout.ts
@@ -1,4 +1,6 @@
 import type { KeyboardLayout } from "../core/keyboardLayout";
+import type { Metadata } from "../core/metadata";
+import { emptyMetadata } from "../core/metadata";
 import type { Rule } from "../core/rule";
 import { newAlphaNumericRuleByLayout } from "./alphaNumericRule";
 import { loadJsonRule } from "./jsonRuleLoader";
@@ -7,15 +9,15 @@ import { loadMozcRule } from "./mozcRuleLoader";
 export function loadMozcRuleWithLayout(
   ruleData: string,
   layout: KeyboardLayout,
-  name: string = "",
+  metadata: Metadata = emptyMetadata(),
 ): Rule {
-  return loadMozcRule(ruleData, layout, name).compose(newAlphaNumericRuleByLayout(layout));
+  return loadMozcRule(ruleData, layout, metadata).compose(newAlphaNumericRuleByLayout(layout));
 }
 
 export function loadJsonRuleWithLayout(
   ruleData: unknown,
   layout: KeyboardLayout,
-  name: string = "",
+  metadata: Metadata = emptyMetadata(),
 ): Rule {
-  return loadJsonRule(ruleData, name).compose(newAlphaNumericRuleByLayout(layout));
+  return loadJsonRule(ruleData, metadata).compose(newAlphaNumericRuleByLayout(layout));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export type {
 export { StrokeEdge, StrokeNode } from "./core/builderStrokeGraph";
 export { InputEvent, InputStroke } from "./core/inputEvent";
 export { KeyboardLayout } from "./core/keyboardLayout";
+export { type Metadata, emptyMetadata } from "./core/metadata";
 export { KeyboardState, type KeyboardStateReader } from "./core/keyboardState";
 export { AndModifier, ModifierGroup } from "./core/modifier";
 export { type Rule, RulePrimitive, RuleEntry, type normalizerFunc } from "./core/rule";

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,8 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

- KeyboardLayout と Rule に metadata (name, url) プロパティを追加
- 既存の name はトップレベルから metadata.name へ移動（破壊的変更）
- Colemak / Colemak-DH / 大西配列 / Eucalyn 配列 / ASTARTE 配列 / Tomisuke 配列 (JIS) を追加
- レイアウトを CLI で表示する show-layout スクリプトを追加

## 設計の背景

レイアウトやルールの定義元 URL を保存できる場所がなく、後から元の定義を辿りたい時に困ることがあった。また、JSON rule には以前 name フィールドが意図的に除外されていたが、正確な名前がどこにも残らない状態は実用上不便なため復活させたい。

name と url は両方とも「実装に影響しない参照情報」という共通の性質を持つため、個別のトップレベルプロパティに分けるよりも metadata オブジェクトにまとめる方が、将来別の参照情報を追加する際の拡張性も保ちやすい。既存の name プロパティは getter で互換維持する案もあったが、API のシンプルさを優先して破壊的変更とした。

新しいキーボードレイアウトの追加は、英語配列・ローマ字最適化配列の選択肢を充実させるため。各レイアウトには参照可能な URL を metadata に記録してある。

show-layout スクリプトは、新しいレイアウトを追加した際にキー配置が意図通りか視覚的に確認するために必要。

## 検討した代替案

- name と url を Rule / KeyboardLayout のトップレベルに個別配置: 拡張性が低く、将来別の参照情報を追加する際にプロパティが増え続ける
- name は getter として互換維持: API がシンプルでなくなり、metadata.name と name の使い分けが曖昧になる
- ローダーの name パラメータを Partial<Metadata> で受ける: 他箇所が Metadata 型で統一されているのに型が揃わず違和感がある

## Test plan

- [x] pnpm run build
- [x] pnpm run test (136 passed)
- [x] pnpm run lint
- [x] pnpm run show-layout で各新規レイアウトを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)