### PR TITLE
docs: 公開 API に JSDoc を追加し、preset キャッシュを廃止

### DIFF
--- a/src/browser/osKeyboardLayout.ts
+++ b/src/browser/osKeyboardLayout.ts
@@ -2,6 +2,13 @@ import { VirtualKeys } from "..";
 import type { KeyboardLayout } from "../core/keyboardLayout";
 import { findMatchedKeyboardLayout, loadPresetKeyboardLayoutQwertyJis } from "../impl/presets";
 
+/**
+ * ブラウザの Keyboard API (`navigator.keyboard.getLayoutMap()`) を使って、
+ * OS に設定されたキーボード配列を推定し、対応する `KeyboardLayout` を返す。
+ *
+ * Keyboard API は Chrome/Edge のみ対応。未対応ブラウザでは QWERTY JIS を
+ * フォールバックとして返す。
+ */
 export async function detectKeyboardLayout(
   window: Window & { navigator: { keyboard?: { getLayoutMap(): Promise<Map<string, string>> } } },
 ): Promise<KeyboardLayout> {

--- a/src/core/automaton.ts
+++ b/src/core/automaton.ts
@@ -10,6 +10,11 @@ import { InputResult } from "./inputResult";
 import type { Rule, RulePrimitive } from "./rule";
 import type { VirtualKey } from "./virtualKey";
 
+/**
+ * タイピング状態機械の実装本体。`build(rule, word)` 経由で生成し、
+ * `input()` / `testInput()` で打鍵を受け付け、`back()` / `reset()` で状態を巻き戻す。
+ * 通常は型 `Automaton` (AutomatonImpl + 拡張クエリ) として利用する。
+ */
 export class AutomatonImpl implements AutomatonState {
   /**
    * @param word かな文字列（配列定義 Rule で使用可能な文字で構成される文字列）

--- a/src/core/builderKanaGraph.ts
+++ b/src/core/builderKanaGraph.ts
@@ -2,13 +2,19 @@ import { setDefaultFunc } from "../utils/map";
 import type { normalizerFunc, Rule, RuleEntry, RulePrimitive } from "./rule";
 import type { RuleStroke } from "./ruleStroke";
 
-// build 中にのみ使用する
+/**
+ * Automaton 構築中にのみ利用する中間表現。かな文字列上の 1 位置を表すノード。
+ */
 export class KanaNode {
   constructor(
+    /** このノードが対応する、かな文字列の開始位置 */
     readonly startIndex: number,
+    /** このノードから次のノードへ遷移する辺 */
     readonly nextEdges: KanaEdge[],
+    /** 前のノードからこのノードへ遷移してくる辺 */
     readonly previousEdges: KanaEdge[],
   ) {}
+  /** entry の nextInput が次ノードの入力先頭と繋がる場合、その連結エッジを previousNode に追加する */
   connectEdgesWithNextInput(previousNode: KanaNode, entry: RuleEntry) {
     this.nextEdges
       .filter((edge) => edge.canConnectWithNextInput(entry.nextInput))
@@ -20,21 +26,28 @@ export class KanaNode {
         edge.next.previousEdges.push(newEdge);
       });
   }
+  /** targetNode を next とする辺を、この KanaNode の nextEdges から除去する */
   clearNextEdgesTo(targetNode: KanaNode) {
     const newNodes = this.nextEdges.filter((edge) => edge.next !== targetNode);
     this.nextEdges.splice(0, this.nextEdges.length, ...newNodes);
   }
+  /** このノードから先へ遷移する辺がないか（＝終端かどうか） */
   isEnd(): boolean {
     return this.nextEdges.length === 0;
   }
 }
 
-// KanaNode間をつなぐ辺
-// build 中にのみ使用する
+/**
+ * KanaNode 間を繋ぐ辺。Automaton 構築中にのみ利用する中間表現。
+ * 1 つの辺が 1 つ以上の RuleEntry 列を担う（nextInput による連結も含む）。
+ */
 export class KanaEdge {
   constructor(
+    /** この辺を構成するエントリ列 */
     readonly entries: RuleEntry[],
+    /** 遷移先 KanaNode */
     readonly next: KanaNode,
+    /** 遷移元 KanaNode */
     readonly previous: KanaNode,
   ) {}
 
@@ -61,8 +74,8 @@ export class KanaEdge {
     return result;
   }
 
-  /*
-  nextInput を渡されたときに、この Edge からつながる Entry の input が nextInput とつながるかどうかを判定する
+  /**
+   * 渡された nextInput と、この Edge の先頭 Entry の input が連結可能かを判定する。
    */
   canConnectWithNextInput(nextInput: RuleStroke[]): boolean {
     return this.entries[0].isConnetableAfter(nextInput);
@@ -97,6 +110,11 @@ export type BuildKanaNodeResult = {
   rulesByKanaIndex: readonly (readonly RulePrimitive[])[];
 };
 
+/**
+ * Rule と入力対象のかな文字列から KanaNode グラフを構築する。
+ * 終端に繋がらない辺は除去され、開始ノードから終端まで到達可能な経路のみが残る。
+ * 構築不能な場合は例外を投げる。
+ */
 export function buildKanaNode(
   rule: Rule,
   kanaText: string,

--- a/src/core/builderStrokeGraph.ts
+++ b/src/core/builderStrokeGraph.ts
@@ -2,13 +2,21 @@ import { setDefault } from "../utils/map";
 import type { KanaNode } from "./builderKanaGraph";
 import type { RuleStroke } from "./ruleStroke";
 
+/**
+ * Automaton グラフ上の 1 つの状態 (ノード) を表す。
+ * currentNode としてユーザの入力位置を保持し、次打鍵の候補 nextEdges を持つ。
+ */
 export class StrokeNode {
   private cost: number = 0; // このノードから打ち切るまでの最短ストローク数
   constructor(
-    readonly kanaIndex: number, // 今入力しようとしている KanaNode
+    /** このノードが対応するかな文字列上の位置 */
+    readonly kanaIndex: number,
+    /** このノードへ遷移してくる辺の一覧 */
     readonly previousEdges: StrokeEdge[],
+    /** このノードから次へ遷移する辺の一覧（先頭が最小コスト経路） */
     readonly nextEdges: StrokeEdge[],
   ) {}
+  /** このノードから終端まで打ち切るのに必要な最小ストローク数を返す */
   getCost(): number {
     return this.cost;
   }
@@ -22,14 +30,25 @@ export class StrokeNode {
   }
 }
 
+/**
+ * 2 つの StrokeNode を 1 打鍵で結ぶ有向辺。
+ * input が受理されると previous から next へ遷移する。
+ */
 export class StrokeEdge {
   constructor(
+    /** この辺が受理する 1 打鍵 */
     readonly input: RuleStroke,
+    /** 遷移元のノード */
     readonly previous: StrokeNode,
+    /** 遷移先のノード */
     readonly next: StrokeNode,
   ) {}
 }
 
+/**
+ * かなグラフ (KanaNode) から StrokeNode グラフを構築し、開始ノードを返す。
+ * 各ノードの nextEdges は最小コスト経路を先頭とする順序で整列される。
+ */
 export function buildStrokeNode(endKanaNode: KanaNode): StrokeNode {
   // KanaNode の index に対応する StrokeNode
   const kanaStrokeNodeMap = new Map<number, StrokeNode>();

--- a/src/core/committer.ts
+++ b/src/core/committer.ts
@@ -427,22 +427,26 @@ export class BackspaceAwareCommitter {
     );
   }
 
+  /** 入力を受け取り、backspace 含む 5 分類の結果を返すと同時に内部状態を更新する。 */
   feed(event: InputEvent, nodeEdges: readonly StrokeEdge[], rule: Rule): BackspaceAwareResult {
     const allEdges = [...nodeEdges, ...this.backspaceEdges];
     const result = this.inner.feed(event, allEdges, rule);
     return this.classify(result);
   }
 
+  /** 副作用なしで、入力を受け取ったらどう分類されるかだけを返す。 */
   dryRun(event: InputEvent, nodeEdges: readonly StrokeEdge[], rule: Rule): BackspaceAwareResult {
     const allEdges = [...nodeEdges, ...this.backspaceEdges];
     const result = this.inner.dryRun(event, allEdges, rule);
     return this.classify(result);
   }
 
+  /** 内部の pending 状態を完全にリセットする。 */
   reset(): void {
     this.inner.reset();
   }
 
+  /** 現在 pending 中のキー集合を取得する (可視化用の公開 API)。 */
   get pendingKeys(): readonly VirtualKey[] {
     return this.inner.pendingKeys;
   }

--- a/src/core/inputEvent.ts
+++ b/src/core/inputEvent.ts
@@ -1,17 +1,31 @@
 import type { KeyboardStateReader } from "./keyboardState";
 import type { VirtualKey } from "./virtualKey";
 
+/** キーイベントの種別。keydown はキー押下、keyup はキー解放。 */
 export type KeyEventType = "keyup" | "keydown";
+
+/**
+ * 1 つのキーの押下／解放イベントを表す最小単位。
+ * InputEvent のコンストラクタに渡す値として利用する。
+ */
 export class InputStroke {
   constructor(
+    /** 対象の仮想キー */
     readonly key: VirtualKey,
+    /** keydown か keyup か */
     readonly type: KeyEventType,
   ) {}
 }
 
+/**
+ * Automaton.input() / testInput() に渡す 1 回の入力イベント。
+ * 打鍵そのもの (input) と発生時点のキーボード状態 (keyboardState) 、発生時刻を保持する。
+ */
 export class InputEvent {
   constructor(
+    /** 今回の入力打鍵 */
     readonly input: InputStroke,
+    /** 入力発生時点のキーボード押下状態 (モディファイア判定等に使用) */
     readonly keyboardState: KeyboardStateReader,
     /**
      * 入力イベントの発生時刻 (DOMHighResTimeStamp, ミリ秒・sub-ms 精度)。

--- a/src/core/inputResult.ts
+++ b/src/core/inputResult.ts
@@ -1,3 +1,7 @@
+/**
+ * `Automaton.input()` / `testInput()` の戻り値として、1 打鍵の結果を表すクラス。
+ * 内部的には 7 つのシングルトン (静的定数) を返し、`isFailed` 等の getter で分類できる。
+ */
 export class InputResult {
   constructor(
     private readonly type:
@@ -10,48 +14,59 @@ export class InputResult {
       | "back", // Rule.backspaceStrokes に一致して backspace 動作が発火した
   ) {}
 
+  /** modifier キーの単独押下など、無視された入力 */
   static readonly IGNORED = new InputResult("ignored");
+  /** ルールに違反した入力（ミスタイプ） */
   static readonly FAILED = new InputResult("failed");
+  /** 1 打鍵分の進捗に成功したが、かな 1 文字の確定には届いていない */
   static readonly KEY_SUCCEEDED = new InputResult("key_succeeded");
+  /** かな 1 文字以上を確定させる打鍵に成功した */
   static readonly KANA_SUCCEEDED = new InputResult("kana_succeeded");
+  /** ワード全体の入力が完了する打鍵に成功した */
   static readonly FINISHED = new InputResult("finished");
+  /** 確定待ち（同時押しの追加入力や keyup を待機中） */
   static readonly PENDING = new InputResult("pending");
+  /** Rule.backspaceStrokes に一致し、backspace として扱われた入力 */
   static readonly BACK = new InputResult("back");
 
+  /** デバッグ用途で内部種別を文字列として返す */
   toString(): string {
     return this.type;
   }
-  // 今回の打鍵が無視されたかどうか（シフトキー等のモディファイアキーの単独入力の場合）
+  /** 今回の打鍵が無視されたかどうか（シフトキー等のモディファイアキーの単独入力の場合） */
   get isIgnored(): boolean {
     return this.type === "ignored";
   }
+  /** 今回の入力が確定待ち（同時押しの追加入力や keyup を待機中）であるかどうか */
   get isPending(): boolean {
     return this.type === "pending";
   }
-  // 今回の1打鍵が入力ミスだったかどうか
+  /** 今回の1打鍵が入力ミスだったかどうか */
   get isFailed(): boolean {
     return this.type === "failed";
   }
-  // 今回の入力に成功したかどうか
+  /** 今回の入力に成功したかどうか */
   get isSucceeded(): boolean {
     return (
       this.type === "key_succeeded" || this.type === "kana_succeeded" || this.type === "finished"
     );
   }
-  // isSucceeded:true の場合の詳細な情報: 今回の1打鍵でかな1文字分の遷移はしていない
+  /** isSucceeded:true の場合の詳細な情報: 今回の1打鍵でかな1文字分の遷移はしていない */
   get isKeySucceeded(): boolean {
     return this.type === "key_succeeded";
   }
-  // isSucceeded:true の場合の詳細な情報: 今回の1打鍵でかな1文字分以上の遷移をした
+  /** isSucceeded:true の場合の詳細な情報: 今回の1打鍵でかな1文字分以上の遷移をした */
   get isKanaSucceeded(): boolean {
     return this.type === "kana_succeeded";
   }
-  // isSucceeded:true の場合の詳細な情報: 今回の1打鍵でワードの入力が完了した
+  /** isSucceeded:true の場合の詳細な情報: 今回の1打鍵でワードの入力が完了した */
   get isFinished(): boolean {
     return this.type === "finished";
   }
-  // 今回の入力が Rule.backspaceStrokes にマッチして backspace として処理された
-  // isSucceeded / isFailed / isIgnored のいずれにも属さない独立カテゴリ
+  /**
+   * 今回の入力が Rule.backspaceStrokes にマッチして backspace として処理された。
+   * isSucceeded / isFailed / isIgnored のいずれにも属さない独立カテゴリ。
+   */
   get isBack(): boolean {
     return this.type === "back";
   }

--- a/src/core/keyboardLayout.ts
+++ b/src/core/keyboardLayout.ts
@@ -5,13 +5,22 @@ import { AndModifier, ModifierGroup } from "./modifier";
 import { SingleStroke } from "./ruleStroke";
 import type { VirtualKey } from "./virtualKey";
 
+/**
+ * 論理キーボードレイアウト。
+ * 「文字 ⇄ 物理キー」の対応関係を保持し、レイアウトに依存した文字／ストロークの相互変換を提供する。
+ * QWERTY US, QWERTY JIS, Dvorak, Colemak などの物理レイアウトの違いを表現する。
+ */
 export class KeyboardLayout {
+  /** 文字から、その文字を入力しうる SingleStroke 候補の一覧を引くインデックス */
   readonly strokesByChar: Map<string, SingleStroke[]>;
   private readonly charByStroke: Map<string, string>;
   private readonly charByStrokeWithoutShift: Map<string, string>;
   constructor(
+    /** レイアウトの名前や URL 等の付随情報 */
     readonly metadata: Metadata = emptyMetadata(),
+    /** [文字, 対応する SingleStroke] のペア列。同一文字に複数打鍵が存在してもよい */
     readonly mapping: [string, SingleStroke][] = [],
+    /** このレイアウトで Shift として扱う仮想キー集合（例: [ShiftLeft, ShiftRight]） */
     readonly shiftKeys: VirtualKey[] = [],
   ) {
     this.strokesByChar = new Map();
@@ -23,6 +32,9 @@ export class KeyboardLayout {
       setDefault(this.charByStrokeWithoutShift, strokeToString(stroke, true, this.shiftKeys), char);
     });
   }
+  /**
+   * 指定文字を入力しうる SingleStroke 候補を返す。該当する打鍵が無い場合は例外を投げる。
+   */
   getStrokesByChar(char: string): SingleStroke[] {
     const strokes = this.strokesByChar.get(char);
     if (!strokes) {
@@ -30,6 +42,10 @@ export class KeyboardLayout {
     }
     return strokes;
   }
+  /**
+   * 物理キー + Shift 押下状態の組み合わせから、このレイアウトで入力される文字を返す。
+   * 定義がない組み合わせを渡した場合は例外を投げる。
+   */
   getCharByKey(key: VirtualKey, shifted: boolean): string {
     const stroke = new SingleStroke(
       key,
@@ -37,6 +53,9 @@ export class KeyboardLayout {
     );
     return this.getCharByStroke(stroke);
   }
+  /**
+   * SingleStroke に対応する文字を返す。定義がない場合は例外を投げる。
+   */
   getCharByStroke(stroke: SingleStroke): string {
     const char = this.charByStroke.get(strokeToString(stroke, false, this.shiftKeys));
     if (char) {
@@ -46,6 +65,7 @@ export class KeyboardLayout {
       `invalid stroke: ${stroke.key.toString()}, mod: ${stroke.requiredModifier.toString()}`,
     );
   }
+  /** この KeyboardLayout 上で、指定文字を入力する打鍵が 1 つでも定義されているか */
   hasChar(char: string): boolean {
     return this.strokesByChar.has(char);
   }

--- a/src/core/keyboardState.ts
+++ b/src/core/keyboardState.ts
@@ -1,10 +1,19 @@
 import type { VirtualKey } from "./virtualKey";
 
+/**
+ * キーボードの押下状態を読み取るための read-only なインターフェース。
+ * InputEvent.keyboardState として渡される値がこの型。
+ */
 export interface KeyboardStateReader {
+  /** 現在押下中のキー一覧 */
   get downedKeys(): readonly VirtualKey[];
+  /** 指定キーが押下中か */
   isKeyDowned(key: VirtualKey): boolean;
+  /** 渡したキーが「すべて」押下中か */
   isAllKeyDowned(...keys: VirtualKey[]): boolean;
+  /** 渡したキーのうち「いずれか」が押下中か */
   isAnyKeyDowned(...keys: VirtualKey[]): boolean;
+  /** 渡したキーのうち、実際に押下中であるものだけを返す */
   findDownedKeys(...keys: VirtualKey[]): VirtualKey[];
 }
 
@@ -18,24 +27,31 @@ export class KeyboardState implements KeyboardStateReader {
   // オブジェクトの同値性ではなく（その方法がない）、同一性で比較されるため、重複した値がセットされてしまう恐れがある
   // そのため、ここでは配列として持った上で equals で明示的に同値チェックを行っている
   constructor(private _downedKeys: VirtualKey[] = []) {}
+  /** 現在押下中のキー一覧（順序は押下順） */
   get downedKeys(): readonly VirtualKey[] {
     return this._downedKeys;
   }
+  /** 指定キーを押下状態として記録する */
   keydown(key: VirtualKey) {
     this._downedKeys.push(key);
   }
+  /** 指定キーを押下状態から外す */
   keyup(key: VirtualKey) {
     this._downedKeys = this._downedKeys.filter((v) => v !== key);
   }
+  /** 指定キーが押下中か */
   isKeyDowned(key: VirtualKey) {
     return this._downedKeys.indexOf(key) >= 0;
   }
+  /** 渡したキーが「すべて」押下中か */
   isAllKeyDowned(...keys: VirtualKey[]) {
     return keys.every((key) => this.isKeyDowned(key));
   }
+  /** 渡したキーのうち「いずれか」が押下中か */
   isAnyKeyDowned(...keys: VirtualKey[]) {
     return keys.some((key) => this.isKeyDowned(key));
   }
+  /** 渡したキーのうち、実際に押下中であるものだけを返す */
   findDownedKeys(...keys: VirtualKey[]): VirtualKey[] {
     return keys.filter((key) => this.isKeyDowned(key));
   }

--- a/src/core/metadata.ts
+++ b/src/core/metadata.ts
@@ -1,8 +1,14 @@
+/**
+ * ルールやキーボードレイアウト等に付与する、名称と参照 URL のメタデータ。
+ */
 export type Metadata = {
+  /** 表示用の名称 (例: "NICOLA", "QWERTY JIS") */
   name: string;
+  /** 由来や仕様の参照 URL */
   url: string;
 };
 
+/** name, url ともに空文字の Metadata を生成する。省略時のデフォルトとして使用する。 */
 export function emptyMetadata(): Metadata {
   return { name: "", url: "" };
 }

--- a/src/core/modifier.ts
+++ b/src/core/modifier.ts
@@ -7,10 +7,15 @@ import type { VirtualKey } from "./virtualKey";
  * 例：modifiers: [ShiftLeft, ShiftRight]
  */
 export class ModifierGroup {
-  constructor(readonly modifiers: VirtualKey[]) {}
+  constructor(
+    /** このグループを構成する修飾キー候補（いずれか 1 つ以上の押下で accept される） */
+    readonly modifiers: VirtualKey[],
+  ) {}
+  /** modifiers のいずれか 1 つが押下中なら true */
   accept(state: KeyboardStateReader): boolean {
     return state.isAnyKeyDowned(...this.modifiers);
   }
+  /** 同じ modifiers 構成であれば true（要素の順序も含めて比較） */
   equals(other: ModifierGroup): boolean {
     return (
       this.modifiers.length === other.modifiers.length &&
@@ -24,15 +29,19 @@ export class ModifierGroup {
       ...other.modifiers.filter((v) => !this.modifiers.includes(v)),
     ]);
   }
+  /** 指定キーがこのグループに含まれているか */
   has(key: VirtualKey): boolean {
     return this.modifiers.some((v) => v === key);
   }
+  /** AndModifier と同形に扱うための便宜 getter。自身を 1 要素配列で返す。 */
   get groups(): ModifierGroup[] {
     return [this];
   }
+  /** デバッグ表示用文字列（`ShiftLeft|ShiftRight` のように `|` 区切り） */
   toString(): string {
     return `${this.modifiers.map((v) => v.toString()).join("|")}`;
   }
+  /** 空グループのシングルトン */
   static readonly empty = new ModifierGroup([]);
 }
 
@@ -41,19 +50,24 @@ export class ModifierGroup {
  * 与えられたグループがすべて accept されるときに accept される
  */
 export class AndModifier {
+  /** この AndModifier を構成する修飾キーグループ（空グループは除外済み） */
   readonly groups: ModifierGroup[];
   constructor(...groups: ModifierGroup[]) {
     this.groups = groups.filter((v) => v.modifiers.length > 0);
   }
+  /** 修飾キーの指定が 1 つもないか */
   get isEmpty(): boolean {
     return this.groups.length === 0;
   }
+  /** 指定キーが、いずれかのグループに含まれているか */
   has(key: VirtualKey): boolean {
     return this.groups.some((v) => v.has(key));
   }
+  /** すべてのグループが accept されるときに true */
   accept(state: KeyboardStateReader): boolean {
     return this.groups.every((group) => group.accept(state));
   }
+  /** グループ構成と順序が一致すれば true */
   equals(other: AndModifier): boolean {
     return (
       this.groups.length === other.groups.length &&
@@ -75,8 +89,10 @@ export class AndModifier {
       )
     );
   }
+  /** デバッグ表示用文字列（グループを `&` で連結） */
   toString(): string {
     return `${this.groups.map((v) => v.toString()).join("&")}`;
   }
+  /** 修飾キーなしを表すシングルトン */
   static readonly empty = new AndModifier();
 }

--- a/src/core/rule.ts
+++ b/src/core/rule.ts
@@ -6,6 +6,10 @@ import { expandPrefixRules } from "./ruleExtender";
 import { SingleStroke, ruleStrokeKeys, type RuleStroke } from "./ruleStroke";
 import { type VirtualKey, VirtualKeys } from "./virtualKey";
 
+/**
+ * ワード文字列を内部比較用に正規化する関数のシグネチャ。
+ * build 時に入力テキストと各エントリの output 双方に適用される。
+ */
 export type normalizerFunc = (value: string) => string;
 
 /**
@@ -16,15 +20,20 @@ export type normalizerFunc = (value: string) => string;
  */
 export class RuleEntry {
   constructor(
+    /** 受け入れ可能なキー入力列 */
     readonly input: RuleStroke[],
+    /** 出力文字列 */
     readonly output: string,
+    /** 次の入力として自動入力されるキー入力列 */
     readonly nextInput: RuleStroke[],
-    // 共通プレフィックスエントリを展開するかどうか
+    /** 共通プレフィックスエントリを展開するかどうか */
     readonly extendCommonPrefixCommonEntry: boolean,
   ) {}
+  /** nextInput が空でない（＝確定後に次のエントリへ打ち継ぐ） */
   get hasNextInput(): boolean {
     return this.nextInput.length > 0;
   }
+  /** 全フィールドが同値なら true */
   equals(other: RuleEntry): boolean {
     return (
       this.input.length === other.input.length &&
@@ -35,6 +44,7 @@ export class RuleEntry {
       this.extendCommonPrefixCommonEntry === other.extendCommonPrefixCommonEntry
     );
   }
+  /** 渡された nextInputs をこのエントリの input の先頭として連結できるかを判定する */
   isConnetableAfter(nextInputs: RuleStroke[]): boolean {
     // 同じ長さの「入力」は「次の入力」経由では使えない
     if (nextInputs.length >= this.input.length) {
@@ -95,11 +105,17 @@ nk/ん/k
  * RulePrimitive 実装は自身の entries のみ、合成実装は全 parts の union を返す。
  */
 export interface Rule {
+  /** ルール名称や参照 URL 等 */
   readonly metadata: Metadata;
+  /** backspace として扱うストローク群 */
   readonly backspaceStrokes: readonly RuleStroke[];
+  /** このルールを構成する RulePrimitive 列（単一ルールなら [this]） */
   readonly primitives: readonly RulePrimitive[];
+  /** 入力キーを先頭とするエントリ一覧（primitives を事前マージ済み） */
   entriesByKey(key: VirtualKey): readonly RuleEntry[];
+  /** 先頭ストロークの修飾キーにマッチするエントリ一覧 */
   entriesByModifier(key: VirtualKey): readonly RuleEntry[];
+  /** このルールと other を合成した新しい Rule を返す */
   compose(other: Rule): Rule;
 }
 
@@ -111,6 +127,7 @@ export interface Rule {
  * 2 つの Rule を合成する場合は `a.compose(b)` を使うと内部で RuleSet が生成される。
  */
 export class RulePrimitive implements Rule {
+  /** 共通プレフィックス展開後のエントリ一覧 */
   readonly entries: readonly RuleEntry[];
   /**
    * RulePrimitive.backspaceStrokes: 入力方式が「特定のキーストロークを backspace として扱う」
@@ -162,18 +179,22 @@ export class RulePrimitive implements Rule {
     this.ownByModifier = byModifier;
   }
 
+  /** 自身 1 つを要素とする配列を返す（Rule インターフェースを満たすため） */
   get primitives(): readonly RulePrimitive[] {
     return [this];
   }
 
+  /** 入力キーを先頭とするエントリ一覧を返す（事前キャッシュ引き） */
   entriesByKey(inputKey: VirtualKey): readonly RuleEntry[] {
     return this.ownByKey.get(inputKey) ?? [];
   }
 
+  /** 先頭ストロークの修飾キーにマッチするエントリ一覧を返す（事前キャッシュ引き） */
   entriesByModifier(modifierKey: VirtualKey): readonly RuleEntry[] {
     return this.ownByModifier.get(modifierKey) ?? [];
   }
 
+  /** このルールと other を合成した Rule を返す */
   compose(other: Rule): Rule {
     return composeRules(this, other);
   }

--- a/src/core/ruleStroke.ts
+++ b/src/core/ruleStroke.ts
@@ -16,6 +16,7 @@ export type RuleStroke = SingleStroke | SimultaneousStroke;
  * requiredModifier は key を押下する前に事前に押下されている必要がある修飾キー群。
  */
 export class SingleStroke {
+  /** discriminated union のタグ。単キー打鍵であることを示す。 */
   readonly kind = "single" as const;
   /**
    * @param key 入力が必要なキー
@@ -27,6 +28,7 @@ export class SingleStroke {
     readonly requiredModifier: AndModifier,
     readonly romanChar: string = "",
   ) {}
+  /** 同種 (SingleStroke) であり、key と requiredModifier が一致するとき true */
   equals(other: RuleStroke): boolean {
     if (other.kind !== "single") {
       return false;
@@ -42,7 +44,9 @@ export class SingleStroke {
  * モディファイア (順序あり) と同時押し (順不同) を同一ストロークで併用できる。
  */
 export class SimultaneousStroke {
+  /** discriminated union のタグ。同時押し打鍵であることを示す。 */
   readonly kind = "simultaneous" as const;
+  /** 同時に押下されている必要があるキー群（重複除去済み） */
   readonly keys: readonly VirtualKey[];
   /**
    * @param keys 同時に押下されている必要があるキー群（2個以上）。順序は保持するが集合意味論で評価する
@@ -68,6 +72,7 @@ export class SimultaneousStroke {
     }
     this.keys = dedup;
   }
+  /** 同種 (SimultaneousStroke) かつ keys 集合と requiredModifier が一致するとき true（順不同） */
   equals(other: RuleStroke): boolean {
     if (other.kind !== "simultaneous") {
       return false;
@@ -83,10 +88,12 @@ export class SimultaneousStroke {
   }
 }
 
+/** RuleStroke が SingleStroke かどうかを判定する型ガード。 */
 export function isSingleStroke(stroke: RuleStroke): stroke is SingleStroke {
   return stroke.kind === "single";
 }
 
+/** RuleStroke が SimultaneousStroke かどうかを判定する型ガード。 */
 export function isSimultaneousStroke(stroke: RuleStroke): stroke is SimultaneousStroke {
   return stroke.kind === "simultaneous";
 }

--- a/src/core/virtualKey.ts
+++ b/src/core/virtualKey.ts
@@ -1,7 +1,10 @@
 import * as v from "valibot";
 
-// ブラウザから渡される Keyboard Event とは直接関係のない仮想的なキー一覧
-// Rule を json ファイル等で定義するときに使うキーはここで定義されている値を文字列として使う
+/**
+ * ブラウザから渡される Keyboard Event とは直接関係のない、emiel 独自の仮想キー一覧。
+ * Rule や KeyboardLayout を JSON 等で定義する際は、ここで定義された文字列をそのまま使う。
+ * KeyboardEvent.code との対応付けは `src/browser/eventHandler.ts` が担う。
+ */
 export const VirtualKeys = {
   Escape: "Escape",
   F1: "F1",
@@ -98,9 +101,16 @@ export const VirtualKeys = {
   NumpadMultiply: "NumpadMultiply",
 } as const;
 
+/** 仮想キー識別子を表す文字列型（VirtualKeys の各キー名のユニオン）。 */
 export type VirtualKey = keyof typeof VirtualKeys;
 
+/**
+ * VirtualKey 名前空間。現状は文字列から VirtualKey への変換ヘルパのみを公開する。
+ */
 export const VirtualKey = {
+  /**
+   * 文字列から VirtualKey を取得する。未知のキー名を渡した場合は例外を投げる。
+   */
   getFromString: (key: string) => {
     if (key in VirtualKeys) {
       return key as VirtualKey;
@@ -109,6 +119,7 @@ export const VirtualKey = {
   },
 } as const;
 
+/** JSON ローダ等で VirtualKey を検証するための valibot スキーマ。 */
 export const virtualKeySchema = v.pipe(
   v.string(),
   v.check((key) => key in VirtualKeys, "unknown virtual key"),

--- a/src/impl/automatonQuery.ts
+++ b/src/impl/automatonQuery.ts
@@ -226,6 +226,9 @@ export const backspaceExtension = {
   getEffectiveLastSucceededInputTime,
 };
 
+/**
+ * `backspaceExtension` を `.with()` で合成した Automaton に追加されるメソッド群の型。
+ */
 export type BackspaceExtensionType = {
   [K in keyof typeof backspaceExtension]: () => ReturnType<(typeof backspaceExtension)[K]>;
 };

--- a/src/impl/buildAutomaton.ts
+++ b/src/impl/buildAutomaton.ts
@@ -5,6 +5,16 @@ import type { normalizerFunc, Rule } from "../core/rule";
 import * as AutomatonQuery from "./automatonQuery";
 import { defaultComposedNormalize } from "./charNormalizer";
 
+/**
+ * 入力ルールとお題かな文字列から `Automaton` を構築する、emiel の中心 API。
+ * 戻り値は AutomatonImpl に `automatonQuery` の基本クエリ関数群を合成したもので、
+ * `automaton.getFinishedWord()` 等がそのまま呼び出せる。
+ *
+ * @param rule 使用する入力ルール (`loadPresetRuleRoman()` 等で取得)
+ * @param kanaText 入力対象の文字列
+ * @param normalize 比較用の文字列正規化関数。未指定時はひらがな→カタカナ等の
+ *   デフォルト正規化 (`defaultComposedNormalize`) が適用される
+ */
 export function build(
   rule: Rule,
   kanaText: string,
@@ -32,8 +42,17 @@ const baseExtension = {
   getPendingRoman: AutomatonQuery.getPendingRoman,
 };
 
+/**
+ * `build()` が自動で合成する基本クエリ関数群の型。
+ * `getFinishedWord()`, `getLastSucceededInputTime()` 等、`automatonQuery` の主要関数を
+ * 引数なしメソッドとして呼び出せるようにマップしたもの。
+ */
 export type BaseExtensionType = {
   [K in keyof typeof baseExtension]: () => ReturnType<(typeof baseExtension)[K]>;
 };
 
+/**
+ * `build()` の戻り値の型。AutomatonImpl に BaseExtensionType を合成したもの。
+ * さらに `automaton.with(...)` で追加の拡張を合成することもできる。
+ */
 export type Automaton = AutomatonImpl & BaseExtensionType;

--- a/src/impl/charNormalizer.ts
+++ b/src/impl/charNormalizer.ts
@@ -217,6 +217,10 @@ const directInputNormalizeMap = Object.assign(
   Object.fromEntries(Object.values(directInputNormalizeBaseMap).map((v) => [v, v])),
 );
 
+/**
+ * ひらがな／カタカナ混在の文字列をカタカナに寄せる正規化。
+ * 他のかな文字はそのまま残す。`build()` の `normalize` 引数に利用できる。
+ */
 export function defaultKanaNormalize(value: string): string {
   return Array.from(value)
     .map((c) => {
@@ -228,6 +232,10 @@ export function defaultKanaNormalize(value: string): string {
     .join("");
 }
 
+/**
+ * 全角英数字・全角記号を半角に寄せる正規化。
+ * 直接入力ルールで「全角 A も半角 A も同じ打鍵で入力可能」とするために使用する。
+ */
 export function defaultDirectInputNormalize(value: string): string {
   return Array.from(value)
     .map((c) => {

--- a/src/impl/directInputRule.ts
+++ b/src/impl/directInputRule.ts
@@ -1,6 +1,11 @@
 import type { KeyboardLayout } from "../core/keyboardLayout";
 import { RuleEntry, RulePrimitive } from "../core/rule";
 
+/**
+ * 指定した KeyboardLayout の文字対応をそのまま使う「直接入力ルール」を生成する。
+ * ローマ字変換を伴わず、1 文字を対応する 1 打鍵で入力する用途（英数字ワード等）で使用する。
+ * かな入力ルールと `compose` することで、かな混じり英数字ワードも入力できるようになる。
+ */
 export function createDirectInputRule(layout: KeyboardLayout): RulePrimitive {
   const entries = Array.from(layout.mapping).map(
     ([key, stroke]) => new RuleEntry([stroke], key, [], false),

--- a/src/impl/jsonRuleLoader.ts
+++ b/src/impl/jsonRuleLoader.ts
@@ -38,6 +38,7 @@ const metadataSchema = v.optional(
   }),
 );
 
+/** `loadJsonRule` が受け付けるルール JSON の valibot スキーマ。 */
 export const jsonRuleSchema = v.object({
   metadata: metadataSchema,
   // 全エントリに対するデフォルトの共通プレフィックス拡張設定
@@ -49,6 +50,7 @@ export const jsonRuleSchema = v.object({
   backspaces: v.optional(v.array(strokeSchema)),
 });
 
+/** `jsonRuleSchema` の推論型。ルール JSON のオブジェクト構造を表す。 */
 export type JsonRuleSchema = v.InferOutput<typeof jsonRuleSchema>;
 type Stroke = v.InferOutput<typeof strokeSchema>;
 
@@ -113,6 +115,10 @@ function loadEntries(
   return entries;
 }
 
+/**
+ * JSON 文字列またはパース済みオブジェクトから `RulePrimitive` を読み込む。
+ * `metadata` 引数が空 (name, url 共に空文字) の場合は、JSON 内の metadata を採用する。
+ */
 export function loadJsonRule(
   jsonRule: unknown,
   metadata: Metadata = emptyMetadata(),

--- a/src/impl/keyboardGuide.ts
+++ b/src/impl/keyboardGuide.ts
@@ -2,7 +2,13 @@ import type { KeyboardLayout } from "../core/keyboardLayout";
 import type { VirtualKey } from "../core/virtualKey";
 import type { PhysicalKeyboardLayout } from "./physicalKeyboardLayout";
 
+/**
+ * キートップの特定位置に表示する 1 つのラベル。
+ * label には `{layout.alpha_or_sign}` 等のテンプレート文字列も指定できる
+ * (`placeKeyboardGuide` 内で解決される)。
+ */
 export type KeyboardGuideLabel = {
+  /** キー内でラベルを描画する位置 (9 区画) */
   position:
     | "topLeft"
     | "top"
@@ -13,12 +19,19 @@ export type KeyboardGuideLabel = {
     | "bottomLeft"
     | "bottom"
     | "bottomRight";
+  /** 表示文字列 (テンプレート `{layout.*}` を含めてもよい) */
   label: string;
 };
 
+/**
+ * キーボードガイドを構成する「物理キー → ラベル群」のマッピング。
+ */
 export type KeyboardGuideLabelMapping = {
+  /** 各仮想キーに対して描画するラベルの集合 */
   entries: {
+    /** 対象の物理キー */
     key: VirtualKey;
+    /** そのキーに表示するラベル群 */
     labels: KeyboardGuideLabel[];
   }[];
 };
@@ -30,13 +43,21 @@ export type KeyboardGuideLabelMapping = {
  * テンプレート解決や物理キーボードレイアウトへの配置は placeKeyboardGuide() が担う。
  */
 export class KeyboardGuide {
-  constructor(readonly guideData: KeyboardGuideLabelMapping) {}
+  constructor(
+    /** 「どの物理キーにどのラベルを付けるか」の純粋なデータ */
+    readonly guideData: KeyboardGuideLabelMapping,
+  ) {}
 }
 
+/** キートップの矩形領域を表す純粋な論理座標（描画フレームワーク非依存）。 */
 export type Rect = {
+  /** 左上 X 座標 */
   x: number;
+  /** 左上 Y 座標 */
   y: number;
+  /** 幅 */
   width: number;
+  /** 高さ */
   height: number;
 };
 
@@ -44,16 +65,27 @@ export type Rect = {
  * 描画用に配置・ラベル解決済みの1キーの情報。UI フレームワークに依存しない純粋な論理データ。
  */
 export type KeyPlacement = {
+  /** 対象の物理キー */
   key: VirtualKey;
+  /** キートップの描画矩形 */
   rect: Rect;
+  /** 左上ラベル（未指定なら undefined） */
   topLeft?: string;
+  /** 上ラベル */
   top?: string;
+  /** 右上ラベル */
   topRight?: string;
+  /** 左ラベル */
   left?: string;
+  /** 中央ラベル */
   center?: string;
+  /** 右ラベル */
   right?: string;
+  /** 左下ラベル */
   bottomLeft?: string;
+  /** 下ラベル */
   bottom?: string;
+  /** 右下ラベル */
   bottomRight?: string;
 };
 

--- a/src/impl/keyboardGuideLoader.ts
+++ b/src/impl/keyboardGuideLoader.ts
@@ -34,6 +34,10 @@ export const jsonKeyboardGuideSchema = v.object({
 
 export type JsonKeyboardGuideSchema = v.InferOutput<typeof jsonKeyboardGuideSchema>;
 
+/**
+ * JSON 文字列またはパース済みオブジェクトから `KeyboardGuide` を読み込む。
+ * スキーマは valibot で検証され、不正な形式の場合は例外を投げる。
+ */
 export function loadJsonKeyboardGuide(jsonGuide: unknown): KeyboardGuide {
   if (typeof jsonGuide === "string") {
     return loadJsonKeyboardGuide(JSON.parse(jsonGuide));

--- a/src/impl/keyboardLayoutLoader.ts
+++ b/src/impl/keyboardLayoutLoader.ts
@@ -27,8 +27,13 @@ const jsonKeyboardLayoutSchema = v.object({
   ),
 });
 
+/** `loadJsonKeyboardLayout` が受け付ける JSON のスキーマ推論型。 */
 export type JsonKeyboardLayoutSchema = v.InferOutput<typeof jsonKeyboardLayoutSchema>;
 
+/**
+ * JSON 文字列またはパース済みオブジェクトから `KeyboardLayout` を読み込む。
+ * 物理キーと出力文字の対応、および Shift 有無を定義した JSON を解釈する。
+ */
 export function loadJsonKeyboardLayout(jsonLayout: unknown): KeyboardLayout {
   if (typeof jsonLayout === "string") {
     return loadJsonKeyboardLayout(JSON.parse(jsonLayout));

--- a/src/impl/mozcRuleLoader.ts
+++ b/src/impl/mozcRuleLoader.ts
@@ -5,6 +5,12 @@ import { RuleEntry, RulePrimitive } from "../core/rule";
 import type { RuleStroke } from "../core/ruleStroke";
 import { product } from "../utils/itertools";
 
+/**
+ * mozc (Google 日本語入力 OSS) 互換のローマ字テーブル形式テキストから `RulePrimitive` を生成する。
+ *
+ * 各行は `<入力>\t<出力>\t<次の入力>` のタブ区切り。3 列目 (次の入力) は省略可。
+ * 入力文字はキーボードレイアウトを介して打鍵列に展開されるので、配列が異なると打鍵列も変わる。
+ */
 export function loadMozcRule(
   text: string,
   layout: KeyboardLayout,

--- a/src/impl/physicalKeyboardLayout.ts
+++ b/src/impl/physicalKeyboardLayout.ts
@@ -16,6 +16,10 @@ const jsonPhysicalKeyboardLayoutSchema = v.object({
  */
 export type PhysicalKeyboardLayout = v.InferOutput<typeof jsonPhysicalKeyboardLayoutSchema>;
 
+/**
+ * JSON 文字列またはパース済みオブジェクトから `PhysicalKeyboardLayout` を読み込む。
+ * `placeKeyboardGuide` による描画領域計算の元データを得るために使う。
+ */
 export function loadJsonPhysicalKeyboardLayout(jsonLayout: unknown): PhysicalKeyboardLayout {
   if (typeof jsonLayout === "string") {
     return loadJsonPhysicalKeyboardLayout(JSON.parse(jsonLayout));

--- a/src/impl/presets/keyboardGuideDirectInput.ts
+++ b/src/impl/presets/keyboardGuideDirectInput.ts
@@ -2,11 +2,7 @@ import directInput from "../../assets/keyboard_guides/direct_input.json";
 import type { KeyboardGuide } from "../keyboardGuide";
 import { loadJsonKeyboardGuide } from "../keyboardGuideLoader";
 
-// KeyboardGuide はイミュータブルで layout 非依存のため、モジュールレベルでキャッシュする。
-// createDirectInputRule など、Rule 生成のたびに呼ばれるパスで valibot parse を
-// 繰り返さないようにするのが目的。
-let cached: KeyboardGuide | undefined;
-
+/** 直接入力用 (英字・記号そのまま) のプリセット `KeyboardGuide` を返す。 */
 export function loadPresetKeyboardGuideDirectInput(): KeyboardGuide {
-  return (cached ??= loadJsonKeyboardGuide(directInput));
+  return loadJsonKeyboardGuide(directInput);
 }

--- a/src/impl/presets/keyboardGuideJisKana.ts
+++ b/src/impl/presets/keyboardGuideJisKana.ts
@@ -2,8 +2,7 @@ import jisKanaGuide from "../../assets/keyboard_guides/jis_kana.json";
 import type { KeyboardGuide } from "../keyboardGuide";
 import { loadJsonKeyboardGuide } from "../keyboardGuideLoader";
 
-let cached: KeyboardGuide | undefined;
-
+/** JIS かな入力用のプリセット `KeyboardGuide` を返す。 */
 export function loadPresetKeyboardGuideJisKana(): KeyboardGuide {
-  return (cached ??= loadJsonKeyboardGuide(jisKanaGuide));
+  return loadJsonKeyboardGuide(jisKanaGuide);
 }

--- a/src/impl/presets/keyboardGuideNicola.ts
+++ b/src/impl/presets/keyboardGuideNicola.ts
@@ -2,8 +2,7 @@ import nicolaGuide from "../../assets/keyboard_guides/nicola.json";
 import type { KeyboardGuide } from "../keyboardGuide";
 import { loadJsonKeyboardGuide } from "../keyboardGuideLoader";
 
-let cached: KeyboardGuide | undefined;
-
+/** NICOLA (親指シフト) 用のプリセット `KeyboardGuide` を返す。 */
 export function loadPresetKeyboardGuideNicola(): KeyboardGuide {
-  return (cached ??= loadJsonKeyboardGuide(nicolaGuide));
+  return loadJsonKeyboardGuide(nicolaGuide);
 }

--- a/src/impl/presets/keyboardLayoutAstarte.ts
+++ b/src/impl/presets/keyboardLayoutAstarte.ts
@@ -1,6 +1,7 @@
 import astarte from "../../assets/keyboard_layouts/astarte.json";
 import { loadJsonKeyboardLayout } from "../keyboardLayoutLoader";
 
+/** Astarte 配列のプリセット `KeyboardLayout` を返す。 */
 export function loadPresetKeyboardLayoutAstarte() {
   return loadJsonKeyboardLayout(astarte);
 }

--- a/src/impl/presets/keyboardLayoutColemak.ts
+++ b/src/impl/presets/keyboardLayoutColemak.ts
@@ -1,6 +1,7 @@
 import colemak from "../../assets/keyboard_layouts/colemak.json";
 import { loadJsonKeyboardLayout } from "../keyboardLayoutLoader";
 
+/** Colemak 配列のプリセット `KeyboardLayout` を返す。 */
 export function loadPresetKeyboardLayoutColemak() {
   return loadJsonKeyboardLayout(colemak);
 }

--- a/src/impl/presets/keyboardLayoutColemakDh.ts
+++ b/src/impl/presets/keyboardLayoutColemakDh.ts
@@ -1,6 +1,7 @@
 import colemakDh from "../../assets/keyboard_layouts/colemak_dh.json";
 import { loadJsonKeyboardLayout } from "../keyboardLayoutLoader";
 
+/** Colemak-DH 配列のプリセット `KeyboardLayout` を返す。 */
 export function loadPresetKeyboardLayoutColemakDh() {
   return loadJsonKeyboardLayout(colemakDh);
 }

--- a/src/impl/presets/keyboardLayoutDvorak.ts
+++ b/src/impl/presets/keyboardLayoutDvorak.ts
@@ -1,6 +1,7 @@
 import dvorak from "../../assets/keyboard_layouts/dvorak.json";
 import { loadJsonKeyboardLayout } from "../keyboardLayoutLoader";
 
+/** Dvorak 配列のプリセット `KeyboardLayout` を返す。 */
 export function loadPresetKeyboardLayoutDvorak() {
   return loadJsonKeyboardLayout(dvorak);
 }

--- a/src/impl/presets/keyboardLayoutEucalyn.ts
+++ b/src/impl/presets/keyboardLayoutEucalyn.ts
@@ -1,6 +1,7 @@
 import eucalyn from "../../assets/keyboard_layouts/eucalyn.json";
 import { loadJsonKeyboardLayout } from "../keyboardLayoutLoader";
 
+/** Eucalyn 配列のプリセット `KeyboardLayout` を返す。 */
 export function loadPresetKeyboardLayoutEucalyn() {
   return loadJsonKeyboardLayout(eucalyn);
 }

--- a/src/impl/presets/keyboardLayoutOnishi.ts
+++ b/src/impl/presets/keyboardLayoutOnishi.ts
@@ -1,6 +1,7 @@
 import onishi from "../../assets/keyboard_layouts/onishi.json";
 import { loadJsonKeyboardLayout } from "../keyboardLayoutLoader";
 
+/** 大西配列のプリセット `KeyboardLayout` を返す。 */
 export function loadPresetKeyboardLayoutOnishi() {
   return loadJsonKeyboardLayout(onishi);
 }

--- a/src/impl/presets/keyboardLayoutQwertyJis.ts
+++ b/src/impl/presets/keyboardLayoutQwertyJis.ts
@@ -1,6 +1,7 @@
 import qwerty_jis from "../../assets/keyboard_layouts/qwerty_jis.json";
 import { loadJsonKeyboardLayout } from "../keyboardLayoutLoader";
 
+/** QWERTY JIS 配列のプリセット `KeyboardLayout` を返す。 */
 export function loadPresetKeyboardLayoutQwertyJis() {
   return loadJsonKeyboardLayout(qwerty_jis);
 }

--- a/src/impl/presets/keyboardLayoutQwertyUs.ts
+++ b/src/impl/presets/keyboardLayoutQwertyUs.ts
@@ -1,6 +1,7 @@
 import qwerty_us from "../../assets/keyboard_layouts/qwerty_us.json";
 import { loadJsonKeyboardLayout } from "../keyboardLayoutLoader";
 
+/** QWERTY US 配列のプリセット `KeyboardLayout` を返す。 */
 export function loadPresetKeyboardLayoutQwertyUs() {
   return loadJsonKeyboardLayout(qwerty_us);
 }

--- a/src/impl/presets/keyboardLayoutTomisukeJis.ts
+++ b/src/impl/presets/keyboardLayoutTomisukeJis.ts
@@ -1,6 +1,7 @@
 import tomisukeJis from "../../assets/keyboard_layouts/tomisuke_jis.json";
 import { loadJsonKeyboardLayout } from "../keyboardLayoutLoader";
 
+/** Tomisuke JIS 配列のプリセット `KeyboardLayout` を返す。 */
 export function loadPresetKeyboardLayoutTomisukeJis() {
   return loadJsonKeyboardLayout(tomisukeJis);
 }

--- a/src/impl/presets/physicalKeyboardLayoutJis106.ts
+++ b/src/impl/presets/physicalKeyboardLayoutJis106.ts
@@ -4,8 +4,7 @@ import {
   type PhysicalKeyboardLayout,
 } from "../physicalKeyboardLayout";
 
-let cached: PhysicalKeyboardLayout | undefined;
-
+/** 日本語 106 キーボードの物理レイアウト (JIS 106) を返す。 */
 export function loadPresetPhysicalKeyboardLayoutJis106(): PhysicalKeyboardLayout {
-  return (cached ??= loadJsonPhysicalKeyboardLayout(jis106));
+  return loadJsonPhysicalKeyboardLayout(jis106);
 }

--- a/src/impl/presets/physicalKeyboardLayoutUs101.ts
+++ b/src/impl/presets/physicalKeyboardLayoutUs101.ts
@@ -4,8 +4,7 @@ import {
   type PhysicalKeyboardLayout,
 } from "../physicalKeyboardLayout";
 
-let cached: PhysicalKeyboardLayout | undefined;
-
+/** 英語 101 キーボードの物理レイアウト (US 101) を返す。 */
 export function loadPresetPhysicalKeyboardLayoutUs101(): PhysicalKeyboardLayout {
-  return (cached ??= loadJsonPhysicalKeyboardLayout(us101));
+  return loadJsonPhysicalKeyboardLayout(us101);
 }

--- a/src/impl/presets/physicalKeyboardLayoutUsHhkb.ts
+++ b/src/impl/presets/physicalKeyboardLayoutUsHhkb.ts
@@ -4,8 +4,7 @@ import {
   type PhysicalKeyboardLayout,
 } from "../physicalKeyboardLayout";
 
-let cached: PhysicalKeyboardLayout | undefined;
-
+/** HHKB (US 配列) 相当の物理レイアウトを返す。 */
 export function loadPresetPhysicalKeyboardLayoutUsHhkb(): PhysicalKeyboardLayout {
-  return (cached ??= loadJsonPhysicalKeyboardLayout(usHhkb));
+  return loadJsonPhysicalKeyboardLayout(usHhkb);
 }

--- a/src/impl/presets/ruleAsuka123.ts
+++ b/src/impl/presets/ruleAsuka123.ts
@@ -2,6 +2,7 @@ import presetRuleAsuka123 from "../../assets/rules/asuka_123.json";
 import type { Rule } from "../../core/rule";
 import { loadJsonRule } from "../jsonRuleLoader";
 
+/** 飛鳥カナ配列 (123 配列) のプリセット `Rule` を返す。 */
 export function loadPresetRuleAsuka123(): Rule {
   return loadJsonRule(presetRuleAsuka123);
 }

--- a/src/impl/presets/ruleAzikRomantable.ts
+++ b/src/impl/presets/ruleAzikRomantable.ts
@@ -3,6 +3,10 @@ import type { KeyboardLayout } from "../../core/keyboardLayout";
 import type { Rule } from "../../core/rule";
 import { loadMozcRule } from "../mozcRuleLoader";
 
+/**
+ * AZIK 拡張ローマ字入力のプリセット `Rule` を返す。
+ * 入力対象の物理キー展開のため `KeyboardLayout` を渡す。
+ */
 export function loadPresetRuleAzikRomantable(layout: KeyboardLayout): Rule {
   return loadMozcRule(presetRuleAzikRomantable, layout);
 }

--- a/src/impl/presets/ruleJisKana.ts
+++ b/src/impl/presets/ruleJisKana.ts
@@ -2,6 +2,7 @@ import presetRuleJisKana from "../../assets/rules/jis_kana.json";
 import type { Rule } from "../../core/rule";
 import { loadJsonRule } from "../jsonRuleLoader";
 
+/** JIS かな入力のプリセット `Rule` を返す。 */
 export function loadPresetRuleJisKana(): Rule {
   return loadJsonRule(presetRuleJisKana);
 }

--- a/src/impl/presets/ruleNaginatashikiV15.ts
+++ b/src/impl/presets/ruleNaginatashikiV15.ts
@@ -2,6 +2,7 @@ import presetRuleNaginatashikiV15 from "../../assets/rules/naginatashiki_v15.jso
 import type { Rule } from "../../core/rule";
 import { loadJsonRule } from "../jsonRuleLoader";
 
+/** 薙刀式 V15 (同時押し系) のプリセット `Rule` を返す。 */
 export function loadPresetRuleNaginatashikiV15(): Rule {
   return loadJsonRule(presetRuleNaginatashikiV15);
 }

--- a/src/impl/presets/ruleNicola.ts
+++ b/src/impl/presets/ruleNicola.ts
@@ -2,6 +2,7 @@ import presetRuleNicola from "../../assets/rules/nicola.json";
 import type { Rule } from "../../core/rule";
 import { loadJsonRule } from "../jsonRuleLoader";
 
+/** NICOLA (親指シフト) のプリセット `Rule` を返す。 */
 export function loadPresetRuleNicola(): Rule {
   return loadJsonRule(presetRuleNicola);
 }

--- a/src/impl/presets/ruleRoman.ts
+++ b/src/impl/presets/ruleRoman.ts
@@ -3,6 +3,10 @@ import type { KeyboardLayout } from "../../core/keyboardLayout";
 import type { Rule } from "../../core/rule";
 import { loadMozcRule } from "../mozcRuleLoader";
 
+/**
+ * Google 日本語入力デフォルトのローマ字入力プリセット `Rule` を返す。
+ * 入力対象の物理キー展開のため `KeyboardLayout` を渡す。
+ */
 export function loadPresetRuleRoman(layout: KeyboardLayout): Rule {
   return loadMozcRule(presetRuleGoogleImeRoman, layout);
 }

--- a/src/impl/presets/ruleShingeta.ts
+++ b/src/impl/presets/ruleShingeta.ts
@@ -2,6 +2,7 @@ import presetRuleShingeta from "../../assets/rules/shingeta.json";
 import type { Rule } from "../../core/rule";
 import { loadJsonRule } from "../jsonRuleLoader";
 
+/** 新下駄配列 (同時押し系) のプリセット `Rule` を返す。 */
 export function loadPresetRuleShingeta(): Rule {
   return loadJsonRule(presetRuleShingeta);
 }

--- a/src/impl/presets/ruleTsuki2_263.ts
+++ b/src/impl/presets/ruleTsuki2_263.ts
@@ -2,6 +2,7 @@ import presetRuleTsuki2_263 from "../../assets/rules/tsuki_2_263.json";
 import type { Rule } from "../../core/rule";
 import { loadJsonRule } from "../jsonRuleLoader";
 
+/** 月配列 2-263 のプリセット `Rule` を返す。 */
 export function loadPresetRuleTsuki2_263(): Rule {
   return loadJsonRule(presetRuleTsuki2_263);
 }


### PR DESCRIPTION
## Summary

- emiel を外部ライブラリとして利用する際に型情報だけで意図が読み取れるよう、src/ 配下の公開関数・クラス・メソッド・getter・フィールド・型に JSDoc を網羅的に付与
- KeyboardGuide / PhysicalKeyboardLayout のプリセットローダーに残っていた `let cached` モジュール変数を削除し、すべての preset を「毎回 loadJson* を呼ぶだけ」のシンプルな実装に統一

## 設計の背景

JSDoc 追加:

中核部分 (Rule, Automaton, StrokeCommitter, automatonQuery, stats) には既に JSDoc が付与されていたが、周辺の公開シンボル (InputEvent, KeyboardLayout, KeyboardState, ModifierGroup, VirtualKey, 各種 loader, preset ローダー 等) には未記述のものが多く残っていた。外部利用者が Go to Definition / ホバーで意図を把握できるよう、網羅的に補完した。

preset キャッシュ廃止:

preset ローダーの cache は歴史的経緯で KeyboardGuide / PhysicalKeyboardLayout にだけ付いており、KeyboardLayout / Rule には付いていない不整合があった。cache は呼び出し側が必要に応じて useMemo / モジュール const で簡単に実現できるので、ライブラリ側では保持しない責務分離に寄せた。テスト間でのモジュール状態リークや tree-shaking の妨げを避ける意図もある。

DirectInput guide に付いていた cache コメント (「createDirectInputRule 経由で呼ばれる」) は、現在の createDirectInputRule には KeyboardGuide 参照がなく古くなっていたため削除した。

## 検討した代替案

preset キャッシュについて:

- すべての preset に cache を追加して統一する案も検討したが、ライブラリ側でモジュール状態を持つと以下のデメリットがあるため採用しなかった
  - Vitest などテスト間でのリーク
  - tree-shaking しづらい (モジュール変数の副作用)
  - 呼び出し側の制御が効かない
- 結果として「cache は呼び出し側の責務」方針に揃える案を採用

## Test plan

- [x] ``pnpm exec oxfmt --check src`` でフォーマット確認
- [x] ``pnpm run lint`` で lint 確認
- [x] ``pnpm run test`` でテスト全件 pass (140/140)
- [x] ``pnpm run build`` で vite build + tsc がエラーなく完了
- [ ] レビュアによる JSDoc 文面の確認 (用語・トーンが既存と揃っているか)

🤖 Generated with [Claude Code](https://claude.com/claude-code)