### PR TITLE
feat: AZIK ローマ字ルールのプリセットを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ npm install emiel
 import {
   build,
   activate,
+  createDirectInputRule,
   detectKeyboardLayout,
   loadPresetRuleRoman,
 } from "emiel";
@@ -46,8 +47,14 @@ import {
 // キーボードレイアウトを自動検出
 const layout = await detectKeyboardLayout(window);
 
-// ローマ字入力ルールとオートマトンを作成
-const rule = loadPresetRuleRoman(layout);
+// ローマ字入力ルールを作成
+const romanRule = loadPresetRuleRoman(layout);
+// 英数字の直接入力ルールを作成
+// （"hello" のように英字・記号のみのワードや、"aから@" のように混ざるケースに対応）
+// かなの入力しかさせない場合はルールの合成は不要
+const directInputRule = createDirectInputRule(layout);
+// ２つのルールを合成してオートマトンを作成
+const rule = romanRule.compose(directInputRule);
 const automaton = build(rule, "かった");
 
 // キーボードイベントを購読

--- a/src/assets/rules/azik.txt
+++ b/src/assets/rules/azik.txt
@@ -1,0 +1,700 @@
+a	あ
+i	い
+u	う
+e	え
+o	お
+
+ka	か
+ki	き
+ku	く
+ke	け
+ko	こ
+
+sa	さ
+si	し
+su	す
+se	せ
+so	そ
+
+ta	た
+ti	ち
+tu	つ
+te	て
+to	と
+
+na	な
+ni	に
+nu	ぬ
+ne	ね
+no	の
+
+ha	は
+hi	ひ
+hu	ふ
+he	へ
+ho	ほ
+
+ma	ま
+mi	み
+mu	む
+me	め
+mo	も
+
+ya	や
+yu	ゆ
+yo	よ
+
+ra	ら
+ri	り
+ru	る
+re	れ
+ro	ろ
+
+wa	わ
+wi	うぃ
+we	うぇ
+wo	を
+
+ga	が
+gi	ぎ
+gu	ぐ
+ge	げ
+go	ご
+
+za	ざ
+zi	じ
+zu	ず
+ze	ぜ
+zo	ぞ
+
+da	だ
+di	ぢ
+du	づ
+de	で
+do	ど
+
+ba	ば
+bi	び
+bu	ぶ
+be	べ
+bo	ぼ
+
+pa	ぱ
+pi	ぴ
+pu	ぷ
+pe	ぺ
+po	ぽ
+
+kya	きゃ
+kyu	きゅ
+kye	きぇ
+kyo	きょ
+
+kga	きゃ
+kgu	きゅ
+kge	きぇ
+kgo	きょ
+
+sya	しゃ
+syu	しゅ
+sye	しぇ
+syo	しょ
+
+xa	しゃ
+xu	しゅ
+xe	しぇ
+xo	しょ
+
+tya	ちゃ
+tyu	ちゅ
+tye	ちぇ
+tyo	ちょ
+
+ca	ちゃ
+cu	ちゅ
+ce	ちぇ
+co	ちょ
+
+nya	にゃ
+nyu	にゅ
+nye	にぇ
+nyo	にょ
+
+nga	にゃ
+ngu	にゅ
+nge	にぇ
+ngo	にょ
+
+hya	ひゃ
+hyu	ひゅ
+hye	ひぇ
+hyo	ひょ
+
+hga	ひゃ
+hgu	ひゅ
+hge	ひぇ
+hgo	ひょ
+
+mya	みゃ
+myu	みゅ
+mye	みぇ
+myo	みょ
+
+mga	みゃ
+mgu	みゅ
+mge	みぇ
+mgo	みょ
+
+rya	りゃ
+ryu	りゅ
+rye	りぇ
+ryo	りょ
+
+gya	ぎゃ
+gyu	ぎゅ
+gye	ぎぇ
+gyo	ぎょ
+
+zya	じゃ
+zyu	じゅ
+zye	じぇ
+zyo	じょ
+
+ja	じゃ
+ju	じゅ
+je	じぇ
+jo	じょ
+
+bya	びゃ
+byu	びゅ
+bye	びぇ
+byo	びょ
+
+pya	ぴゃ
+pyu	ぴゅ
+pye	ぴぇ
+pyo	ぴょ
+
+pga	ぴゃ
+pgu	ぴゅ
+pge	ぴぇ
+pgo	ぴょ
+
+fa	ふぁ
+fi	ふぃ
+fu	ふ
+fe	ふぇ
+fo	ふぉ
+
+va	ヴぁ
+vi	ヴぃ
+vu	ヴ
+ve	ヴぇ
+vo	ヴぉ
+
+tgi	てぃ
+tgu	とぅ
+
+dci	でぃ
+dcu	どぅ
+
+wso	うぉ
+
+la	ぁ
+li	ぃ
+lu	ぅ
+le	ぇ
+lo	ぉ
+lya	ゃ
+lyu	ゅ
+lyo	ょ
+
+;	っ
+q	ん
+nn	ん
+-	ー
+:	ー
+
+~	〜
+.	。
+,	、
+z/	・
+z.	…
+z,	‥
+z-	〜
+z[	『
+z]	』
+[	「
+]	」
+
+kz	かん
+kn	かん
+kk	きん
+kj	くん
+kd	けん
+kl	こん
+
+sz	さん
+sn	さん
+sk	しん
+sj	すん
+sd	せん
+sl	そん
+
+tz	たん
+tn	たん
+tk	ちん
+tj	つん
+td	てん
+tl	とん
+
+nz	なん
+nk	にん
+nj	ぬん
+nd	ねん
+nl	のん
+
+hz	はん
+hn	はん
+hk	ひん
+hj	ふん
+hd	へん
+hl	ほん
+
+mz	まん
+mk	みん
+mj	むん
+md	めん
+ml	もん
+
+yz	やん
+yn	やん
+yj	ゆん
+yl	よん
+
+rz	らん
+rn	らん
+rk	りん
+rj	るん
+rd	れん
+rl	ろん
+
+wz	わん
+wn	わん
+wk	うぃん
+wd	うぇん
+wl	うぉん
+
+gz	がん
+gn	がん
+gk	ぎん
+gj	ぐん
+gd	げん
+gl	ごん
+
+zz	ざん
+zn	ざん
+zk	じん
+zj	ずん
+zd	ぜん
+zl	ぞん
+
+dz	だん
+dn	だん
+dk	ぢん
+dj	づん
+dd	でん
+dl	どん
+
+bz	ばん
+bn	ばん
+bk	びん
+bj	ぶん
+bd	べん
+bl	ぼん
+
+pz	ぱん
+pn	ぱん
+pk	ぴん
+pj	ぷん
+pd	ぺん
+pl	ぽん
+
+kyz	きゃん
+kyn	きゃん
+kyj	きゅん
+kyd	きぇん
+kyl	きょん
+
+kgz	きゃん
+kgn	きゃん
+kgj	きゅん
+kgd	きぇん
+kgl	きょん
+
+syz	しゃん
+syn	しゃん
+syj	しゅん
+syd	しぇん
+syl	しょん
+
+xz	しゃん
+xn	しゃん
+xj	しゅん
+xd	しぇん
+xl	しょん
+
+tyz	ちゃん
+tyn	ちゃん
+tyj	ちゅん
+tyd	ちぇん
+tyl	ちょん
+
+cz	ちゃん
+cn	ちゃん
+cj	ちゅん
+cd	ちぇん
+cl	ちょん
+
+nyz	にゃん
+nyn	にゃん
+nyj	にゅん
+nyd	にぇん
+nyl	にょん
+
+ngz	にゃん
+ngn	にゃん
+ngj	にゅん
+ngd	にぇん
+ngl	にょん
+
+hyz	ひゃん
+hyn	ひゃん
+hyj	ひゅん
+hyd	ひぇん
+hyl	ひょん
+
+hgz	ひゃん
+hgn	ひゃん
+hgj	ひゅん
+hgd	ひぇん
+hgl	ひょん
+
+myz	みゃん
+myn	みゃん
+myj	みゅん
+myd	みぇん
+myl	みょん
+
+mgz	みゃん
+mgn	みゃん
+mgj	みゅん
+mgd	みぇん
+mgl	みょん
+
+ryz	りゃん
+ryn	りゃん
+ryj	りゅん
+ryd	りぇん
+ryl	りょん
+
+gyz	ぎゃん
+gyn	ぎゃん
+gyj	ぎゅん
+gyd	ぎぇん
+gyl	ぎょん
+
+zyz	じゃん
+zyn	じゃん
+zyj	じゅん
+zyd	じぇん
+zyl	じょん
+
+jz	じゃん
+jn	じゃん
+jj	じゅん
+jd	じぇん
+jl	じょん
+
+byz	びゃん
+byn	びゃん
+byj	びゅん
+byd	びぇん
+byl	びょん
+
+pyz	ぴゃん
+pyn	ぴゃん
+pyj	ぴゅん
+pyd	ぴぇん
+pyl	ぴょん
+
+pgz	ぴゃん
+pgn	ぴゃん
+pgj	ぴゅん
+pgd	ぴぇん
+pgl	ぴょん
+
+fz	ふぁん
+fn	ふぁん
+fk	ふぃん
+fj	ふん
+fd	ふぇん
+fl	ふぉん
+
+vz	ヴぁん
+vn	ヴぁん
+vk	ヴぃん
+vj	ヴん
+vd	ヴぇん
+vl	ヴぉん
+
+tgk	てぃん
+
+tgj	とぅん
+
+dck	でぃん
+
+dcj	どぅん
+
+lz	ぁん
+ln	ぁん
+lk	ぃん
+ld	ぇん
+ll	ぉん
+
+lyz	ゃん
+lyn	ゃん
+lyj	ゅん
+lyl	ょん
+
+kq	かい
+kh	くう
+kw	けい
+kp	こう
+
+sq	さい
+sh	すう
+sw	せい
+sp	そう
+
+tq	たい
+th	つう
+tw	てい
+tp	とう
+
+nq	ない
+nh	ぬう
+nw	ねい
+np	のう
+
+hq	はい
+hh	ふう
+hw	へい
+hp	ほう
+
+mq	まい
+mh	むう
+mw	めい
+mp	もう
+
+yq	やい
+yh	ゆう
+yp	よう
+
+rq	らい
+rh	るう
+rw	れい
+rp	ろう
+
+gq	がい
+gh	ぐう
+gw	げい
+gp	ごう
+
+zq	ざい
+zh	ずう
+zw	ぜい
+zp	ぞう
+
+dq	だい
+dh	づう
+dw	でい
+dp	どう
+
+bq	ばい
+bh	ぶう
+bw	べい
+bp	ぼう
+
+pq	ぱい
+ph	ぷう
+pw	ぺい
+pp	ぽう
+
+kyq	きゃい
+kyh	きゅう
+kyw	きぇい
+kyp	きょう
+
+kgq	きゃい
+kgh	きゅう
+kgw	きぇい
+kgp	きょう
+
+syq	しゃい
+syh	しゅう
+syw	しぇい
+syp	しょう
+
+xq	しゃい
+xh	しゅう
+xw	しぇい
+xp	しょう
+
+tyq	ちゃい
+tyh	ちゅう
+tyw	ちぇい
+typ	ちょう
+
+cq	ちゃい
+ch	ちゅう
+cw	ちぇい
+cp	ちょう
+
+nyq	にゃい
+nyh	にゅう
+nyw	にぇい
+nyp	にょう
+
+ngq	にゃい
+ngh	にゅう
+ngw	にぇい
+ngp	にょう
+
+hyq	ひゃい
+hyh	ひゅう
+hyw	ひぇい
+hyp	ひょう
+
+hgq	ひゃい
+hgh	ひゅう
+hgw	ひぇい
+hgp	ひょう
+
+myq	みゃい
+myh	みゅう
+myw	みぇい
+myp	みょう
+
+mgq	みゃい
+mgh	みゅう
+mgw	みぇい
+mgp	みょう
+
+ryq	りゃい
+ryh	りゅう
+ryw	りぇい
+ryp	りょう
+
+gyq	ぎゃい
+gyh	ぎゅう
+gyw	ぎぇい
+gyp	ぎょう
+
+zyq	じゃい
+zyh	じゅう
+zyw	じぇい
+zyp	じょう
+
+jq	じゃい
+jh	じゅう
+jw	じぇい
+jp	じょう
+
+byq	びゃい
+byh	びゅう
+byw	びぇい
+byp	びょう
+
+pyq	ぴゃい
+pyh	ぴゅう
+pyw	ぴぇい
+pyp	ぴょう
+
+pgq	ぴゃい
+pgh	ぴゅう
+pgw	ぴぇい
+pgp	ぴょう
+
+fq	ふぁい
+fh	ふう
+fw	ふぇい
+fp	ふぉー
+
+vq	ヴぁい
+vh	ヴー
+vw	ヴぇい
+vp	ヴぉー
+
+tgh	とぅー
+
+dch	どぅー
+
+wq	わい
+ww	うぇい
+wp	うぉー
+
+lq	ぁい
+lh	ぅう
+lw	ぇい
+lp	ぉう
+
+lyq	ゃい
+lyh	ゅう
+lyp	ょう
+
+kf	き
+jf	じゅ
+hf	ふ
+yf	ゆ
+mf	む
+nf	ぬ
+df	で
+cf	ちぇ
+pf	ぽん
+
+wf	わい
+sf	さい
+ss	せい
+zc	ざ
+zv	ざい
+zf	ぜ
+zx	ぜい
+
+kt	こと
+wt	わた
+km	かも
+sr	する
+rr	られ
+nb	ねば
+nt	にち
+st	した
+mn	もの
+tm	ため
+tr	たら
+zr	ざる
+bt	びと
+dt	だち
+tt	たち
+ms	ます
+dm	でも
+nr	なる
+mt	また
+gr	がら
+wr	われ
+ht	ひと
+ds	です
+kr	から
+yr	よる
+tb	たび
+gt	ごと

--- a/src/impl/presets/index.ts
+++ b/src/impl/presets/index.ts
@@ -15,6 +15,7 @@ export { loadPresetKeyboardLayoutQwertyJis } from "./keyboardLayoutQwertyJis";
 export { loadPresetKeyboardLayoutQwertyUs } from "./keyboardLayoutQwertyUs";
 export { loadPresetKeyboardLayoutTomisukeJis } from "./keyboardLayoutTomisukeJis";
 export { loadPresetRuleAsuka123 } from "./ruleAsuka123";
+export { loadPresetRuleAzikRomantable } from "./ruleAzikRomantable";
 export { loadPresetRuleJisKana } from "./ruleJisKana";
 export { loadPresetRuleNaginatashikiV15 } from "./ruleNaginatashikiV15";
 export { loadPresetRuleNicola } from "./ruleNicola";

--- a/src/impl/presets/ruleAzikRomantable.ts
+++ b/src/impl/presets/ruleAzikRomantable.ts
@@ -1,0 +1,8 @@
+import presetRuleAzikRomantable from "../../assets/rules/azik.txt?raw";
+import type { KeyboardLayout } from "../../core/keyboardLayout";
+import type { Rule } from "../../core/rule";
+import { loadMozcRule } from "../mozcRuleLoader";
+
+export function loadPresetRuleAzikRomantable(layout: KeyboardLayout): Rule {
+  return loadMozcRule(presetRuleAzikRomantable, layout);
+}

--- a/src/impl/presets/rules.test.ts
+++ b/src/impl/presets/rules.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 import {
   loadPresetKeyboardLayoutQwertyJis,
   loadPresetRuleAsuka123,
+  loadPresetRuleAzikRomantable,
   loadPresetRuleJisKana,
   loadPresetRuleNicola,
   loadPresetRuleRoman,
@@ -13,6 +14,11 @@ import {
 test("load google ime roman rule", () => {
   const rule = loadPresetRuleRoman(loadPresetKeyboardLayoutQwertyJis());
   expect(rule.primitives[0].entries.length).toBe(324);
+});
+
+test("load azik romantable rule", () => {
+  const rule = loadPresetRuleAzikRomantable(loadPresetKeyboardLayoutQwertyJis());
+  expect(rule.primitives[0].entries.length).toBeGreaterThan(500);
 });
 
 test("load jis kana rule", () => {


### PR DESCRIPTION
## Summary

- AZIK ローマ字入力ルール (`azik.txt`) を mozc 形式で `src/assets/rules/` に追加
- `loadPresetRuleAzikRomantable(layout)` プリセット loader を追加し `presets/index.ts` から export
- `rules.test.ts` に AZIK ルールの読み込みテストを追加
- README の最小コード例に `createDirectInputRule(layout)` を `compose` する手順を追加（英字のみ・混在ワード対応、かな入力のみなら不要の注意書きも追記）

## Test plan

- [x] `pnpm run test` (140 passed)
- [x] `pnpm run lint` (0 warnings / 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)