### PR TITLE
fix(examples): react-multi-word の直接入力対応と flex-wrap 追加

### DIFF
--- a/examples/react-multi-word/src/App.tsx
+++ b/examples/react-multi-word/src/App.tsx
@@ -2,6 +2,7 @@ import type { Automaton, InputStroke, KeyboardLayout } from "emiel";
 import {
   activate,
   build,
+  createDirectInputRule,
   detectKeyboardLayout,
   loadPresetRuleRoman,
   logging,
@@ -44,7 +45,10 @@ function App() {
 }
 
 function Typing(props: { layout: KeyboardLayout }) {
-  const romanRule = useMemo(() => loadPresetRuleRoman(props.layout), [props.layout]);
+  const romanRule = useMemo(
+    () => loadPresetRuleRoman(props.layout).merge(createDirectInputRule(props.layout)),
+    [props.layout],
+  );
   const [selector, setSelector] = useState(
     () =>
       new MultiWordState(
@@ -81,7 +85,7 @@ function Typing(props: { layout: KeyboardLayout }) {
 
   return (
     <>
-      <ul style={{ display: "flex", gap: "2rem", listStyle: "none" }}>
+      <ul style={{ display: "flex", flexWrap: "wrap", gap: "2rem", listStyle: "none", padding: 0 }}>
         {[...selector.items]
           .sort((a, b) => a.getPosition() - b.getPosition())
           .map((a, i) => (


### PR DESCRIPTION
## Summary

- `createDirectInputRule` を `loadPresetRuleRoman` にマージし、`"aから@"` のような ASCII 文字・記号混在ワードでオートマトン構築時にエラーが発生する問題を修正
- `ul` に `flexWrap: "wrap"` と `padding: 0` を追加し、画面幅に合わせてワードが折り返し表示されるように変更（StackBlitz 等の狭い画面でのスクロールを解消）

## 設計の背景

`loadPresetRuleRoman` はかな文字のみを対象とするローマ字ルールのため、`"aから@"` の `a` や `@` に対応するエントリが存在せず、`build()` 時に `Rule can't generate an automaton` エラーが発生していた。README の最小コード例にあるように `createDirectInputRule` をマージすることで ASCII 文字・記号も処理できるようにした。

## Test plan

- [ ] `"aから@"` が含まれるワードで `build()` がエラーなく完了すること
- [ ] StackBlitz 等の狭い画面でワードが折り返して表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)