### PR TITLE
ci: GitHub Release 公開時に npm publish する workflow を追加

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,35 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Node.js 24.x
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24.x
+          registry-url: https://registry.npmjs.org
+      - uses: pnpm/action-setup@b307475762933b98ed359c036b0e51f26b63b74b # v5.0.0
+      - name: Upgrade npm for Trusted Publishing
+        run: npm install -g npm@latest
+      - run: pnpm i --frozen-lockfile
+      - run: pnpm run lint
+      - run: pnpm run test
+      - run: pnpm run build
+      - name: Sync package.json version with release tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+      - name: Publish to npm
+        if: github.event.release.prerelease == false
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- GitHub Release を publish したタイミングで npm へ自動公開する `.github/workflows/release.yaml` を追加
- 認証は npm Trusted Publishing（OIDC）で行い、long-lived なトークンを保持しない
- タグ名（`vX.Y.Z`）からバージョンを抽出して `package.json` に反映してから公開
- pre-release フラグが立った Release では `npm publish` をスキップし、誤って `latest` dist-tag に beta を流し込まない

## 設計の背景

これまで `make publish` で手動 `pnpm publish` していたため、タグと公開バージョンがズレるリスクがあった。Release を起点にした自動化で「タグ = npm の version」を担保し、リリース手順を一本化する。

Trusted Publishing を選んだ理由:
- npm 側の警告どおり、Classic Token は security risk として非推奨
- OIDC 連携でリポジトリと workflow ファイル名に紐づけた短命トークンが発行されるので、漏洩リスクが実質ない
- provenance attestation もセットで付与でき、パッケージの出所検証が容易になる

publish だけ `pnpm publish` ではなく `npm publish` を使うのは、Trusted Publishing サポートが pnpm の版によって不安定なため。build/test/install は pnpm のままで、publish のみ確実に動く `npm publish` に寄せた。

## 検討した代替案

1. NPM_TOKEN（Automation Token）を GitHub Secrets に保存する方式
   - シンプルだが long-lived なトークンをリポジトリに紐付けるため漏洩リスクがある
   - npm 公式も Trusted Publishing を推奨しているので却下

2. prerelease でも dist-tag を自動切替して公開する方式
   - `v1.0.0-beta.1` 等で `--tag beta` を付けて公開する案
   - 現状 beta 運用の予定がないため、まずは prerelease は publish をスキップする最小実装にとどめた。必要になったら後で切替ロジックを足す

3. `pnpm publish` を使い続ける方式
   - pnpm のバージョンアップ次第で Trusted Publishing に正式対応する可能性はある
   - 現時点では挙動が読みにくいので、確実に動く `npm publish` に寄せた

## Test plan

- [ ] npmjs.com 側で Trusted Publisher が `tomoemon/emiel` + `release.yaml` で登録済みであること
- [ ] `package.json` の version を一時的に少し上げ、`vX.Y.Z` 形式のタグで Release を公開
- [ ] Actions タブで workflow が走り、lint → test → build → publish が成功することを確認
- [ ] `npm view emiel versions` で新バージョンが反映されていること
- [ ] pre-release として Release を公開した場合に publish ステップが skip されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)