### PR TITLE
docs(readme): レイテンシ計測の使い方例を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,29 @@ activate(window, (event) => {
 });
 ```
 
+## レイテンシの計測
+
+ワードが表示されてから最初の1打鍵が成功するまでの時間（レイテンシ）を計測する例です。
+
+高精度な時刻取得にはブラウザ組み込みの `performance.now()` を使います。ミリ秒未満の精度を持つ単調増加時刻（`DOMHighResTimeStamp`）を返す関数で、`KeyboardEvent.timeStamp` や `automaton.eventsView()` から得られる各入力イベントの `timestamp` と同じ時間軸のため、差分を取るだけで経過時間を計算できます（`Date.now()` とは時間軸が異なるため併用不可）。
+
+```typescript
+const automaton = build(rule, "かった");
+
+// ワードが表示された瞬間の時刻を記録
+const wordDisplayedAt = performance.now();
+
+activate(window, (event) => {
+  automaton.input(event);
+  const events = automaton.eventsView();
+  // succeededCount が 1 になる瞬間 ＝ 最初の1打鍵成功時
+  if (events.succeededCount === 1) {
+    const latency = events.firstSucceeded!.timestamp - wordDisplayedAt;
+    console.log(`latency: ${latency}ms`);
+  }
+});
+```
+
 ## Examples
 
 - <a href="./examples/react-simple">react-simple</a> - 単語を次々と入力するシンプルなタイピング練習


### PR DESCRIPTION
## Summary

- README に「レイテンシの計測」セクションを追加
- ワード表示から最初の1打鍵成功までを計測する最小コード例を記載
- 計測ロジックは examples/react-result-record と同じ方式（`wordDisplayedAt` と `eventsView().firstSucceeded.timestamp` の差分）
- `performance.now()` の説明を冒頭に置き、精度・時間軸・`Date.now()` との違いに触れた

## 設計の背景

タイピングゲームの品質評価でレイテンシ（表示〜初打鍵）は基本指標だが、既存の README の最小コード例は入力ループのみを示しており、時間計測の糸口が示せていなかった。react-result-record では同じ計測を行っているが、複数ファイルにまたがるためスニペットとして参照しにくい。

`performance.now()` は `Date.now()` と時間軸が異なり、InputEvent の `timestamp` と同じ時間軸で扱える点が非自明なので、コード例の前に明示的に説明を置いた。

## 検討した代替案

- 新しい examples ディレクトリとして追加する案: レイテンシ計測は単独で数行の差分にしかならず、独立した example を作るほどの規模ではないため README 内のスニペットに収めた
- 最初の1打鍵の検出を外部フラグで行う案（`let firstKey = true` を閉包に持つ）: 動作は等価だが、`automaton.eventsView().succeededCount === 1` を使う方が react-result-record と同じ API で完結し、Automaton 側の状態で判定が閉じるのでこちらを採用
- トリガーを `result.isSucceeded` でフィルタする案: keydown 以外も拾って多重発火し得るので不採用。`succeededCount === 1` は初回成功時ちょうど 1 回だけ真になる

## Test plan

- [x] README のレンダリングを GitHub 上で確認する
- [x] 掲載したコードが既存 API（`build`, `activate`, `automaton.eventsView()` の `succeededCount` / `firstSucceeded.timestamp`）と一致していることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)