### PR TITLE
chore: release v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ activate(window, (event) => {
 - <a href="./examples/react-mixed-guide">react-mixed-guide</a> - 漢字かな混じりテキストのローマ字入力
 - <a href="./examples/react-multi-word">react-multi-word</a> - 複数単語を同時表示するマルチターゲットタイピング
 - <a href="./examples/react-result-record">react-result-record</a> - タイピング成績（タイム・入力数）の記録・表示
+- <a href="./examples/react-typewell">react-typewell</a> - タイプウェル風の連続ワード入力（末尾「ん」1 打確定・ワード単位の KPM 集計）
 - <a href="./examples/react-keyboardguide">react-keyboardguide</a> - 物理キーボード配列・入力ガイドのビジュアライザー
 - <a href="./examples/react-stroke-graph">react-stroke-graph</a> - キー入力の状態遷移をグラフで可視化
 - <a href="./examples/cli">cli</a> - Node.js 環境でのオートマトン直接操作

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "emiel",
   "author": "tomoemon",
   "packageManager": "pnpm@9.11.0",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

v0.4.0 リリース準備。

- `package.json` の version を 0.3.0 → 0.4.0 に bump
- README の Examples に `react-typewell` を追加

## v0.3.0 からの主な変更

- **破壊的変更**: `Rule.compose` → `Rule.merge` へリネーム (#42)
- `Rule.primitives` / `RuleSet` / `composeRules` / `computeRulesByKanaIndex` / `rulesByKanaIndex` を削除
- `RuleEntry.sources` / `StrokeEdge.entry` を追加。各打鍵の由来 `RulePrimitive` を追跡可能に
- `ruleExtender` が primitive をまたぐプレフィックス展開を生成 (ローマ字 `n/ん` + direct input `space/ ` 等)
- タイプウェル風の連続入力サンプル `react-typewell` を追加

## Test plan

- [x] `pnpm run test` 全通過
- [x] `pnpm run lint` / `pnpm run fmt:check` 通過
- [x] `pnpm run build:all` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)