### PR TITLE
feat(logger): ラベルベースのデバッグログ機構を追加

### DIFF
--- a/examples/react-backspace/src/App.tsx
+++ b/examples/react-backspace/src/App.tsx
@@ -1,10 +1,12 @@
 import type { KeyboardLayout } from "emiel";
-import { detectKeyboardLayout } from "emiel";
+import { detectKeyboardLayout, logging } from "emiel";
 import { useEffect, useState } from "react";
 import "./App.css";
 import { MissAccumulatingApp } from "./MissAccumulatingApp";
 import { MissClearingApp } from "./MissClearingApp";
 import { MissCountingApp } from "./MissCountingApp";
+
+logging.enable("keyboard.*", "automaton.*");
 
 type TabId = "clearing" | "counting" | "accumulating";
 

--- a/examples/react-kanji-annotation/src/App.tsx
+++ b/examples/react-kanji-annotation/src/App.tsx
@@ -5,10 +5,13 @@ import {
   createDirectInputRule,
   detectKeyboardLayout,
   loadPresetRuleRoman,
+  logging,
 } from "emiel";
 import { useEffect, useMemo, useState } from "react";
 import "./App.css";
 import { MixedText, withMixedText } from "./MixedText";
+
+logging.enable("keyboard.*", "automaton.*");
 
 function App() {
   const [layout, setLayout] = useState<KeyboardLayout | undefined>();

--- a/examples/react-keyboardguide/src/App.tsx
+++ b/examples/react-keyboardguide/src/App.tsx
@@ -16,9 +16,12 @@ import {
   loadPresetPhysicalKeyboardLayoutJis106,
   loadPresetPhysicalKeyboardLayoutUs101,
   loadPresetPhysicalKeyboardLayoutUsHhkb,
+  logging,
   placeKeyboardGuide,
 } from "emiel";
 import { useEffect, useMemo, useState } from "react";
+
+logging.enable("keyboard.*", "automaton.*");
 
 type LayoutName = "qwerty-jis" | "qwerty-us" | "dvorak";
 type PhysicalLayoutName = "jis_106" | "us_101" | "us_hhkb";

--- a/examples/react-mixed-input-guide/src/App.tsx
+++ b/examples/react-mixed-input-guide/src/App.tsx
@@ -8,10 +8,13 @@ import {
   loadPresetKeyboardLayoutQwertyJis,
   loadPresetPhysicalKeyboardLayoutJis106,
   loadPresetRuleJisKana,
+  logging,
   placeKeyboardGuide,
 } from "emiel";
 import { useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { KeyboardGuideView } from "./KeyboardGuideView";
+
+logging.enable("keyboard.*", "automaton.*");
 
 const WORDS = [
   "こんにちはHello",

--- a/examples/react-mixed-layout/src/App.tsx
+++ b/examples/react-mixed-layout/src/App.tsx
@@ -6,9 +6,12 @@ import {
   loadPresetKeyboardLayoutDvorak,
   loadPresetKeyboardLayoutQwertyJis,
   loadPresetRuleRoman,
+  logging,
 } from "emiel";
 import { useEffect, useMemo, useState } from "react";
 import "./App.css";
+
+logging.enable("keyboard.*", "automaton.*");
 
 const words = ["おをひく", "apple", "docomoとau"];
 

--- a/examples/react-multi-word/src/App.tsx
+++ b/examples/react-multi-word/src/App.tsx
@@ -1,9 +1,18 @@
 import type { Automaton, InputStroke, KeyboardLayout } from "emiel";
-import { activate, build, detectKeyboardLayout, loadPresetRuleRoman, VirtualKeys } from "emiel";
+import {
+  activate,
+  build,
+  detectKeyboardLayout,
+  loadPresetRuleRoman,
+  logging,
+  VirtualKeys,
+} from "emiel";
 import { useEffect, useMemo, useState } from "react";
 import "./App.css";
 import { MultiWordState } from "./multiWordState";
 import { Word } from "./word";
+
+logging.enable("keyboard.*", "automaton.*");
 
 // 繰り返し次のワードを生成するジェネレータ
 const wordGen = (function* wordGenerator(): Generator<string, string> {

--- a/examples/react-result-record/src/App.tsx
+++ b/examples/react-result-record/src/App.tsx
@@ -1,10 +1,18 @@
 import type { Automaton, KeyboardLayout } from "emiel";
-import { build, createDirectInputRule, detectKeyboardLayout, loadPresetRuleRoman } from "emiel";
+import {
+  build,
+  createDirectInputRule,
+  detectKeyboardLayout,
+  loadPresetRuleRoman,
+  logging,
+} from "emiel";
 import { useEffect, useMemo, useState } from "react";
 import "./App.css";
 import type { WordRecordValue } from "./Record";
 import { Record } from "./Record";
 import { Typing } from "./Typing";
+
+logging.enable("keyboard.*", "automaton.*");
 
 function App() {
   const [layout, setLayout] = useState<KeyboardLayout | undefined>();

--- a/examples/react-roman-or-kana/src/App.tsx
+++ b/examples/react-roman-or-kana/src/App.tsx
@@ -5,10 +5,13 @@ import {
   detectKeyboardLayout,
   loadPresetRuleJisKana,
   loadPresetRuleRoman,
+  logging,
   VirtualKeys,
 } from "emiel";
 import { useEffect, useMemo, useState } from "react";
 import "./App.css";
+
+logging.enable("keyboard.*", "automaton.*");
 
 type ActiveKey = "roman" | "kana";
 const ALL_ACTIVES: ReadonlySet<ActiveKey> = new Set(["roman", "kana"]);

--- a/examples/react-simple/src/App.tsx
+++ b/examples/react-simple/src/App.tsx
@@ -5,9 +5,12 @@ import {
   createDirectInputRule,
   detectKeyboardLayout,
   loadPresetRuleRoman,
+  logging,
 } from "emiel";
 import { useEffect, useMemo, useState } from "react";
 import "./App.css";
+
+logging.enable("keyboard.*", "automaton.*");
 
 function App() {
   const [layout, setLayout] = useState<KeyboardLayout | undefined>();
@@ -38,7 +41,6 @@ function Typing(props: { layout: KeyboardLayout }) {
     return activate(window, (e) => {
       setLastInputKey(e.input);
       const result = automatons[wordIndex].input(e);
-      console.log(e.input.key.toString(), e.input.type, result);
       if (result.isFinished) {
         automatons[wordIndex].reset();
         setWordIndex((current) => (current + 1) % words.length);

--- a/examples/react-stroke-graph/src/App.tsx
+++ b/examples/react-stroke-graph/src/App.tsx
@@ -8,10 +8,13 @@ import {
   loadPresetRuleNaginatashikiV15,
   loadPresetRuleNicola,
   loadPresetRuleRoman,
+  logging,
 } from "emiel";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import "./App.css";
 import { TypingGraph } from "./typingGraph";
+
+logging.enable("keyboard.*", "automaton.*");
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 cytoscape.use(dagre);

--- a/src/browser/eventHandler.ts
+++ b/src/browser/eventHandler.ts
@@ -1,8 +1,14 @@
 import type { KeyEventType } from "../core/inputEvent";
 import { InputEvent, InputStroke } from "../core/inputEvent";
 import { KeyboardState } from "../core/keyboardState";
+import { logging } from "../core/logger";
 import type { VirtualKey } from "../core/virtualKey";
 import { VirtualKeys } from "../core/virtualKey";
+
+const logActivate = logging.getLogger("keyboard.activate");
+const logDeactivate = logging.getLogger("keyboard.deactivate");
+const logKeyDown = logging.getLogger("keyboard.keydown");
+const logKeyUp = logging.getLogger("keyboard.keyup");
 
 /**
  * @param target addEventListener,removeEventListener を持つ Window object のような型
@@ -22,6 +28,13 @@ export function activate(
     const keyboardEvent = evt as KeyboardEvent;
     const keyStroke = toInputKeyStrokeFromKeyboardEvent("keydown", keyboardEvent, keyMap);
     keyboardState.keydown(keyStroke.key);
+    if (logKeyDown.enabled) {
+      logKeyDown.log({
+        code: keyboardEvent.code,
+        key: keyStroke.key,
+        downedKeys: [...keyboardState.downedKeys],
+      });
+    }
     keyEventHandler(
       new InputEvent(
         keyStroke,
@@ -37,6 +50,13 @@ export function activate(
     const keyboardEvent = evt as KeyboardEvent;
     const keyStroke = toInputKeyStrokeFromKeyboardEvent("keyup", keyboardEvent, keyMap);
     keyboardState.keyup(keyStroke.key);
+    if (logKeyUp.enabled) {
+      logKeyUp.log({
+        code: keyboardEvent.code,
+        key: keyStroke.key,
+        downedKeys: [...keyboardState.downedKeys],
+      });
+    }
     keyEventHandler(
       new InputEvent(
         keyStroke,
@@ -48,9 +68,11 @@ export function activate(
   };
   target.addEventListener("keydown", keyDownEventHandler);
   target.addEventListener("keyup", keyUpEventHandler);
+  logActivate.log({ keyMapSize: keyMap.size });
   return () => {
     target.removeEventListener("keydown", keyDownEventHandler);
     target.removeEventListener("keyup", keyUpEventHandler);
+    logDeactivate.log();
   };
 }
 

--- a/src/core/automaton.ts
+++ b/src/core/automaton.ts
@@ -7,8 +7,13 @@ import {
 } from "./committer";
 import type { InputEvent } from "./inputEvent";
 import { InputResult } from "./inputResult";
+import { logging } from "./logger";
 import type { Rule, RulePrimitive } from "./rule";
 import type { VirtualKey } from "./virtualKey";
+
+const logInput = logging.getLogger("automaton.input");
+const logBack = logging.getLogger("automaton.back");
+const logReset = logging.getLogger("automaton.reset");
 
 /**
  * タイピング状態機械の実装本体。`build(rule, word)` 経由で生成し、
@@ -66,6 +71,7 @@ export class AutomatonImpl implements AutomatonState {
    * ワードを最初から入力し直す場合に使用する。
    */
   reset(): void {
+    logReset.log({ word: this.word });
     this.currentNode = this.startNode;
     this.inputHistory = [];
     this.committer.reset();
@@ -79,7 +85,10 @@ export class AutomatonImpl implements AutomatonState {
    * 成功 edge を skip しながら、最初に見つかった未取り消しの成功 edge を取り消す。
    */
   back(): void {
-    if (this.currentNode === this.startNode) return;
+    if (this.currentNode === this.startNode) {
+      logBack.log("ignored (at startNode)", { kanaIndex: this.currentNode.kanaIndex });
+      return;
+    }
     let skip = 0;
     for (let i = this.inputHistory.length - 1; i >= 0; i--) {
       const entry = this.inputHistory[i];
@@ -94,6 +103,10 @@ export class AutomatonImpl implements AutomatonState {
         }
         this.inputHistory.push({ back: true, undoneEdge: entry.edge });
         this.currentNode = entry.edge.previous;
+        logBack.log("undone", {
+          kanaIndex: this.currentNode.kanaIndex,
+          undoneEdge: entry.edge,
+        });
         break;
       }
     }
@@ -142,19 +155,27 @@ export class AutomatonImpl implements AutomatonState {
           result: inputResult,
           edge: result.stroke.edge,
         });
+        logInput.log("committed", {
+          event: result.stroke.triggerEvent,
+          result: inputResult.toString(),
+        });
         return inputResult;
       }
       case "backspace":
         this.inputHistory.push({ event: stroke, result: InputResult.BACK });
+        logInput.log("backspace", { event: stroke });
         return InputResult.BACK;
       case "pending":
         this.inputHistory.push({ event: stroke, result: InputResult.PENDING });
+        logInput.log("pending", { event: stroke });
         return InputResult.PENDING;
       case "failed":
         this.inputHistory.push({ event: result.event, result: InputResult.FAILED });
+        logInput.log("failed", { event: result.event });
         return InputResult.FAILED;
       case "ignored":
         this.inputHistory.push({ event: stroke, result: InputResult.IGNORED });
+        logInput.log("ignored", { event: stroke });
         return InputResult.IGNORED;
     }
   }

--- a/src/core/logger.test.ts
+++ b/src/core/logger.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { type LogRecord, logging } from "./logger";
+
+beforeEach(() => {
+  logging.disableAll();
+  logging.resetHandler();
+});
+
+test("getLogger returns the same instance for the same label", () => {
+  const a = logging.getLogger("automaton.input");
+  const b = logging.getLogger("automaton.input");
+  expect(a).toBe(b);
+});
+
+test("logger is disabled by default", () => {
+  const log = logging.getLogger("automaton.input");
+  expect(log.enabled).toBe(false);
+  const handler = vi.fn();
+  logging.setHandler(handler);
+  log.log("msg");
+  expect(handler).not.toHaveBeenCalled();
+});
+
+test("enable with exact match activates only that label", () => {
+  const input = logging.getLogger("automaton.input");
+  const back = logging.getLogger("automaton.back");
+  logging.enable("automaton.input");
+  expect(input.enabled).toBe(true);
+  expect(back.enabled).toBe(false);
+});
+
+test("enable with wildcard activates matching labels", () => {
+  const input = logging.getLogger("automaton.input");
+  const back = logging.getLogger("automaton.back");
+  const build = logging.getLogger("builder.build");
+  logging.enable("automaton.*");
+  expect(input.enabled).toBe(true);
+  expect(back.enabled).toBe(true);
+  expect(build.enabled).toBe(false);
+});
+
+test("enable('*') activates all labels", () => {
+  const a = logging.getLogger("a");
+  const b = logging.getLogger("b.c");
+  logging.enable("*");
+  expect(a.enabled).toBe(true);
+  expect(b.enabled).toBe(true);
+});
+
+test("enabled state updates for loggers created after enable", () => {
+  logging.enable("automaton.*");
+  const log = logging.getLogger("automaton.input");
+  expect(log.enabled).toBe(true);
+});
+
+test("disable removes a previously enabled pattern", () => {
+  const log = logging.getLogger("automaton.input");
+  logging.enable("automaton.*");
+  expect(log.enabled).toBe(true);
+  logging.disable("automaton.*");
+  expect(log.enabled).toBe(false);
+});
+
+test("multiple patterns are combined with OR", () => {
+  const input = logging.getLogger("automaton.input");
+  const build = logging.getLogger("builder.build");
+  const other = logging.getLogger("loader.json");
+  logging.enable("automaton.input");
+  logging.enable("builder.*");
+  expect(input.enabled).toBe(true);
+  expect(build.enabled).toBe(true);
+  expect(other.enabled).toBe(false);
+});
+
+test("enable accepts multiple patterns as varargs", () => {
+  const a = logging.getLogger("a");
+  const b = logging.getLogger("b");
+  const c = logging.getLogger("c");
+  logging.enable("a", "b");
+  expect(a.enabled).toBe(true);
+  expect(b.enabled).toBe(true);
+  expect(c.enabled).toBe(false);
+});
+
+test("disable accepts multiple patterns as varargs", () => {
+  const a = logging.getLogger("a");
+  const b = logging.getLogger("b");
+  logging.enable("a", "b");
+  logging.disable("a", "b");
+  expect(a.enabled).toBe(false);
+  expect(b.enabled).toBe(false);
+});
+
+test("disableAll clears all active patterns", () => {
+  const a = logging.getLogger("a");
+  const b = logging.getLogger("b");
+  logging.enable("a", "b");
+  logging.disableAll();
+  expect(a.enabled).toBe(false);
+  expect(b.enabled).toBe(false);
+});
+
+test("handler receives a LogRecord when the logger is enabled", () => {
+  const records: LogRecord[] = [];
+  logging.setHandler((r) => records.push(r));
+  const log = logging.getLogger("automaton.input");
+  logging.enable("automaton.input");
+  log.log("hello", 42, { foo: "bar" });
+  expect(records).toHaveLength(1);
+  expect(records[0].label).toBe("automaton.input");
+  expect(records[0].args).toEqual(["hello", 42, { foo: "bar" }]);
+  expect(typeof records[0].timestamp).toBe("number");
+});
+
+test("resetHandler restores the default handler", () => {
+  const customHandler = vi.fn();
+  logging.setHandler(customHandler);
+  logging.resetHandler();
+  const log = logging.getLogger("automaton.input");
+  logging.enable("automaton.input");
+  log.log("msg");
+  expect(customHandler).not.toHaveBeenCalled();
+});
+
+test("exact label pattern does not match sub-labels", () => {
+  const a = logging.getLogger("automaton");
+  const b = logging.getLogger("automaton.input");
+  logging.enable("automaton");
+  expect(a.enabled).toBe(true);
+  expect(b.enabled).toBe(false);
+});

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,0 +1,169 @@
+import { setDefaultFunc } from "../utils/map";
+
+/**
+ * 1 回のログ出力を表すレコード。`LogHandler` の引数として渡される。
+ */
+export type LogRecord = {
+  /** ログ出力箇所を識別するラベル（例: "automaton.input"）。 */
+  label: string;
+  /** `Logger.log(...args)` に渡された引数列。 */
+  args: unknown[];
+  /** `Date.now()` で取得した出力時刻のミリ秒。 */
+  timestamp: number;
+};
+
+/**
+ * ログ出力の実処理を担う関数型。`logging.setHandler` で差し替え可能。
+ * 既定ハンドラは `console.log` で `[label] HH:MM:SS.mmm - ...args` 形式で出力する。
+ */
+export type LogHandler = (record: LogRecord) => void;
+
+/**
+ * 特定ラベルに紐づくロガー。`logging.getLogger(label)` で取得する。
+ *
+ * `log(...args)` は `enabled` が true のときのみハンドラを呼び出す。
+ * 引数計算コストが高い場合は `if (logger.enabled)` で事前ガードできる。
+ */
+export type Logger = {
+  /** このロガーが紐づくラベル。 */
+  readonly label: string;
+  /** 現在有効化されているかどうか（`logging.enable` / `logging.disable` で変化する）。 */
+  readonly enabled: boolean;
+  /** 有効時のみ、登録済みハンドラにレコードを渡す。 */
+  log(...args: unknown[]): void;
+};
+
+class LoggerImpl implements Logger {
+  enabled = false;
+  constructor(readonly label: string) {}
+  log(...args: unknown[]): void {
+    if (!this.enabled) return;
+    currentHandler({ label: this.label, args, timestamp: Date.now() });
+  }
+}
+
+function formatTimestamp(ms: number): string {
+  const d = new Date(ms);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  const ss = String(d.getSeconds()).padStart(2, "0");
+  const mmm = String(d.getMilliseconds()).padStart(3, "0");
+  return `${hh}:${mm}:${ss}.${mmm}`;
+}
+
+const defaultHandler: LogHandler = (record) => {
+  console.log(`${formatTimestamp(record.timestamp)} [${record.label}]`, ...record.args);
+};
+
+const cache = new Map<string, LoggerImpl>();
+let enabledPatterns = new Set<string>();
+let enabledRegexes: RegExp[] = [];
+let currentHandler: LogHandler = defaultHandler;
+
+function patternToRegex(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+  return new RegExp(`^${escaped}$`);
+}
+
+function matches(label: string): boolean {
+  for (const regex of enabledRegexes) {
+    if (regex.test(label)) return true;
+  }
+  return false;
+}
+
+function refresh(): void {
+  enabledRegexes = [...enabledPatterns].map(patternToRegex);
+  for (const logger of cache.values()) {
+    logger.enabled = matches(logger.label);
+  }
+}
+
+function getLogger(label: string): Logger {
+  return setDefaultFunc(cache, label, () => {
+    const logger = new LoggerImpl(label);
+    logger.enabled = matches(label);
+    return logger;
+  });
+}
+
+function enable(...patterns: string[]): void {
+  let changed = false;
+  for (const pattern of patterns) {
+    if (!enabledPatterns.has(pattern)) {
+      enabledPatterns.add(pattern);
+      changed = true;
+    }
+  }
+  if (changed) refresh();
+}
+
+function disable(...patterns: string[]): void {
+  let changed = false;
+  for (const pattern of patterns) {
+    if (enabledPatterns.delete(pattern)) changed = true;
+  }
+  if (changed) refresh();
+}
+
+function disableAll(): void {
+  if (enabledPatterns.size === 0) return;
+  enabledPatterns.clear();
+  refresh();
+}
+
+function setHandler(handler: LogHandler): void {
+  currentHandler = handler;
+}
+
+function resetHandler(): void {
+  currentHandler = defaultHandler;
+}
+
+/**
+ * emiel のデバッグログ制御 API。Python の `logging` モジュールに近い使い方ができる。
+ *
+ * @example
+ * ```ts
+ * import { logging } from "emiel";
+ *
+ * logging.enable("automaton.*", "builder.build"); // 複数指定可
+ * logging.enable("*"); // 全部
+ * logging.disable("automaton.input"); // 個別解除
+ * logging.disableAll(); // すべて無効化
+ *
+ * logging.setHandler((record) => {
+ *   myAppLogger.debug(`[${record.label}]`, ...record.args);
+ * });
+ * ```
+ */
+export const logging = {
+  /**
+   * ラベルに対応する `Logger` を取得する。同じラベルには同一インスタンスを返す。
+   * @param label ドット区切り推奨（例: "automaton.input"）
+   */
+  getLogger,
+  /**
+   * 指定したパターンに一致するラベルのログを有効化する。複数指定可。
+   * `*` をワイルドカードとして使える（例: "automaton.*", "*"）。
+   * 既に登録済みのパターンは無視される。
+   */
+  enable,
+  /**
+   * `enable` で有効化したパターンを取り消す。複数指定可。
+   * 未登録のパターンは無視される。
+   */
+  disable,
+  /**
+   * 有効化中のパターンをすべて取り消して全ロガーを無効化する。
+   */
+  disableAll,
+  /**
+   * ログ出力の実処理を差し替える。自社ロガーへの転送などに使用する。
+   */
+  setHandler,
+  /**
+   * `setHandler` で差し替えたハンドラを既定（console.log 出力）に戻す。
+   */
+  resetHandler,
+} as const;

--- a/src/impl/buildAutomaton.ts
+++ b/src/impl/buildAutomaton.ts
@@ -1,9 +1,12 @@
 import { AutomatonImpl } from "../core/automaton";
 import { buildKanaNode, computeRulesByKanaIndex } from "../core/builderKanaGraph";
 import { buildStrokeNode } from "../core/builderStrokeGraph";
+import { logging } from "../core/logger";
 import type { normalizerFunc, Rule } from "../core/rule";
 import * as AutomatonView from "./automatonView";
 import { defaultComposedNormalize } from "./charNormalizer";
+
+const logBuild = logging.getLogger("builder.build");
 
 /**
  * 入力ルールとお題かな文字列から `Automaton` を構築する、emiel の中心 API。
@@ -20,9 +23,11 @@ export function build(
   kanaText: string,
   normalize: normalizerFunc = defaultComposedNormalize,
 ): Automaton {
+  logBuild.log("start", { kanaText });
   const { startNode: kanaStartNode, endNode } = buildKanaNode(rule, kanaText, normalize);
   const rulesByKanaIndex = computeRulesByKanaIndex(kanaStartNode, endNode.startIndex, rule);
   const automaton = new AutomatonImpl(kanaText, buildStrokeNode(endNode), rule, rulesByKanaIndex);
+  logBuild.log("done", { kanaText, endIndex: endNode.startIndex });
   return automaton.with(baseExtension);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,3 +48,5 @@ export {
 
 export { build, type Automaton, type BaseExtensionType } from "./impl/buildAutomaton";
 export { type CurrentView, type EventsView } from "./impl/automatonView";
+
+export { logging, type Logger, type LogHandler, type LogRecord } from "./core/logger";


### PR DESCRIPTION
## Summary

- `logging` namespace を公開し、`getLogger` / `enable` / `disable` / `disableAll` / `setHandler` / `resetHandler` を提供
- ワイルドカード (`*`) でラベル単位の ON/OFF 切り替え（例: `logging.enable(\"automaton.*\", \"keyboard.*\")`）
- `automaton.input` 等の内部イベントをラベル付きで出力し、デフォルトハンドラは `HH:MM:SS.mmm [label] ...args` 形式で `console.log` に流す
- `setHandler` で利用者が自社ロガーに転送可能
- 全 example の App.tsx で `logging.enable(\"keyboard.*\", \"automaton.*\")` を追加しデバッグ出力を有効化

## 設計の背景

これまで emiel 内部のデバッグ出力は `console.log` が散在するのみで、ライブラリ利用者が必要な情報を取得する手段が統一されていなかった。利用者側でモジュール/イベント単位に ON/OFF を切り替えたいというニーズがあり、Python の `logging` モジュール風の API を自前実装した。

レベル（DEBUG/INFO/WARN/ERROR）は持たず、ラベル名とワイルドカードだけで制御するシンプルな設計にした。emiel は主にタイピングゲーム用ライブラリで、利用者が必要なときだけデバッグ出力を覗く使い方が想定されるため、レベルよりもラベル命名の粒度で十分と判断。

ホットパス（`keyboard.keydown` / `keyboard.keyup`）では `if (log.enabled)` ガードで無効時の引数評価コストを削減している。

## 検討した代替案

- debug パッケージ採用: レベル不要・ラベル ON/OFF という要件に合うが、外部依存を追加せず自前で最小実装にした（ライブラリの依存ゼロを維持）
- ログレベル方式: Python logging の完全再現案を検討したが、レベルの多段階管理は overkill と判断して見送り
- `setPatterns(string[])` による全置換 API: 初期実装に含めていたが「enable と対になる関数名が `setPatterns` では分かりづらい」との指摘を受け、`enable` を varargs 化して削除した。全消去は `disableAll()` に分離

## Test plan

- [x] `pnpm run test` — 179 件パス（logger.test.ts に 14 ケース追加）
- [x] `pnpm run lint` — clean
- [x] `pnpm run build` / `pnpm run build:all` — 成功
- [ ] ブラウザで examples/react-simple を起動し、DevTools Console にキー入力・オートマトン遷移のログが流れることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)