### PR TITLE
ci: StackBlitz でオンライン動作確認できる環境を追加

### DIFF
--- a/.github/workflows/stackblitz.yaml
+++ b/.github/workflows/stackblitz.yaml
@@ -1,0 +1,32 @@
+name: update-stackblitz
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-stackblitz:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Get version
+        id: version
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+      - name: Update examples package.json
+        run: |
+          VERSION="${{ steps.version.outputs.value }}"
+          for pkg in examples/*/package.json; do
+            sed -i 's/"emiel": "workspace:\*"/"emiel": "^'"$VERSION"'"/' "$pkg"
+          done
+      - name: Remove pnpm-lock.yaml from examples
+        run: find examples -maxdepth 2 -name "pnpm-lock.yaml" -delete
+      - name: Push to stackblitz branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B stackblitz
+          git add examples/
+          git commit -m "chore: prepare examples for stackblitz (v${{ steps.version.outputs.value }})"
+          git push origin stackblitz --force

--- a/README.md
+++ b/README.md
@@ -92,16 +92,22 @@ activate(window, (event) => {
 
 ## Examples
 
-- <a href="./examples/react-simple">react-simple</a> - 単語を次々と入力するシンプルなタイピング練習
-- <a href="./examples/react-backspace">react-backspace</a> - バックスペースの3つの実装パターン比較（全クリア/カウント/入力戻し）
-- <a href="./examples/react-roman-or-kana">react-roman-or-kana</a> - ローマ字入力とJISかな入力の両対応デュアル入力モード
-- <a href="./examples/react-mixed-guide">react-mixed-guide</a> - 漢字かな混じりテキストのローマ字入力
-- <a href="./examples/react-multi-word">react-multi-word</a> - 複数単語を同時表示するマルチターゲットタイピング
-- <a href="./examples/react-result-record">react-result-record</a> - タイピング成績（タイム・入力数）の記録・表示
-- <a href="./examples/react-typewell">react-typewell</a> - タイプウェル風の連続ワード入力（末尾「ん」1 打確定・ワード単位の KPM 集計）
-- <a href="./examples/react-keyboardguide">react-keyboardguide</a> - 物理キーボード配列・入力ガイドのビジュアライザー
-- <a href="./examples/react-stroke-graph">react-stroke-graph</a> - キー入力の状態遷移をグラフで可視化
-- <a href="./examples/cli">cli</a> - Node.js 環境でのオートマトン直接操作
+"Open in StackBlitz" をクリックすると、インストール不要でブラウザ上でコードを編集・実行できるオンライン環境が開きます。
+
+| Example | 説明 | |
+|---|---|:---:|
+| [react-simple](./examples/react-simple) | 単語を次々と入力するシンプルなタイピング練習 | [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz_small.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-simple) |
+| [react-backspace](./examples/react-backspace) | バックスペースの3つの実装パターン比較（全クリア/カウント/入力戻し）| [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz_small.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-backspace) |
+| [react-roman-or-kana](./examples/react-roman-or-kana) | ローマ字入力とJISかな入力の両対応デュアル入力モード | [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz_small.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-roman-or-kana) |
+| [react-kanji-annotation](./examples/react-kanji-annotation) | 漢字かな混じりテキストのローマ字入力 | [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz_small.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-kanji-annotation) |
+| [react-multi-word](./examples/react-multi-word) | 複数単語を同時表示するマルチターゲットタイピング | [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz_small.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-multi-word) |
+| [react-result-record](./examples/react-result-record) | タイピング成績（タイム・入力数）の記録・表示 | [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz_small.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-result-record) |
+| [react-typewell](./examples/react-typewell) | タイプウェル風の連続ワード入力（末尾「ん」1 打確定・ワード単位の KPM 集計）| [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz_small.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-typewell) |
+| [react-keyboardguide](./examples/react-keyboardguide) | 物理キーボード配列・入力ガイドのビジュアライザー | [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz_small.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-keyboardguide) |
+| [react-stroke-graph](./examples/react-stroke-graph) | キー入力の状態遷移をグラフで可視化 | [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz_small.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-stroke-graph) |
+| [react-mixed-layout](./examples/react-mixed-layout) | かなと英字で異なるキーボードレイアウトを使う混在構成 | [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz_small.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-mixed-layout) |
+| [react-mixed-input-guide](./examples/react-mixed-input-guide) | かな・英字混在ワードのキーボードガイド表示 | [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz_small.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-mixed-input-guide) |
+| [cli](./examples/cli) | Node.js 環境でのオートマトン直接操作 | |
 
 # 特徴
 

--- a/examples/react-backspace/README.md
+++ b/examples/react-backspace/README.md
@@ -1,3 +1,5 @@
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-backspace)
+
 # 概要
 
 入力ミスがあったときに、ミスした分の入力を Backspace で消すまで次の正しい入力をさせない例。

--- a/examples/react-kanji-annotation/README.md
+++ b/examples/react-kanji-annotation/README.md
@@ -1,3 +1,5 @@
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-kanji-annotation)
+
 # 概要
 
 課題文のかな文字とキー列だけでなく、漢字かな交じりの文の入力状態も表示する例。

--- a/examples/react-keyboardguide/README.md
+++ b/examples/react-keyboardguide/README.md
@@ -1,3 +1,5 @@
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-keyboardguide)
+
 # React + TypeScript + Vite
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.

--- a/examples/react-mixed-layout/README.md
+++ b/examples/react-mixed-layout/README.md
@@ -1,3 +1,5 @@
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-mixed-layout)
+
 # react-mixed-layout
 
 かなと英字で異なるキーボードレイアウトを使う混在構成のサンプル。

--- a/examples/react-multi-word/README.md
+++ b/examples/react-multi-word/README.md
@@ -1,3 +1,5 @@
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-multi-word)
+
 # 概要
 
 複数のワードが同時に表示されて、任意のワードを打つことができる例。

--- a/examples/react-result-record/README.md
+++ b/examples/react-result-record/README.md
@@ -1,3 +1,5 @@
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-result-record)
+
 # 概要
 
 入力した結果のリザルトを表示する例。

--- a/examples/react-roman-or-kana/README.md
+++ b/examples/react-roman-or-kana/README.md
@@ -1,3 +1,5 @@
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-roman-or-kana)
+
 # 概要
 
 1 つのワードをローマ字入力とかな入力のどちらで入力することもできる例。

--- a/examples/react-simple/README.md
+++ b/examples/react-simple/README.md
@@ -1,3 +1,5 @@
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-simple)
+
 # 概要
 
 シンプルなローマ字入力の例。

--- a/examples/react-stroke-graph/README.md
+++ b/examples/react-stroke-graph/README.md
@@ -1,3 +1,5 @@
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-stroke-graph)
+
 # 概要
 
 StrokeNode のグラフ表示例。

--- a/examples/react-typewell/README.md
+++ b/examples/react-typewell/README.md
@@ -1,3 +1,5 @@
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-typewell)
+
 # 概要
 
 タイプウェル風の複数ワード連続入力サンプル。


### PR DESCRIPTION
## Summary

- リリース（GitHub release publish）をトリガーに examples の `workspace:*` を公開バージョンに書き換えた `stackblitz` ブランチを自動生成する workflow を追加（`.github/workflows/stackblitz.yaml`）
- `pnpm-lock.yaml` は `workspace:*` を参照しているため stackblitz ブランチでは削除する
- ルート `README.md` の Examples セクションをテーブル形式に変更し、各 example に "Open in StackBlitz" バッジを追加
- 各 example の `README.md` にも StackBlitz バッジを追加

## 設計の背景

examples は `"emiel": "workspace:*"` でローカルの workspace パッケージを参照しているため、GitHub 上のリポジトリを StackBlitz でそのまま開いても依存解決できない。

ローカルの開発フロー（`workspace:*` で最新ビルドを参照）を変えずにオンライン環境を提供する方法として、以下の 3 案を検討した。

## 検討した代替案

- GitHub Pages への静的デプロイ: リリース時にビルド済み成果物をデプロイする方法。コードを見ながら触れないがデモとして最もシンプル。
- StackBlitz の monorepo サポートに依存: `workspace:*` のまま StackBlitz に任せる方法。実際に解決できるか不明なためリスクがある。
- 採用案: CI でのみ package.json を書き換えた `stackblitz` ブランチを自動生成し、StackBlitz URL はそのブランチを指す。ローカルの開発フローへの影響ゼロで確実に動作する。

## Test plan

- [ ] `stackblitz` ブランチの examples/react-simple/package.json の emiel が `^0.4.0` になっていることを確認（手動で作成済み）
- [ ] https://stackblitz.com/github/tomoemon/emiel/tree/stackblitz/examples/react-simple を開いてインストール・起動が成功することを確認
- [ ] 次回リリース時に `stackblitz` ブランチが自動更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)