### PR TITLE
refactor: 入力タイミング計測を DOMHighResTimeStamp ベースに変更

### DIFF
--- a/docs/automaton-api-design.md
+++ b/docs/automaton-api-design.md
@@ -68,7 +68,7 @@ const a = build(rule, "こんにちは").with({
   getProgress: (state) => (state.currentNode.kanaIndex / state.word.length) * 100,
   getKPM: (state) => {
     const edges = getEffectiveEdges(state);
-    const duration = getLastInputTime(state).getTime() - getFirstInputTime(state).getTime();
+    const duration = getLastInputTime(state) - getFirstInputTime(state);
     return (edges.length / duration) * 60000;
   },
 });

--- a/examples/cli-simple/index.ts
+++ b/examples/cli-simple/index.ts
@@ -83,7 +83,7 @@ function handleChar(str: string) {
   for (const group of stroke.requiredModifier.groups) {
     if (group.modifiers.length > 0) state.keydown(group.modifiers[0]);
   }
-  const ev = new InputEvent(new InputStroke(stroke.key, "keydown"), state, new Date());
+  const ev = new InputEvent(new InputStroke(stroke.key, "keydown"), state, performance.now());
   const result = automaton.input(ev);
   typedKeys += str;
   lastStatus = result.toString();

--- a/examples/cli-test/index.ts
+++ b/examples/cli-test/index.ts
@@ -13,6 +13,8 @@ const automaton = build(loadPresetRuleRoman(layout), "かった");
 const Key = VirtualKeys;
 const inputResult = [Key.K, Key.A, Key.F, Key.T, Key.T, Key.A].map((k) => [
   k,
-  automaton.input(new InputEvent(new InputStroke(k, "keydown"), new KeyboardState(), new Date())),
+  automaton.input(
+    new InputEvent(new InputStroke(k, "keydown"), new KeyboardState(), performance.now()),
+  ),
 ]);
 console.log(inputResult);

--- a/examples/react-result-record/src/App.tsx
+++ b/examples/react-result-record/src/App.tsx
@@ -24,7 +24,7 @@ function TypingRoot(props: { layout: KeyboardLayout }) {
   }, [props.layout]);
   const [wordIndex, setWordIndex] = useState(0);
   const [wordRecords, setWordRecords] = useState<WordRecordValue[]>([]);
