### PR TITLE
feat(examples): react-stroke-graph に preset rule/layout 選択 UI を追加

### DIFF
--- a/examples/react-stroke-graph/src/App.css
+++ b/examples/react-stroke-graph/src/App.css
@@ -66,6 +66,23 @@
 .controls button {
   padding: 0.15rem 0.6rem;
   font-size: 0.875rem;
+  border: 1px solid #646cff;
+  border-radius: 4px;
+  background-color: #646cff;
+  color: #fff;
+  cursor: pointer;
+}
+
+.controls button:hover:not(:disabled) {
+  background-color: #535bf2;
+  border-color: #535bf2;
+}
+
+.controls button:disabled {
+  border-color: #444;
+  background-color: #2a2a2a;
+  color: #777;
+  cursor: not-allowed;
 }
 
 /* 単語欄を改行して 1 段下に配置し、全単語が見える幅を確保する */

--- a/examples/react-stroke-graph/src/App.css
+++ b/examples/react-stroke-graph/src/App.css
@@ -1,7 +1,7 @@
 #root {
   max-width: 1280px;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 0.5rem 2rem;
   text-align: center;
 }
 
@@ -39,6 +39,43 @@
 
 .read-the-docs {
   color: #888;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.25rem 1rem;
+  margin-bottom: 0.5rem;
+}
+
+/* 入力対象ワードの表示 */
+.target-word {
+  margin: 0.25rem 0;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.controls label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+}
+
+.controls button {
+  padding: 0.15rem 0.6rem;
+  font-size: 0.875rem;
+}
+
+/* 単語欄を改行して 1 段下に配置し、全単語が見える幅を確保する */
+.controls .words-field {
+  flex-basis: 100%;
+  justify-content: center;
+}
+
+.controls .words-field input {
+  width: 24rem;
 }
 
 h1 {

--- a/examples/react-stroke-graph/src/App.tsx
+++ b/examples/react-stroke-graph/src/App.tsx
@@ -1,13 +1,27 @@
 import cytoscape from "cytoscape";
 import dagre from "cytoscape-dagre";
-import type { Automaton, KeyboardLayout } from "emiel";
+import type { Automaton, KeyboardLayout, Rule } from "emiel";
 import {
   build,
-  detectKeyboardLayout,
+  createDirectInputRule,
+  loadPresetKeyboardLayoutAstarte,
+  loadPresetKeyboardLayoutColemak,
+  loadPresetKeyboardLayoutColemakDh,
+  loadPresetKeyboardLayoutDvorak,
+  loadPresetKeyboardLayoutEucalyn,
+  loadPresetKeyboardLayoutOnishi,
+  loadPresetKeyboardLayoutQwertyJis,
+  loadPresetKeyboardLayoutQwertyUs,
+  loadPresetKeyboardLayoutTomisukeJis,
+  loadPresetRuleAsuka123,
+  loadPresetRuleAsuka290,
+  loadPresetRuleAzikRomantable,
   loadPresetRuleJisKana,
   loadPresetRuleNaginatashikiV15,
   loadPresetRuleNicola,
   loadPresetRuleRoman,
+  loadPresetRuleShingeta,
+  loadPresetRuleTsuki2_263,
   logging,
 } from "emiel";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -19,59 +33,150 @@ logging.enable("keyboard.*", "automaton.*");
 // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 cytoscape.use(dagre);
 
-function App() {
-  const [layout, setLayout] = useState<KeyboardLayout | undefined>();
-  useEffect(() => {
-    detectKeyboardLayout(window).then(setLayout).catch(console.error);
-  }, []);
-  return layout ? <Typing layout={layout} /> : <></>;
-}
+const rules: { name: string; load: (layout: KeyboardLayout) => Rule }[] = [
+  { name: "ローマ字", load: (layout) => loadPresetRuleRoman(layout) },
+  { name: "JISかな", load: () => loadPresetRuleJisKana() },
+  { name: "NICOLA", load: () => loadPresetRuleNicola() },
+  { name: "薙刀式", load: () => loadPresetRuleNaginatashikiV15() },
+  { name: "飛鳥123", load: () => loadPresetRuleAsuka123() },
+  { name: "飛鳥290", load: () => loadPresetRuleAsuka290() },
+  { name: "AZIK", load: (layout) => loadPresetRuleAzikRomantable(layout) },
+  { name: "新下駄", load: () => loadPresetRuleShingeta() },
+  { name: "月2-263", load: () => loadPresetRuleTsuki2_263() },
+];
 
-function Typing(props: { layout: KeyboardLayout }) {
-  const rules = useMemo(
-    () => [
-      { name: "ローマ字", rule: loadPresetRuleRoman(props.layout) },
-      { name: "JISかな", rule: loadPresetRuleJisKana() },
-      { name: "NICOLA", rule: loadPresetRuleNicola() },
-      { name: "薙刀式", rule: loadPresetRuleNaginatashikiV15() },
-    ],
-    [props.layout],
-  );
-  const [automaton, setAutomaton] = useState<Automaton | undefined>(undefined);
-  const [ruleName, setRuleName] = useState("");
+const layouts: { name: string; load: () => KeyboardLayout }[] = [
+  { name: "QWERTY JIS", load: loadPresetKeyboardLayoutQwertyJis },
+  { name: "QWERTY US", load: loadPresetKeyboardLayoutQwertyUs },
+  { name: "Dvorak", load: loadPresetKeyboardLayoutDvorak },
+  { name: "Colemak", load: loadPresetKeyboardLayoutColemak },
+  { name: "Colemak DH", load: loadPresetKeyboardLayoutColemakDh },
+  { name: "大西配列", load: loadPresetKeyboardLayoutOnishi },
+  { name: "eucalyn", load: loadPresetKeyboardLayoutEucalyn },
+  { name: "Astarte", load: loadPresetKeyboardLayoutAstarte },
+  { name: "とみすけ JIS", load: loadPresetKeyboardLayoutTomisukeJis },
+];
+
+const initialWordsText = "じょをひく しるため しょうがっこう";
+
+function App() {
+  // 操作中の入力値（適用ボタンを押すまで反映されない）
+  const [draftRuleIndex, setDraftRuleIndex] = useState(0);
+  const [draftLayoutIndex, setDraftLayoutIndex] = useState(0);
+  const [draftWordsText, setDraftWordsText] = useState(initialWordsText);
+
+  // 適用済みの値（適用ボタンを押したタイミングで draft を反映する）
+  const [applied, setApplied] = useState({
+    ruleIndex: 0,
+    layoutIndex: 0,
+    wordsText: initialWordsText,
+  });
+
   const [wordIndex, setWordIndex] = useState(0);
-  const [ruleIndex, setRuleIndex] = useState(0);
-  const onFinished = useCallback(() => {
-    const words = ["じょをひく", "しるため", "しょうがっこう"];
-    const automaton = build(rules[ruleIndex].rule, words[wordIndex]);
-    setAutomaton(automaton);
-    setRuleName(rules[ruleIndex].name);
-    if (wordIndex < words.length - 1) {
-      setWordIndex(wordIndex + 1);
-    } else {
-      setWordIndex(0);
-      if (ruleIndex < rules.length - 1) {
-        setRuleIndex(ruleIndex + 1);
-      } else {
-        setRuleIndex(0);
-      }
-    }
-  }, [ruleIndex, rules, wordIndex]);
+  // 入力完了ごとに増やすカウンタ。単語が 1 つだけで wordIndex が変わらない場合でも
+  // automaton を作り直してループさせるために使う
+  const [round, setRound] = useState(0);
+  const [automaton, setAutomaton] = useState<Automaton | undefined>(undefined);
+
+  const layout = useMemo(() => layouts[applied.layoutIndex].load(), [applied.layoutIndex]);
+  // 英字・記号を含むワードにも対応できるよう、直接入力ルールを合成する
+  const rule = useMemo(
+    () => rules[applied.ruleIndex].load(layout).merge(createDirectInputRule(layout)),
+    [applied.ruleIndex, layout],
+  );
+  const words = useMemo(
+    () => applied.wordsText.trim().split(/\s+/).filter(Boolean),
+    [applied.wordsText],
+  );
+
+  // rule / layout / 単語が変わったら出題位置を先頭へ戻す（打鍵状態リセット）
   useEffect(() => {
-    if (wordIndex === 0) {
-      onFinished();
+    setWordIndex(0);
+    setRound(0);
+  }, [rule, words]);
+
+  // automaton を再構築する。新しい automaton インスタンスへの差し替えが打鍵状態リセットになる
+  useEffect(() => {
+    const word = words[wordIndex];
+    if (word !== undefined) {
+      setAutomaton(build(rule, word));
+    } else {
+      setAutomaton(undefined);
     }
-  }, [onFinished, wordIndex]);
+  }, [rule, words, wordIndex, round]);
+
+  const onFinished = useCallback(() => {
+    setWordIndex((i) => (words.length > 0 ? (i + 1) % words.length : 0));
+    setRound((r) => r + 1);
+  }, [words.length]);
+
+  // 単語が入力済みで、かつ draft が適用済みの値から変更されている場合のみ適用できる
+  const isDirty =
+    draftRuleIndex !== applied.ruleIndex ||
+    draftLayoutIndex !== applied.layoutIndex ||
+    draftWordsText !== applied.wordsText;
+  const canApply = draftWordsText.trim().length > 0 && isDirty;
+  const apply = () => {
+    if (!canApply) {
+      return;
+    }
+    setApplied({
+      ruleIndex: draftRuleIndex,
+      layoutIndex: draftLayoutIndex,
+      wordsText: draftWordsText,
+    });
+  };
+
   return (
     <>
+      <div className="controls">
+        <label>
+          入力ルール{" "}
+          <select
+            value={draftRuleIndex}
+            onChange={(e) => setDraftRuleIndex(Number(e.target.value))}
+          >
+            {rules.map((r, i) => (
+              <option key={r.name} value={i}>
+                {r.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          キーボードレイアウト{" "}
+          <select
+            value={draftLayoutIndex}
+            onChange={(e) => setDraftLayoutIndex(Number(e.target.value))}
+          >
+            {layouts.map((l, i) => (
+              <option key={l.name} value={i}>
+                {l.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="words-field">
+          <input
+            type="text"
+            value={draftWordsText}
+            onChange={(e) => setDraftWordsText(e.target.value)}
+            onKeyDown={(e) => {
+              // IME 変換確定の Enter は除外する
+              if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+                apply();
+              }
+            }}
+          />
+          <button type="button" onClick={apply} disabled={!canApply}>
+            適用
+          </button>
+        </label>
+      </div>
       {automaton ? (
-        <TypingGraph
-          automaton={automaton}
-          ruleName={ruleName}
-          onFinished={onFinished}
-        ></TypingGraph>
+        <TypingGraph automaton={automaton} onFinished={onFinished}></TypingGraph>
       ) : (
-        <>loading...</>
+        <>単語を入力してください</>
       )}
     </>
   );

--- a/examples/react-stroke-graph/src/typingGraph.tsx
+++ b/examples/react-stroke-graph/src/typingGraph.tsx
@@ -2,20 +2,16 @@ import cytoscape from "cytoscape";
 import dagre from "cytoscape-dagre";
 import type { Automaton, InputStroke } from "emiel";
 import { activate } from "emiel";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { buildGraphData } from "./graphData";
 import { cyStylesheet } from "./grpahStyle";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
 cytoscape.use(dagre);
 
-export function TypingGraph(props: {
-  automaton: Automaton;
-  ruleName: string;
-  onFinished: () => void;
-}) {
-  const automaton = props.automaton;
-  const graphData = buildGraphData(automaton.startNode);
+export function TypingGraph(props: { automaton: Automaton; onFinished: () => void }) {
+  const { automaton, onFinished } = props;
+  const graphData = useMemo(() => buildGraphData(automaton.startNode), [automaton]);
   const htmlElem = useRef(null);
   const [, setLastInputKey] = useState<InputStroke | undefined>();
   useEffect(() => {
@@ -39,7 +35,7 @@ export function TypingGraph(props: {
       const result = automaton.input(e);
       console.log(e.input.key.toString(), e.input.type, result);
       if (result.isFinished) {
-        props.onFinished();
+        onFinished();
       } else if (result.isSucceeded) {
         const nodeId = graphData.nodesMap.get(automaton.currentNode);
         if (nodeId !== undefined) {
@@ -52,25 +48,23 @@ export function TypingGraph(props: {
         }
       }
     });
-  }, [props]);
+  }, [automaton, graphData, onFinished]);
 
   const view = automaton.currentView();
-  const finishedRomanSubstr = view.finishedRoman;
-  const pendingRomanSubstr = view.pendingRoman;
   return (
     <>
-      <h2>{props.ruleName}</h2>
-      <h1>
+      <p className="target-word">
         <span style={{ color: "gray" }}>{view.finishedWord}</span> {view.pendingWord}
-      </h1>
-      {finishedRomanSubstr || pendingRomanSubstr ? (
-        <h1>
-          <span style={{ color: "gray" }}>{finishedRomanSubstr}</span> {pendingRomanSubstr}
-        </h1>
-      ) : (
-        <></>
-      )}
-      <div ref={htmlElem} style={{ width: "600px", height: "300px", border: "1px solid white" }} />
+      </p>
+      <div
+        ref={htmlElem}
+        style={{
+          width: "600px",
+          height: "300px",
+          border: "1px solid white",
+          margin: "0 auto",
+        }}
+      />
     </>
   );
 }


### PR DESCRIPTION
## Summary

- react-stroke-graph の rule/layout 自動ループ方式を廃止し、画面上で preset rule（全 9 種）・preset layout（全 9 種）・入力単語を選択できるようにした
- rule/layout/単語を draft 状態として保持し、適用ボタン（または単語欄での Enter）でまとめて反映。適用時に automaton を再構築して打鍵状態をリセットする
- 単語欄は空白区切りで複数指定でき、入力完了ごとに循環する
- 英字・記号を含む単語にも対応するため directInputRule を合成
- 選択欄・グラフ描画と重複するルール名・ローマ字表記の表示を削除し、レイアウトを調整

## 設計の背景

従来は事前定義した 4 rule × 3 単語を入力完了ごとに自動で切り替えていく方式で、任意の rule/layout/単語を試せなかった。emiel の全 preset rule/layout を手元で確認できるよう、選択 UI に置き換えた。

rule/layout/単語の変更を即座に automaton へ反映すると、文字入力の途中でグラフが再描画されレイアウトが崩れる。これを避けるため操作中の値（draft）と適用済みの値（applied）を分離し、適用ボタン押下時にのみ反映する構成とした。適用は新しい automaton インスタンスへの差し替えで行われ、これがそのまま打鍵状態のリセットになる。

単語が 1 つだけのとき wordIndex が変化せず再構築が走らないため、入力完了ごとに増える round カウンタを automaton 再構築の依存に加えてループを成立させている。

## 検討した代替案

- rule/layout/単語を直接 state にして即時反映する案: 実装は単純だが、単語欄をタイプするたびにグラフが再描画されレイアウトが崩れるため不採用
- 単語ループに key による再マウントを使う案: round カウンタと効果は同等だが、automaton 再構築ロジックを 1 つの useEffect に集約できる現状の方が見通しがよいため不採用
- 全 preset を列挙するライブラリ API を新設する案: 今回はサンプル内で完結させる方針のため、example 側に rules/layouts 配列を定義するに留めた

## Test plan

- [x] pnpm run lint
- [x] pnpm run fmt:check
- [x] examples/react-stroke-graph で tsc --noEmit
- [ ] dev server で rule/layout/単語の切替時に打鍵状態がリセットされることを確認
- [ ] 単語入力欄での Enter（IME 変換確定を除く）で適用されることを確認
- [ ] 単語 1 つのときに入力完了でループすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)