### PR TITLE
fix(eventsView): first を keydown イベントに限定する

### DIFF
--- a/src/impl/automatonView.test.ts
+++ b/src/impl/automatonView.test.ts
@@ -158,6 +158,41 @@ describe("eventsView: 基本", () => {
     expect(view.totalCount).toBe(2);
   });
 
+  test("stale keyup のみ受けた場合: first は undefined のまま（keydown 限定）、last は keyup で更新", () => {
+    // 前ワード完了直後の Automaton 切替で、前ワードの keydown に対応する keyup だけが流入するケース
+    const automaton = build(simpleRule(), "あ");
+    runInputs(
+      automaton,
+      [
+        { key: VirtualKeys.A, type: "keyup" }, // t=1000 stale keyup（自動的に IGNORED として inputHistory に残る）
+      ],
+      1000,
+    );
+    const view = automaton.eventsView();
+    expect(view.first).toBeUndefined();
+    expect(view.last?.timestamp).toBe(1000);
+    expect(view.firstSucceeded).toBeUndefined();
+    expect(view.succeededCount).toBe(0);
+    expect(view.failedCount).toBe(0);
+  });
+
+  test("stale keyup → keydown の順: first は新しい keydown の timestamp", () => {
+    const automaton = build(simpleRule(), "あ");
+    runInputs(
+      automaton,
+      [
+        { key: VirtualKeys.A, type: "keyup" }, // t=1000 stale keyup
+        { key: VirtualKeys.A, type: "keydown" }, // t=1010 実際の最初の keydown
+        { key: VirtualKeys.A, type: "keyup" }, // t=1020
+      ],
+      1000,
+    );
+    const view = automaton.eventsView();
+    expect(view.first?.timestamp).toBe(1010);
+    expect(view.firstSucceeded?.timestamp).toBe(1010);
+    expect(view.last?.timestamp).toBe(1020);
+  });
+
   test("first / last の timestamp は失敗イベントも含めて決定される", () => {
     const automaton = build(simpleRule(), "あ");
     runInputs(

--- a/src/impl/automatonView.ts
+++ b/src/impl/automatonView.ts
@@ -30,9 +30,12 @@ export type CurrentView = {
  * を残すため、back() 取消区間も含めて数える。
  */
 export type EventsView = {
-  /** 最初の入力イベント（成功・失敗問わず） */
+  /**
+   * 最初の keydown イベント（成功・失敗・IGNORED 問わず）。
+   * ワード切替直後に前ワードから漏れた keyup が流入しても first が汚染されないよう keydown のみを対象にする。
+   */
   first: InputEvent | undefined;
-  /** 最後の入力イベント（成功・失敗問わず） */
+  /** 最後の入力イベント（keydown/keyup・成功/失敗問わず） */
   last: InputEvent | undefined;
   /** 最初の成功入力イベント */
   firstSucceeded: InputEvent | undefined;
@@ -122,7 +125,7 @@ export function eventsView(state: AutomatonState): EventsView {
   for (let i = 0; i < state.inputHistory.length; i++) {
     const entry = state.inputHistory[i];
     if ("back" in entry) continue;
-    if (!first) first = entry.event;
+    if (!first && entry.event.input.type === "keydown") first = entry.event;
     last = entry.event;
     if (entry.result.isFailed) {
       failedCount++;


### PR DESCRIPTION
## Summary

- `eventsView().first` を keydown イベントのみを対象に変更
- `last` / `firstSucceeded` / `lastSucceeded` は現状維持
- EventsView.first の JSDoc を更新
- stale keyup のみ / stale keyup → keydown の順のテストを追加

## 設計の背景

ワード完了の瞬間にクライアントが新しい Automaton へ切り替えると、前ワードの最後 keydown に対応する keyup が新 Automaton の `input()` に流入する。committer は観測していないキーの keyup を IGNORED として `inputHistory` に push するため、`eventsView().first` の timestamp が「前ワードから漏れた keyup」で汚染され、ワードごとの反応時間などの計測が不正確になっていた。

Automaton / committer の挙動を変えずに、集計レイヤーだけで補正する方針を採った。keyup はキー押下時間の分析などに使える情報なので、inputHistory には従来どおり残す。

## 検討した代替案

- committer に `observedDownKeys` を追加し、観測していないキーの keyup を `inputHistory` から除外する案: keyup の情報が失われる。押下時間分析など別用途への転用余地がなくなる。
- activate 層でフィルタする案: 1 activate × 複数 Automaton のケース（react-multi-word など）では activate 側が各 Automaton の観測状態を知り得ないため破綻する。
- `InputResult.STALE_KEYUP` を新設する案: 戻り値の分類を増やすわりに、既存のクライアントコードからは区別する利点が薄い。

## Test plan

- [x] `pnpm run test` で全テスト通過（18 ファイル / 165 テスト）
- [x] 新規テスト: stale keyup のみを受けたとき `first === undefined` になる
- [x] 新規テスト: stale keyup → keydown の順で `first` が keydown の timestamp を指す
- [ ] examples/react-result-record で連続ワード入力時の計測値が意図通りになることの目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)