-  const onWordFinished = (a: Automaton, displayedAt: Date) => {
+  const onWordFinished = (a: Automaton, displayedAt: DOMHighResTimeStamp) => {
     setWordRecords((wordRecords) => [
       ...wordRecords,
       {

--- a/examples/react-result-record/src/App.tsx
+++ b/examples/react-result-record/src/App.tsx
@@ -1,5 +1,5 @@
 import type { Automaton, KeyboardLayout } from "emiel";
-import { build, detectKeyboardLayout, loadPresetRuleRoman } from "emiel";
+import { build, createDirectInputRule, detectKeyboardLayout, loadPresetRuleRoman } from "emiel";
 import { useEffect, useMemo, useState } from "react";
 import "./App.css";
 import type { WordRecordValue } from "./Record";
@@ -15,13 +15,16 @@ function App() {
 }
 
 function TypingRoot(props: { layout: KeyboardLayout }) {
-  const romanRule = useMemo(() => loadPresetRuleRoman(props.layout), [props.layout]);
+  const rule = useMemo(
+    () => loadPresetRuleRoman(props.layout).compose(createDirectInputRule(props.layout)),
+    [props.layout],
+  );
   const automatons = useMemo(() => {
     const words = ["おをひく", "こんとん", "がっこう", "aから@"];
     return words.map((w) => {
-      return build(romanRule, w);
+      return build(rule, w);
     });
-  }, [props.layout]);
+  }, [rule]);
   const [wordIndex, setWordIndex] = useState(0);
   const [wordRecords, setWordRecords] = useState<WordRecordValue[]>([]);
   const onWordFinished = (a: Automaton, displayedAt: DOMHighResTimeStamp) => {

--- a/examples/react-result-record/src/Record.tsx
+++ b/examples/react-result-record/src/Record.tsx
@@ -70,8 +70,8 @@ export function Record(props: { wordRecords: WordRecordValue[] }) {
         {records.map((r, index) => {
           return (
             <li key={index}>
-              {r.word} latency:{r.latency}ms kpm:{r.kpm} rkpm:{r.rkpm} acc:
-              {(r.accuracy * 100).toFixed(2)}%
+              {r.word} latency:{Math.trunc(r.latency)}ms kpm:{Math.trunc(r.kpm)} rkpm:
+              {Math.trunc(r.rkpm)} acc:{(r.accuracy * 100).toFixed(2)}%
             </li>
           );
         })}

--- a/examples/react-result-record/src/Record.tsx
+++ b/examples/react-result-record/src/Record.tsx
@@ -3,14 +3,14 @@ import { getAccuracy, getKpm, getRkpm } from "emiel";
 
 export type WordRecordValue = {
   automaton: Automaton;
-  displayedAt: Date;
+  displayedAt: DOMHighResTimeStamp;
 };
 
 export function Record(props: { wordRecords: WordRecordValue[] }) {
   const records = props.wordRecords.map((record) => {
     // ワードが表示されてから1打鍵めに成功するまでの経過時間
     const automaton = record.automaton;
-    const latency = automaton.getFirstSucceededInputTime().getTime() - record.displayedAt.getTime();
+    const latency = automaton.getFirstSucceededInputTime() - record.displayedAt;
     const succeededCount = automaton.getEffectiveEdges().length;
     const rkpm = getRkpm(
       succeededCount,

--- a/examples/react-result-record/src/Typing.tsx
+++ b/examples/react-result-record/src/Typing.tsx
@@ -5,12 +5,12 @@ import "./App.css";
 export function Typing(props: {
   layout: emiel.KeyboardLayout;
   automaton: emiel.Automaton;
-  onWordFinished: (a: emiel.Automaton, displayedAt: Date) => void;
+  onWordFinished: (a: emiel.Automaton, displayedAt: DOMHighResTimeStamp) => void;
 }) {
   const [lastInputKey, setLastInputKey] = useState<emiel.InputStroke | undefined>();
   const automaton = props.automaton;
   useEffect(() => {
-    const wordDisplayedAt = new Date();
+    const wordDisplayedAt = performance.now();
     return emiel.activate(window, (e) => {
       setLastInputKey(e.input);
       const result = automaton.input(e);

--- a/src/browser/eventHandler.ts
+++ b/src/browser/eventHandler.ts
@@ -19,28 +19,30 @@ export function activate(
 ) {
   const keyboardState = new KeyboardState();
   const keyDownEventHandler = (evt: Event) => {
-    const keyStroke = toInputKeyStrokeFromKeyboardEvent("keydown", evt as KeyboardEvent, keyMap);
+    const keyboardEvent = evt as KeyboardEvent;
+    const keyStroke = toInputKeyStrokeFromKeyboardEvent("keydown", keyboardEvent, keyMap);
     keyboardState.keydown(keyStroke.key);
-    const now = new Date();
     keyEventHandler(
       new InputEvent(
         keyStroke,
         // キー入力ごとのその時点での KeyboardState を渡す
         new KeyboardState([...keyboardState.downedKeys]),
-        now,
+        // KeyboardEvent.timeStamp はブラウザがイベントを受け取った時刻 (DOMHighResTimeStamp)。
+        // ハンドラ実行時刻ではなく、イベントループ遅延を含まない。
+        keyboardEvent.timeStamp,
       ),
     );
   };
   const keyUpEventHandler = (evt: Event) => {
-    const keyStroke = toInputKeyStrokeFromKeyboardEvent("keyup", evt as KeyboardEvent, keyMap);
+    const keyboardEvent = evt as KeyboardEvent;
+    const keyStroke = toInputKeyStrokeFromKeyboardEvent("keyup", keyboardEvent, keyMap);
     keyboardState.keyup(keyStroke.key);
-    const now = new Date();
     keyEventHandler(
       new InputEvent(
         keyStroke,
         // キー入力ごとのその時点での KeyboardState を渡す
         new KeyboardState([...keyboardState.downedKeys]),
-        now,
+        keyboardEvent.timeStamp,
       ),
     );
   };

--- a/src/core/automaton.test.ts
+++ b/src/core/automaton.test.ts
@@ -173,7 +173,7 @@ function runInputsOn(
       state.keyup(ev.key);
     }
     const result = automaton.input(
-      new InputEvent(new InputStroke(ev.key, ev.type), state, new Date()),
+      new InputEvent(new InputStroke(ev.key, ev.type), state, performance.now()),
     );
     results.push(result.toString());
   }
@@ -295,7 +295,7 @@ describe("Automaton backspace stroke integration", () => {
     const state = new KeyboardState();
     state.keydown(VirtualKeys.U);
     const [result] = automaton.testInput(
-      new InputEvent(new InputStroke(VirtualKeys.U, "keydown"), state, new Date()),
+      new InputEvent(new InputStroke(VirtualKeys.U, "keydown"), state, performance.now()),
     );
     expect(result.isBack).toBe(true);
     // dryRun では状態を動かさない

--- a/src/core/committer.test.ts
+++ b/src/core/committer.test.ts
@@ -33,7 +33,7 @@ function runInputs(
       state.keyup(ev.key);
     }
     const result = automaton.input(
-      new InputEvent(new InputStroke(ev.key, ev.type), state, new Date()),
+      new InputEvent(new InputStroke(ev.key, ev.type), state, performance.now()),
     );
     results.push(result.toString());
   }

--- a/src/core/inputEvent.ts
+++ b/src/core/inputEvent.ts
@@ -15,8 +15,12 @@ export class InputEvent {
     readonly keyboardState: KeyboardStateReader,
     /**
      * 入力イベントの発生時刻 (DOMHighResTimeStamp, ミリ秒・sub-ms 精度)。
-     * ブラウザでは KeyboardEvent.timeStamp、それ以外では performance.now() の値を渡す。
-     * 単調時計なので差分で経過時間を計算できる。
+     *
+     * `activate()` 経由で受け取る場合は `KeyboardEvent.timeStamp` が自動でセットされる。
+     * 自前で InputEvent を生成する場合は高精度タイマー `performance.now()` の値を渡すこと。
+     * `Date.now()` や `new Date().getTime()` は時間軸が異なるため使用不可。
+     *
+     * 単調時計なので、同じく `performance.now()` で取得した他の時刻との差分で経過時間を計算できる。
      */
     readonly timestamp: DOMHighResTimeStamp,
   ) {}

--- a/src/core/inputEvent.ts
+++ b/src/core/inputEvent.ts
@@ -13,6 +13,11 @@ export class InputEvent {
   constructor(
     readonly input: InputStroke,
     readonly keyboardState: KeyboardStateReader,
-    readonly timestamp: Date,
+    /**
+     * 入力イベントの発生時刻 (DOMHighResTimeStamp, ミリ秒・sub-ms 精度)。
+     * ブラウザでは KeyboardEvent.timeStamp、それ以外では performance.now() の値を渡す。
+     * 単調時計なので差分で経過時間を計算できる。
+     */
+    readonly timestamp: DOMHighResTimeStamp,
   ) {}
 }

--- a/src/impl/automatonQuery.ts
+++ b/src/impl/automatonQuery.ts
@@ -78,8 +78,11 @@ export function getPendingStroke(state: AutomatonState): RuleStroke[] {
 
 /**
  * 最初の入力時刻（成功・失敗問わず）
+ *
+ * 戻り値は DOMHighResTimeStamp (ミリ秒、sub-ms 精度の単調時計)。
+ * 差分で経過時間を計算できる。
  */
-export function getFirstInputTime(state: AutomatonState): Date {
+export function getFirstInputTime(state: AutomatonState): DOMHighResTimeStamp {
   const entries = inputEntries(state);
   return entries[0].event.timestamp;
 }
@@ -87,7 +90,7 @@ export function getFirstInputTime(state: AutomatonState): Date {
 /**
  * 最後の入力時刻（成功・失敗問わず）
  */
-export function getLastInputTime(state: AutomatonState): Date {
+export function getLastInputTime(state: AutomatonState): DOMHighResTimeStamp {
   const entries = inputEntries(state);
   return entries[entries.length - 1].event.timestamp;
 }
@@ -95,7 +98,7 @@ export function getLastInputTime(state: AutomatonState): Date {
 /**
  * 最初の成功入力時刻
  */
-export function getFirstSucceededInputTime(state: AutomatonState): Date {
+export function getFirstSucceededInputTime(state: AutomatonState): DOMHighResTimeStamp {
   const entries = inputEntries(state);
   const first = entries.find((e) => e.result.isSucceeded);
   if (!first) {
@@ -107,7 +110,7 @@ export function getFirstSucceededInputTime(state: AutomatonState): Date {
 /**
  * 最後の成功入力時刻
  */
-export function getLastSucceededInputTime(state: AutomatonState): Date {
+export function getLastSucceededInputTime(state: AutomatonState): DOMHighResTimeStamp {
   const entries = inputEntries(state);
   for (let i = entries.length - 1; i >= 0; i--) {
     if (entries[i].result.isSucceeded) {
@@ -164,8 +167,8 @@ function computeEffectiveStats(state: AutomatonState) {
   }
 
   let failedCount = 0;
-  let firstSucceededTime: Date | undefined;
-  let lastSucceededTime: Date | undefined;
+  let firstSucceededTime: DOMHighResTimeStamp | undefined;
+  let lastSucceededTime: DOMHighResTimeStamp | undefined;
   for (let i = 0; i < state.inputHistory.length; i++) {
     if (backed.has(i)) continue;
     const entry = state.inputHistory[i];
@@ -197,7 +200,7 @@ export function getEffectiveTotalInputCount(state: AutomatonState): number {
 /**
  * back() で取り消されていない最初の成功入力時刻
  */
-export function getEffectiveFirstSucceededInputTime(state: AutomatonState): Date {
+export function getEffectiveFirstSucceededInputTime(state: AutomatonState): DOMHighResTimeStamp {
   const { firstSucceededTime } = computeEffectiveStats(state);
   if (!firstSucceededTime) throw new Error("No effective succeeded input found");
   return firstSucceededTime;
@@ -206,7 +209,7 @@ export function getEffectiveFirstSucceededInputTime(state: AutomatonState): Date
 /**
  * back() で取り消されていない最後の成功入力時刻
  */
-export function getEffectiveLastSucceededInputTime(state: AutomatonState): Date {
+export function getEffectiveLastSucceededInputTime(state: AutomatonState): DOMHighResTimeStamp {
   const { lastSucceededTime } = computeEffectiveStats(state);
   if (!lastSucceededTime) throw new Error("No effective succeeded input found");
   return lastSucceededTime;

--- a/src/impl/stats.ts
+++ b/src/impl/stats.ts
@@ -12,12 +12,16 @@ export function getAccuracy(failedCount: number, succeededCount: number): number
  * KPM (1分あたりの打鍵数) を計算する
  *
  * @param succeededCount 正しく入力できた打鍵数
- * @param startedAt  開始時刻（一般的にワードが表示されて入力可能になった時刻）
- * @param finishedAt 終了時刻（一般的にワードの入力が完了した時刻）
+ * @param startedAt  開始時刻（一般的にワードが表示されて入力可能になった時刻、ミリ秒）
+ * @param finishedAt 終了時刻（一般的にワードの入力が完了した時刻、ミリ秒）
  * @returns
  */
-export function getKpm(succeededCount: number, startedAt: Date, finishedAt: Date): number {
-  return Math.trunc((succeededCount / (finishedAt.getTime() - startedAt.getTime())) * 1000 * 60);
+export function getKpm(
+  succeededCount: number,
+  startedAt: DOMHighResTimeStamp,
+  finishedAt: DOMHighResTimeStamp,
+): number {
+  return Math.trunc((succeededCount / (finishedAt - startedAt)) * 1000 * 60);
 }
 
 /**
@@ -26,12 +30,14 @@ export function getKpm(succeededCount: number, startedAt: Date, finishedAt: Date
  * 「latency の時間を除く」＝「1打鍵めに要する時間を除く」ということなので、打鍵数を1減らして計算する
  *
  * @param succeededCount 正しく入力できた打鍵数
- * @param firstInputtedAt 1打鍵目の入力時刻
- * @param finishedAt 終了時刻（一般的にワードの入力が完了した時刻）
+ * @param firstInputtedAt 1打鍵目の入力時刻（ミリ秒）
+ * @param finishedAt 終了時刻（一般的にワードの入力が完了した時刻、ミリ秒）
  * @returns
  */
-export function getRkpm(succeededCount: number, firstInputtedAt: Date, finishedAt: Date): number {
-  return Math.trunc(
-    ((succeededCount - 1) / (finishedAt.getTime() - firstInputtedAt.getTime())) * 1000 * 60,
-  );
+export function getRkpm(
+  succeededCount: number,
+  firstInputtedAt: DOMHighResTimeStamp,
+  finishedAt: DOMHighResTimeStamp,
+): number {
+  return Math.trunc(((succeededCount - 1) / (finishedAt - firstInputtedAt)) * 1000 * 60);
 }

--- a/src/impl/stats.ts
+++ b/src/impl/stats.ts
@@ -11,9 +11,13 @@ export function getAccuracy(failedCount: number, succeededCount: number): number
 /**
  * KPM (1分あたりの打鍵数) を計算する
  *
+ * 時刻は高精度タイマー `performance.now()` で取得した DOMHighResTimeStamp (ミリ秒) を渡す。
+ * automaton から取得する入力時刻（`getLastSucceededInputTime()` 等）も同じ時間軸なので
+ * `finishedAt` にそのまま渡せる。
+ *
  * @param succeededCount 正しく入力できた打鍵数
- * @param startedAt  開始時刻（一般的にワードが表示されて入力可能になった時刻、ミリ秒）
- * @param finishedAt 終了時刻（一般的にワードの入力が完了した時刻、ミリ秒）
+ * @param startedAt  開始時刻（一般的にワードが表示されて入力可能になった時刻）。`performance.now()` で取得
+ * @param finishedAt 終了時刻（一般的にワードの入力が完了した時刻）。`automaton.getLastSucceededInputTime()` 等で取得
  * @returns
  */
 export function getKpm(
@@ -21,7 +25,7 @@ export function getKpm(
   startedAt: DOMHighResTimeStamp,
   finishedAt: DOMHighResTimeStamp,
 ): number {
-  return Math.trunc((succeededCount / (finishedAt - startedAt)) * 1000 * 60);
+  return (succeededCount / (finishedAt - startedAt)) * 1000 * 60;
 }
 
 /**
@@ -29,9 +33,13 @@ export function getKpm(
  *
  * 「latency の時間を除く」＝「1打鍵めに要する時間を除く」ということなので、打鍵数を1減らして計算する
  *
+ * 時刻は高精度タイマー  `performance.now()` で取得した DOMHighResTimeStamp (ミリ秒) を渡す。
+ * automaton から取得する入力時刻（`getFirstSucceededInputTime()`, `getLastSucceededInputTime()` 等）
+ * も同じ時間軸なのでそのまま渡せる。
+ *
  * @param succeededCount 正しく入力できた打鍵数
- * @param firstInputtedAt 1打鍵目の入力時刻（ミリ秒）
- * @param finishedAt 終了時刻（一般的にワードの入力が完了した時刻、ミリ秒）
+ * @param firstInputtedAt 1打鍵目の入力時刻。`automaton.getFirstSucceededInputTime()` 等で取得
+ * @param finishedAt 終了時刻（一般的にワードの入力が完了した時刻）。`automaton.getLastSucceededInputTime()` 等で取得
  * @returns
  */
 export function getRkpm(
@@ -39,5 +47,5 @@ export function getRkpm(
   firstInputtedAt: DOMHighResTimeStamp,
   finishedAt: DOMHighResTimeStamp,
 ): number {
-  return Math.trunc(((succeededCount - 1) / (finishedAt - firstInputtedAt)) * 1000 * 60);
+  return ((succeededCount - 1) / (finishedAt - firstInputtedAt)) * 1000 * 60;
 }


### PR DESCRIPTION
## Summary

- `InputEvent.timestamp` の型を `Date` から `DOMHighResTimeStamp` (`number`) に変更
- ブラウザでは `KeyboardEvent.timeStamp` を直接記録し、イベントループ遅延の影響を排除
- `automatonQuery` の `get*InputTime` 系 6 関数および `stats.getKpm` / `stats.getRkpm` の引数・戻り値の型を同期
- `getKpm` / `getRkpm` の `Math.trunc` を削除し、丸めを呼び出し側の責務に移譲
- 時刻引数の JSDoc を追記（`performance.now()` で取得し、`automaton.get*SucceededInputTime()` と同じ時間軸で渡せる旨を明記）
- `react-result-record` example のバグ修正（`"aから@"` のような英数字混在ワードを build できるよう `createDirectInputRule` と合成）

## 設計の背景

従来の `Date` + `getTime()` による時刻管理には以下の問題があった:

- `Date` はミリ秒精度の壁時計であり sub-ms 精度を保持できない
- ブラウザで `new Date()` をハンドラ内で呼ぶと、イベント発生時刻ではなくハンドラ実行時刻が記録され、イベントループ遅延分の誤差が乗る
- `Date.now()` は壁時計なので NTP 同期等で逆行する可能性がある

`DOMHighResTimeStamp` (= `performance.now()` / `KeyboardEvent.timeStamp`) は単調増加・sub-ms 精度の高精度タイマーであり、タイピング計測用途に適している。`KeyboardEvent.timeStamp` と `performance.now()` は同じタイムオリジン（`performance.timeOrigin`）なので、ワード表示時刻と入力時刻を同一軸で比較できる。

`Math.trunc` を除去した理由は、ライブラリは生の値を返すべきで、整形は呼び出し側の責務だから。`getAccuracy` が小数を返すのと同じ方針に揃えた。

## 検討した代替案

- `Date` のまま `sub-ms` 精度の拡張プロパティを持つ独自型を追加: API が複雑化する上、`performance.now()` という既存の標準 API と重複するため不採用
- `number` 型をそのまま露出（`DOMHighResTimeStamp` を使わない）: 型名から意味が読み取れず、`Date.now()` 由来の壁時計値と混同する余地があるため不採用
- `getKpm` の戻り値を `number` ではなく独自の `Kpm` 型に: 過剰設計と判断し見送り

## 破壊的変更

- `InputEvent.timestamp`: `Date` → `DOMHighResTimeStamp`
- `automatonQuery.get{First,Last}InputTime` / `get{First,Last}SucceededInputTime` / `getEffective{First,Last}SucceededInputTime`: 戻り値が `Date` → `DOMHighResTimeStamp`
- `stats.getKpm` / `stats.getRkpm`: 引数が `Date` → `DOMHighResTimeStamp`、戻り値が整数 → 実数

## Test plan

- [x] `pnpm run test` が通る（17 files, 140 tests）
- [x] `pnpm run lint` が通る
- [x] `pnpm run build` が通る
- [x] `react-result-record` example を起動し "aから@" のワードで console エラーが出ないこと
- [x] latency / kpm / rkpm が整数表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)