### PR TITLE
ci: package.json の version 変更で自動 tag + release を作成

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: release
 description: リリース用のバージョン bump コミット + PR 作成を一括で行う
-argument-hint: [optional next-version like "0.4.0"]
-allowed-tools: Bash, Read, Edit, AskUserQuestion
+argument-hint: "[next-version] (例: 0.5.0)"
 ---
 
 # Release

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: release
+description: リリース用のバージョン bump コミット + PR 作成を一括で行う
+argument-hint: [optional next-version like "0.4.0"]
+allowed-tools: Bash, Read, Edit, AskUserQuestion
+---
+
+# Release
+
+emiel のリリース手順 (`CONTRIBUTING.md` の「リリース手順」) に沿って、
+`package.json` の version bump → release コミット → push → PR 作成 を一括で行う。
+
+PR がマージされると `.github/workflows/release-tag.yaml` が自動でタグと GitHub release を作成し、
+続いて `.github/workflows/release.yaml` が npm publish を実行する。
+
+## 1. 事前チェック
+
+以下を並列で実行する:
+
+- `gh auth status` で GitHub CLI 認証確認。未認証ならエラーで終了
+- `git status` で working tree の状態確認
+- 現バージョンを `package.json` から取得:
+  ```
+  node -p "require('./package.json').version"
+  ```
+- 最新タグを取得 (参考情報): `git describe --tags --abbrev=0 2>/dev/null || echo none`
+- main との差分から `feat` / `fix` / `!` を含むコミットの有無を確認:
+  ```
+  git log --oneline origin/main..main 2>/dev/null || git log --oneline v<current>..main 2>/dev/null
+  ```
+
+## 2. 次バージョンの決定
+
+- `$ARGUMENTS` が指定されていればそれを次バージョンとして使う (例: `0.5.0`)
+- 指定がなければ、現バージョンを提示して AskUserQuestion で確認する:
+  - patch bump (0.x.Y → 0.x.Y+1)
+  - minor bump (0.X.y → 0.X+1.0)
+  - major bump (X.y.z → X+1.0.0) ※ 0.x 系でも破壊的変更時は任意選択可
+  - 直接入力 (その他)
+
+選択肢の根拠として、 main に溜まっているコミットのうち `feat`/`fix`/`!` の内訳を示す。
+
+## 3. ブランチ作成
+
+ブランチ名は `chore/release-v<version>` とする (例: `chore/release-v0.5.0`)。
+
+- main ブランチにいる場合: そのままブランチを作成してチェックアウト
+- main 以外のブランチにいる場合: AskUserQuestion で確認する:
+  - 現在のブランチで続行する
+  - main に切り替えてから `chore/release-v<version>` を作成する
+
+後者を選んだ場合、 working tree に未コミットの変更があれば先にユーザへ通知して中断する
+(stash / commit の判断はユーザに委ねる)。
+
+## 4. package.json の version 更新
+
+- `Edit` で `package.json` の `"version": "<old>"` を `"version": "<new>"` に書き換える
+- それ以外のファイルは変更しない (README などは別 PR で扱う)
+
+## 5. コミット
+
+- `git add package.json` (個別指定、 `-A` は禁止)
+- コミットメッセージは以下 (HEREDOC で渡す):
+  ```
+  chore: release v<version>
+
+  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+  ```
+
+## 6. プッシュ
+
+```
+git push -u origin chore/release-v<version>
+```
+
+## 7. PR 作成
+
+`gh pr create` で PR を作成する。タイトルは `chore: release v<version>`。
+
+body は HEREDOC で渡す。以下を含める:
+
+```
+## Summary
+
+v<version> リリース準備。 `package.json` の version を <old> → <new> に bump。
+
+## 変更内容 (v<current> 以降)
+
+- main に溜まっている feat / fix / breaking-change のコミットを箇条書きで列挙
+  (`git log v<current>..main --oneline` の出力から抽出)
+  - 破壊的変更 (`!` 付き) は先頭に明示
+  - feat → 機能追加
+  - fix → バグ修正
+  - それ以外 (refactor / docs / test / chore) は重要なもののみ
+
+## リリースフロー
+
+マージ後、以下が自動で走る:
+
+1. `release-tag` workflow がタグ `v<version>` を作成し GitHub release を生成
+2. `release` workflow が GitHub release の publish を検知して npm publish を実行
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+## 8. 完了
+
+作成された PR の URL をユーザに報告する。マージ後はタグ作成 / GitHub release / npm publish が自動で進む旨も伝える。

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -1,0 +1,36 @@
+name: release-tag
+
+on:
+  push:
+    branches: [main]
+    paths: [package.json]
+
+jobs:
+  release-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - id: version
+        name: Read version from package.json
+        run: echo "value=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+      - id: tag-check
+        name: Check if tag already exists
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.value }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create tag and GitHub release
+        if: steps.tag-check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.value }}"
+          git tag "v$VERSION"
+          git push origin "v$VERSION"
+          gh release create "v$VERSION" --title "v$VERSION" --generate-notes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,44 @@
+# リリース手順
+
+emiel は `package.json` の version bump 経由でリリースする。 main に push されたタイミングで `package.json` の version に対応するタグが存在しない場合、 `.github/workflows/release-tag.yaml` が自動でタグを打ち GitHub release を作成する。 GitHub release が publish されると `.github/workflows/release.yaml` が npm publish を実行する。
+
+## 手順
+
+1. 作業ブランチで `package.json` の `version` を次のバージョンに書き換える
+   - `feat` が入っていれば minor bump (0.x 系では major 相当の破壊的変更でも minor)
+   - `fix` のみなら patch bump
+2. 「chore: release vX.Y.Z」コミットを作り push、PR を作成する
+3. CI (main branch workflow) が緑になったらマージする
+4. マージ後、 `release-tag` workflow がタグ作成 + GitHub release 作成を自動実行する
+5. release publish をトリガーに `release` workflow が npm publish を自動実行する
+
+## Claude Code の skill から行う場合
+
+`/release` skill (`.claude/skills/release/SKILL.md`) を使うと、ブランチ作成 → version bump → コミット → push → PR 作成までを一括で行える。
+
+## 注意
+
+- `release-tag` workflow は `package.json` の変更が main に到達した時にのみ発火する。 README など他ファイルの変更を同じ PR に混ぜても問題ないが、 1 リリース = 1 PR を推奨する
+- すでに同じバージョンのタグが存在する場合、 workflow は何もしない
+
+# コミットメッセージ
+
+Conventional Commits 形式を用いる:
+
+```
+<type>(<scope>)!: <subject>
+```
+
+- `type`: `feat` / `fix` / `chore` / `docs` / `refactor` / `test` / `perf` / `build` / `ci`
+- `scope`: 任意 (例: `rule`, `automaton`, `examples`)
+- `!`: 破壊的変更を示す
+- `subject`: 変更内容の短い説明 (日本語可)
+
+例:
+- `feat(rule)!: compose を merge にリネーム`
+- `fix(eventsView): first を keydown イベントに限定する`
+- `docs(readme): Examples に react-typewell を追加`
+
 # ローカルでの examples の動作確認
 
 pnpm workspace を使って、examples 側からローカルの emiel を参照しています。


### PR DESCRIPTION
## Summary

- `.github/workflows/release-tag.yaml` を追加。 main への push で `package.json` の version に対応するタグが無ければ、自動で `v<version>` タグ + GitHub release (`--generate-notes`) を作成する
- CONTRIBUTING.md にリリース手順とコミットメッセージ規約 (Conventional Commits) のセクションを追加
- `.claude/skills/release/SKILL.md` を追加。 `/release` でリリース用ブランチ作成 + version bump + PR 作成を一括実行できる

## 設計の背景

これまでリリースは「release ブランチを切る → version bump コミット → PR → merge → `git tag` + `gh release create` を手動実行 → npm publish は CI」という流れで、マージ後の「タグ作成」「GitHub release 作成」を毎回手でやっていた。

release-please の「conventional commits から自動で release PR を開く」モデルは「リリースする／しないをコミット内容で自動判断される」ことを意味し、意図しないタイミングで release PR が生まれる懸念があった。

そこで逆向きに「 version bump は従来通り手動 PR で行い、マージされた後の tag + release 作成だけを自動化する」方針にした。これなら利用者がリリースタイミングを制御したまま、手作業を減らせる。

既存 `release.yaml` は `release: published` イベントで発火するので、 release-tag で作った release がそのまま npm publish をトリガーする。ワークフロー同士はイベントで疎結合に繋がっている。

## 検討した代替案

- release-please 導入: conventional commits の自動解析はメリットだが、リリースタイミングの制御が利用者の手から離れる。また CHANGELOG.md 生成を無効化する設定が release-please のバージョンによって異なり、運用が面倒になりうる
- `pnpm version` を使った半自動: ローカルで `pnpm version minor` → コミット + タグまでは作れるが、 GitHub release 作成が手動で残る。 PR レビューのステップも省けない
- release-please と今回の workflow の併用: 目的が重複するので不採用

## 変更ファイル

- 追加: `.github/workflows/release-tag.yaml` (25 行)
- 追加: `.claude/skills/release/SKILL.md` (skill 定義)
- 更新: `CONTRIBUTING.md` (リリース手順 + コミットメッセージ規約)

## Test plan

- [x] workflow の YAML 構文チェック (`actions/checkout` は他 workflow と同じ pinned SHA を使用)
- [ ] 次回のリリース時に動作確認 (次バージョンの PR をマージして release が自動生成されることを確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)