### PR TITLE
feat: 飛鳥290 の追加と飛鳥123 の連続シフト対応

### DIFF
--- a/src/assets/rules/asuka_123.json
+++ b/src/assets/rules/asuka_123.json
@@ -5,739 +5,371 @@
   },
   "entries": [
     {
-      "input": [
-        {
-          "keys": ["Q"]
-        }
-      ],
+      "input": [{ "keys": ["Q"] }],
       "output": "「"
     },
     {
-      "input": [
-        {
-          "keys": ["W"]
-        }
-      ],
+      "input": [{ "keys": ["W"] }],
       "output": "ー"
     },
     {
-      "input": [
-        {
-          "keys": ["R"]
-        }
-      ],
+      "input": [{ "keys": ["R"] }],
       "output": "び"
     },
     {
-      "input": [
-        {
-          "keys": ["I"]
-        }
-      ],
+      "input": [{ "keys": ["I"] }],
       "output": "と"
     },
     {
-      "input": [
-        {
-          "keys": ["O"]
-        }
-      ],
+      "input": [{ "keys": ["O"] }],
       "output": "は"
     },
     {
-      "input": [
-        {
-          "keys": ["P"]
-        }
-      ],
+      "input": [{ "keys": ["P"] }],
       "output": "ぽ"
     },
     {
-      "input": [
-        {
-          "keys": ["BracketLeft"]
-        }
-      ],
+      "input": [{ "keys": ["BracketLeft"] }],
       "output": "」"
     },
     {
-      "input": [
-        {
-          "keys": ["A"]
-        }
-      ],
+      "input": [{ "keys": ["A"] }],
       "output": "き"
     },
     {
-      "input": [
-        {
-          "keys": ["S"]
-        }
-      ],
+      "input": [{ "keys": ["S"] }],
       "output": "し"
     },
     {
-      "input": [
-        {
-          "keys": ["D"]
-        }
-      ],
+      "input": [{ "keys": ["D"] }],
       "output": "う"
     },
     {
-      "input": [
-        {
-          "keys": ["F"]
-        }
-      ],
+      "input": [{ "keys": ["F"] }],
       "output": "て"
     },
     {
-      "input": [
-        {
-          "keys": ["G"]
-        }
-      ],
+      "input": [{ "keys": ["G"] }],
       "output": "ぎ"
     },
     {
-      "input": [
-        {
-          "keys": ["H"]
-        }
-      ],
+      "input": [{ "keys": ["H"] }],
       "output": "ゆ"
     },
     {
-      "input": [
-        {
-          "keys": ["J"]
-        }
-      ],
+      "input": [{ "keys": ["J"] }],
       "output": "ん"
     },
     {
-      "input": [
-        {
-          "keys": ["K"]
-        }
-      ],
+      "input": [{ "keys": ["K"] }],
       "output": "い"
     },
     {
-      "input": [
-        {
-          "keys": ["L"]
-        }
-      ],
+      "input": [{ "keys": ["L"] }],
       "output": "か"
     },
     {
-      "input": [
-        {
-          "keys": ["Semicolon"]
-        }
-      ],
+      "input": [{ "keys": ["Semicolon"] }],
       "output": "た"
     },
     {
-      "input": [
-        {
-          "keys": ["Quote"]
-        }
-      ],
+      "input": [{ "keys": ["Quote"] }],
       "output": "ほ"
     },
     {
-      "input": [
-        {
-          "keys": ["Backslash"]
-        }
-      ],
+      "input": [{ "keys": ["Backslash"] }],
       "output": "・"
     },
     {
-      "input": [
-        {
-          "keys": ["Z"]
-        }
-      ],
+      "input": [{ "keys": ["Z"] }],
       "output": "じ"
     },
     {
-      "input": [
-        {
-          "keys": ["X"]
-        }
-      ],
+      "input": [{ "keys": ["X"] }],
       "output": "ち"
     },
     {
-      "input": [
-        {
-          "keys": ["C"]
-        }
-      ],
+      "input": [{ "keys": ["C"] }],
       "output": "に"
     },
     {
-      "input": [
-        {
-          "keys": ["V"]
-        }
-      ],
+      "input": [{ "keys": ["V"] }],
       "output": "り"
     },
     {
-      "input": [
-        {
-          "keys": ["B"]
-        }
-      ],
+      "input": [{ "keys": ["B"] }],
       "output": "ぶ"
     },
     {
-      "input": [
-        {
-          "keys": ["N"]
-        }
-      ],
+      "input": [{ "keys": ["N"] }],
       "output": "ゃ"
     },
     {
-      "input": [
-        {
-          "keys": ["M"]
-        }
-      ],
+      "input": [{ "keys": ["M"] }],
       "output": "っ"
     },
     {
-      "input": [
-        {
-          "keys": ["Comma"]
-        }
-      ],
+      "input": [{ "keys": ["Comma"] }],
       "output": "ょ"
     },
     {
-      "input": [
-        {
-          "keys": ["Period"]
-        }
-      ],
+      "input": [{ "keys": ["Period"] }],
       "output": "ゅ"
     },
     {
-      "input": [
-        {
-          "keys": ["Slash"]
-        }
-      ],
+      "input": [{ "keys": ["Slash"] }],
       "output": "さ"
     },
     {
-      "input": [
-        {
-          "keys": ["Digit5", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["Digit5"], "modifiers": [["LangLeft"]] }],
       "output": "゛"
     },
     {
-      "input": [
-        {
-          "keys": ["Digit7", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["Digit7"], "modifiers": [["LangLeft"]] }],
       "output": "’"
     },
     {
-      "input": [
-        {
-          "keys": ["Digit9", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["Digit9"], "modifiers": [["LangLeft"]] }],
       "output": "￥"
     },
     {
-      "input": [
-        {
-          "keys": ["Q", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["Q"], "modifiers": [["LangLeft"]] }],
       "output": "ぃ"
     },
     {
-      "input": [
-        {
-          "keys": ["W", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["W"], "modifiers": [["LangLeft"]] }],
       "output": "ひ"
     },
     {
-      "input": [
-        {
-          "keys": ["E", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["E"], "modifiers": [["LangLeft"]] }],
       "output": "け"
     },
     {
-      "input": [
-        {
-          "keys": ["R", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["R"], "modifiers": [["LangLeft"]] }],
       "output": "ぁ"
     },
     {
-      "input": [
-        {
-          "keys": ["T", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["T"], "modifiers": [["LangLeft"]] }],
       "output": "ぅ"
     },
     {
-      "input": [
-        {
-          "keys": ["Y", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["Y"], "modifiers": [["LangLeft"]] }],
       "output": "ヴ"
     },
     {
-      "input": [
-        {
-          "keys": ["I", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["I"], "modifiers": [["LangLeft"]] }],
       "output": "よ"
     },
     {
-      "input": [
-        {
-          "keys": ["O", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["O"], "modifiers": [["LangLeft"]] }],
       "output": "ふ"
     },
     {
-      "input": [
-        {
-          "keys": ["P", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["P"], "modifiers": [["LangLeft"]] }],
       "output": "へ"
     },
     {
-      "input": [
-        {
-          "keys": ["A", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["A"], "modifiers": [["LangLeft"]] }],
       "output": "だ"
     },
     {
-      "input": [
-        {
-          "keys": ["S", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["S"], "modifiers": [["LangLeft"]] }],
       "output": "あ"
     },
     {
-      "input": [
-        {
-          "keys": ["D", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["D"], "modifiers": [["LangLeft"]] }],
       "output": "が"
     },
     {
-      "input": [
-        {
-          "keys": ["F", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["F"], "modifiers": [["LangLeft"]] }],
       "output": "ば"
     },
     {
-      "input": [
-        {
-          "keys": ["G", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["G"], "modifiers": [["LangLeft"]] }],
       "output": "ぇ"
     },
     {
-      "input": [
-        {
-          "keys": ["H", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["H"], "modifiers": [["LangLeft"]] }],
       "output": "ず"
     },
     {
-      "input": [
-        {
-          "keys": ["J", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["J"], "modifiers": [["LangLeft"]] }],
       "output": "る"
     },
     {
-      "input": [
-        {
-          "keys": ["K", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["K"], "modifiers": [["LangLeft"]] }],
       "output": "す"
     },
     {
-      "input": [
-        {
-          "keys": ["L", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["L"], "modifiers": [["LangLeft"]] }],
       "output": "ま"
     },
     {
-      "input": [
-        {
-          "keys": ["Semicolon", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["Semicolon"], "modifiers": [["LangLeft"]] }],
       "output": "で"
     },
     {
-      "input": [
-        {
-          "keys": ["Quote", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["Quote"], "modifiers": [["LangLeft"]] }],
       "output": "げ"
     },
     {
-      "input": [
-        {
-          "keys": ["Z", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["Z"], "modifiers": [["LangLeft"]] }],
       "output": "ぜ"
     },
     {
-      "input": [
-        {
-          "keys": ["X", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["X"], "modifiers": [["LangLeft"]] }],
       "output": "ね"
     },
     {
-      "input": [
-        {
-          "keys": ["C", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["C"], "modifiers": [["LangLeft"]] }],
       "output": "せ"
     },
     {
-      "input": [
-        {
-          "keys": ["V", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["V"], "modifiers": [["LangLeft"]] }],
       "output": "ぴ"
     },
     {
-      "input": [
-        {
-          "keys": ["B", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["B"], "modifiers": [["LangLeft"]] }],
       "output": "ぉ"
     },
     {
-      "input": [
-        {
-          "keys": ["N", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["N"], "modifiers": [["LangLeft"]] }],
       "output": "や"
     },
     {
-      "input": [
-        {
-          "keys": ["M", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["M"], "modifiers": [["LangLeft"]] }],
       "output": "え"
     },
     {
-      "input": [
-        {
-          "keys": ["Comma", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["Comma"], "modifiers": [["LangLeft"]] }],
       "output": "、"
     },
     {
-      "input": [
-        {
-          "keys": ["Period", "LangLeft"]
-        }
-      ],
+      "input": [{ "keys": ["Period"], "modifiers": [["LangLeft"]] }],
       "output": "。"
     },
     {
-      "input": [
-        {
-          "keys": ["Digit2", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["Digit2"], "modifiers": [["LangRight"]] }],
       "output": "”"
     },
     {
-      "input": [
-        {
-          "keys": ["Digit8", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["Digit8"], "modifiers": [["LangRight"]] }],
       "output": "゜"
     },
     {
-      "input": [
-        {
-          "keys": ["W", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["W"], "modifiers": [["LangRight"]] }],
       "output": "べ"
     },
     {
-      "input": [
-        {
-          "keys": ["E", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["E"], "modifiers": [["LangRight"]] }],
       "output": "れ"
     },
     {
-      "input": [
-        {
-          "keys": ["R", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["R"], "modifiers": [["LangRight"]] }],
       "output": "ぺ"
     },
     {
-      "input": [
-        {
-          "keys": ["Y", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["Y"], "modifiers": [["LangRight"]] }],
       "output": "ぢ"
     },
     {
-      "input": [
-        {
-          "keys": ["U", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["U"], "modifiers": [["LangRight"]] }],
       "output": "ぬ"
     },
     {
-      "input": [
-        {
-          "keys": ["I", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["I"], "modifiers": [["LangRight"]] }],
       "output": "ど"
     },
     {
-      "input": [
-        {
-          "keys": ["O", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["O"], "modifiers": [["LangRight"]] }],
       "output": "め"
     },
     {
-      "input": [
-        {
-          "keys": ["P", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["P"], "modifiers": [["LangRight"]] }],
       "output": "ぞ"
     },
     {
-      "input": [
-        {
-          "keys": ["BracketLeft", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["BracketLeft"], "modifiers": [["LangRight"]] }],
       "output": "ご"
     },
     {
-      "input": [
-        {
-          "keys": ["A", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["A"], "modifiers": [["LangRight"]] }],
       "output": "わ"
     },
     {
-      "input": [
-        {
-          "keys": ["S", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["S"], "modifiers": [["LangRight"]] }],
       "output": "お"
     },
     {
-      "input": [
-        {
-          "keys": ["D", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["D"], "modifiers": [["LangRight"]] }],
       "output": "な"
     },
     {
-      "input": [
-        {
-          "keys": ["F", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["F"], "modifiers": [["LangRight"]] }],
       "output": "ら"
     },
     {
-      "input": [
-        {
-          "keys": ["G", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["G"], "modifiers": [["LangRight"]] }],
       "output": "ぷ"
     },
     {
-      "input": [
-        {
-          "keys": ["H", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["H"], "modifiers": [["LangRight"]] }],
       "output": "づ"
     },
     {
-      "input": [
-        {
-          "keys": ["J", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["J"], "modifiers": [["LangRight"]] }],
       "output": "く"
     },
     {
-      "input": [
-        {
-          "keys": ["K", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["K"], "modifiers": [["LangRight"]] }],
       "output": "の"
     },
     {
-      "input": [
-        {
-          "keys": ["L", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["L"], "modifiers": [["LangRight"]] }],
       "output": "こ"
     },
     {
-      "input": [
-        {
-          "keys": ["Semicolon", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["Semicolon"], "modifiers": [["LangRight"]] }],
       "output": "そ"
     },
     {
-      "input": [
-        {
-          "keys": ["Quote", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["Quote"], "modifiers": [["LangRight"]] }],
       "output": "ろ"
     },
     {
-      "input": [
-        {
-          "keys": ["Z", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["Z"], "modifiers": [["LangRight"]] }],
       "output": "ぱ"
     },
     {
-      "input": [
-        {
-          "keys": ["X", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["X"], "modifiers": [["LangRight"]] }],
       "output": "ぐ"
     },
     {
-      "input": [
-        {
-          "keys": ["C", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["C"], "modifiers": [["LangRight"]] }],
       "output": "み"
     },
     {
-      "input": [
-        {
-          "keys": ["V", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["V"], "modifiers": [["LangRight"]] }],
       "output": "ざ"
     },
     {
-      "input": [
-        {
-          "keys": ["N", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["N"], "modifiers": [["LangRight"]] }],
       "output": "む"
     },
     {
-      "input": [
-        {
-          "keys": ["M", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["M"], "modifiers": [["LangRight"]] }],
       "output": "を"
     },
     {
-      "input": [
-        {
-          "keys": ["Comma", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["Comma"], "modifiers": [["LangRight"]] }],
       "output": "つ"
     },
     {
-      "input": [
-        {
-          "keys": ["Period", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["Period"], "modifiers": [["LangRight"]] }],
       "output": "も"
     },
     {
-      "input": [
-        {
-          "keys": ["Slash", "LangRight"]
-        }
-      ],
+      "input": [{ "keys": ["Slash"], "modifiers": [["LangRight"]] }],
       "output": "ぼ"
     }
   ]

--- a/src/assets/rules/asuka_290.json
+++ b/src/assets/rules/asuka_290.json
@@ -1,0 +1,421 @@
+{
+  "metadata": {
+    "name": "飛鳥290",
+    "url": "http://www.eurus.dti.ne.jp/~yfi/aska_arrangement/"
+  },
+  "backspaces": [
+    {
+      "keys": ["Backslash"]
+    },
+    {
+      "keys": ["Backslash"],
+      "modifiers": [["LangRight"]]
+    }
+  ],
+  "entries": [
+    {
+      "input": [{ "keys": ["Q"] }],
+      "output": "「"
+    },
+    {
+      "input": [{ "keys": ["W"] }],
+      "output": "ー"
+    },
+    {
+      "input": [{ "keys": ["E"] }],
+      "output": "じ"
+    },
+    {
+      "input": [{ "keys": ["R"] }],
+      "output": "ぴ"
+    },
+    {
+      "input": [{ "keys": ["T"] }],
+      "output": "％"
+    },
+    {
+      "input": [{ "keys": ["Y"] }],
+      "output": "−"
+    },
+    {
+      "input": [{ "keys": ["U"] }],
+      "output": "・"
+    },
+    {
+      "input": [{ "keys": ["I"] }],
+      "output": "と"
+    },
+    {
+      "input": [{ "keys": ["O"] }],
+      "output": "は"
+    },
+    {
+      "input": [{ "keys": ["P"] }],
+      "output": "へ"
+    },
+    {
+      "input": [{ "keys": ["BracketLeft"] }],
+      "output": "」"
+    },
+    {
+      "input": [{ "keys": ["BracketRight"] }],
+      "output": "￥"
+    },
+    {
+      "input": [{ "keys": ["A"] }],
+      "output": "き"
+    },
+    {
+      "input": [{ "keys": ["S"] }],
+      "output": "し"
+    },
+    {
+      "input": [{ "keys": ["D"] }],
+      "output": "う"
+    },
+    {
+      "input": [{ "keys": ["F"] }],
+      "output": "て"
+    },
+    {
+      "input": [{ "keys": ["G"] }],
+      "output": "ぎ"
+    },
+    {
+      "input": [{ "keys": ["H"] }],
+      "output": "ゆ"
+    },
+    {
+      "input": [{ "keys": ["J"] }],
+      "output": "ん"
+    },
+    {
+      "input": [{ "keys": ["K"] }],
+      "output": "い"
+    },
+    {
+      "input": [{ "keys": ["L"] }],
+      "output": "か"
+    },
+    {
+      "input": [{ "keys": ["Semicolon"] }],
+      "output": "た"
+    },
+    {
+      "input": [{ "keys": ["Quote"] }],
+      "output": "け"
+    },
+    {
+      "input": [{ "keys": ["Z"] }],
+      "output": "ほ"
+    },
+    {
+      "input": [{ "keys": ["X"] }],
+      "output": "せ"
+    },
+    {
+      "input": [{ "keys": ["C"] }],
+      "output": "み"
+    },
+    {
+      "input": [{ "keys": ["V"] }],
+      "output": "ぶ"
+    },
+    {
+      "input": [{ "keys": ["B"] }],
+      "output": "び"
+    },
+    {
+      "input": [{ "keys": ["N"] }],
+      "output": "ゃ"
+    },
+    {
+      "input": [{ "keys": ["M"] }],
+      "output": "っ"
+    },
+    {
+      "input": [{ "keys": ["Comma"] }],
+      "output": "ょ"
+    },
+    {
+      "input": [{ "keys": ["Period"] }],
+      "output": "ゅ"
+    },
+    {
+      "input": [{ "keys": ["Slash"] }],
+      "output": "め"
+    },
+    {
+      "input": [{ "keys": ["JpnRo"] }],
+      "output": "，"
+    },
+    {
+      "input": [{ "keys": ["Q"], "modifiers": [["LangLeft"]] }],
+      "output": "ざ"
+    },
+    {
+      "input": [{ "keys": ["W"], "modifiers": [["LangLeft"]] }],
+      "output": "ね"
+    },
+    {
+      "input": [{ "keys": ["E"], "modifiers": [["LangLeft"]] }],
+      "output": "え"
+    },
+    {
+      "input": [{ "keys": ["R"], "modifiers": [["LangLeft"]] }],
+      "output": "ぁ"
+    },
+    {
+      "input": [{ "keys": ["T"], "modifiers": [["LangLeft"]] }],
+      "output": "ぅ"
+    },
+    {
+      "input": [{ "keys": ["Y"], "modifiers": [["LangLeft"]] }],
+      "output": "ぇ"
+    },
+    {
+      "input": [{ "keys": ["U"], "modifiers": [["LangLeft"]] }],
+      "output": "ぃ"
+    },
+    {
+      "input": [{ "keys": ["I"], "modifiers": [["LangLeft"]] }],
+      "output": "よ"
+    },
+    {
+      "input": [{ "keys": ["O"], "modifiers": [["LangLeft"]] }],
+      "output": "ふ"
+    },
+    {
+      "input": [{ "keys": ["P"], "modifiers": [["LangLeft"]] }],
+      "output": "！"
+    },
+    {
+      "input": [{ "keys": ["BracketLeft"], "modifiers": [["LangLeft"]] }],
+      "output": "）"
+    },
+    {
+      "input": [{ "keys": ["BracketRight"], "modifiers": [["LangLeft"]] }],
+      "output": "＿"
+    },
+    {
+      "input": [{ "keys": ["A"], "modifiers": [["LangLeft"]] }],
+      "output": "だ"
+    },
+    {
+      "input": [{ "keys": ["S"], "modifiers": [["LangLeft"]] }],
+      "output": "さ"
+    },
+    {
+      "input": [{ "keys": ["D"], "modifiers": [["LangLeft"]] }],
+      "output": "あ"
+    },
+    {
+      "input": [{ "keys": ["F"], "modifiers": [["LangLeft"]] }],
+      "output": "り"
+    },
+    {
+      "input": [{ "keys": ["G"], "modifiers": [["LangLeft"]] }],
+      "output": "ぉ"
+    },
+    {
+      "input": [{ "keys": ["H"], "modifiers": [["LangLeft"]] }],
+      "output": "ず"
+    },
+    {
+      "input": [{ "keys": ["J"], "modifiers": [["LangLeft"]] }],
+      "output": "る"
+    },
+    {
+      "input": [{ "keys": ["K"], "modifiers": [["LangLeft"]] }],
+      "output": "す"
+    },
+    {
+      "input": [{ "keys": ["L"], "modifiers": [["LangLeft"]] }],
+      "output": "ま"
+    },
+    {
+      "input": [{ "keys": ["Semicolon"], "modifiers": [["LangLeft"]] }],
+      "output": "で"
+    },
+    {
+      "input": [{ "keys": ["Quote"], "modifiers": [["LangLeft"]] }],
+      "output": "げ"
+    },
+    {
+      "input": [{ "keys": ["Z"], "modifiers": [["LangLeft"]] }],
+      "output": "ぜ"
+    },
+    {
+      "input": [{ "keys": ["X"], "modifiers": [["LangLeft"]] }],
+      "output": "ひ"
+    },
+    {
+      "input": [{ "keys": ["C"], "modifiers": [["LangLeft"]] }],
+      "output": "ち"
+    },
+    {
+      "input": [{ "keys": ["V"], "modifiers": [["LangLeft"]] }],
+      "output": "ば"
+    },
+    {
+      "input": [{ "keys": ["B"], "modifiers": [["LangLeft"]] }],
+      "output": "ヴ"
+    },
+    {
+      "input": [{ "keys": ["N"], "modifiers": [["LangLeft"]] }],
+      "output": "や"
+    },
+    {
+      "input": [{ "keys": ["M"], "modifiers": [["LangLeft"]] }],
+      "output": "が"
+    },
+    {
+      "input": [{ "keys": ["Comma"], "modifiers": [["LangLeft"]] }],
+      "output": "、"
+    },
+    {
+      "input": [{ "keys": ["Period"], "modifiers": [["LangLeft"]] }],
+      "output": "。"
+    },
+    {
+      "input": [{ "keys": ["Slash"], "modifiers": [["LangLeft"]] }],
+      "output": "？"
+    },
+    {
+      "input": [{ "keys": ["JpnRo"], "modifiers": [["LangLeft"]] }],
+      "output": "￥"
+    },
+    {
+      "input": [{ "keys": ["Q"], "modifiers": [["LangRight"]] }],
+      "output": "（"
+    },
+    {
+      "input": [{ "keys": ["W"], "modifiers": [["LangRight"]] }],
+      "output": "べ"
+    },
+    {
+      "input": [{ "keys": ["E"], "modifiers": [["LangRight"]] }],
+      "output": "れ"
+    },
+    {
+      "input": [{ "keys": ["R"], "modifiers": [["LangRight"]] }],
+      "output": "ぺ"
+    },
+    {
+      "input": [{ "keys": ["T"], "modifiers": [["LangRight"]] }],
+      "output": "＆"
+    },
+    {
+      "input": [{ "keys": ["Y"], "modifiers": [["LangRight"]] }],
+      "output": "ぢ"
+    },
+    {
+      "input": [{ "keys": ["U"], "modifiers": [["LangRight"]] }],
+      "output": "〜"
+    },
+    {
+      "input": [{ "keys": ["I"], "modifiers": [["LangRight"]] }],
+      "output": "そ"
+    },
+    {
+      "input": [{ "keys": ["O"], "modifiers": [["LangRight"]] }],
+      "output": "こ"
+    },
+    {
+      "input": [{ "keys": ["P"], "modifiers": [["LangRight"]] }],
+      "output": "ぞ"
+    },
+    {
+      "input": [{ "keys": ["BracketLeft"], "modifiers": [["LangRight"]] }],
+      "output": "ご"
+    },
+    {
+      "input": [{ "keys": ["A"], "modifiers": [["LangRight"]] }],
+      "output": "わ"
+    },
+    {
+      "input": [{ "keys": ["S"], "modifiers": [["LangRight"]] }],
+      "output": "お"
+    },
+    {
+      "input": [{ "keys": ["D"], "modifiers": [["LangRight"]] }],
+      "output": "な"
+    },
+    {
+      "input": [{ "keys": ["F"], "modifiers": [["LangRight"]] }],
+      "output": "ら"
+    },
+    {
+      "input": [{ "keys": ["G"], "modifiers": [["LangRight"]] }],
+      "output": "ぬ"
+    },
+    {
+      "input": [{ "keys": ["H"], "modifiers": [["LangRight"]] }],
+      "output": "ぼ"
+    },
+    {
+      "input": [{ "keys": ["J"], "modifiers": [["LangRight"]] }],
+      "output": "く"
+    },
+    {
+      "input": [{ "keys": ["K"], "modifiers": [["LangRight"]] }],
+      "output": "の"
+    },
+    {
+      "input": [{ "keys": ["L"], "modifiers": [["LangRight"]] }],
+      "output": "つ"
+    },
+    {
+      "input": [{ "keys": ["Semicolon"], "modifiers": [["LangRight"]] }],
+      "output": "に"
+    },
+    {
+      "input": [{ "keys": ["Quote"], "modifiers": [["LangRight"]] }],
+      "output": "ろ"
+    },
+    {
+      "input": [{ "keys": ["Z"], "modifiers": [["LangRight"]] }],
+      "output": "ぷ"
+    },
+    {
+      "input": [{ "keys": ["X"], "modifiers": [["LangRight"]] }],
+      "output": "ぐ"
+    },
+    {
+      "input": [{ "keys": ["C"], "modifiers": [["LangRight"]] }],
+      "output": "ぱ"
+    },
+    {
+      "input": [{ "keys": ["V"], "modifiers": [["LangRight"]] }],
+      "output": "づ"
+    },
+    {
+      "input": [{ "keys": ["B"], "modifiers": [["LangRight"]] }],
+      "output": "＊"
+    },
+    {
+      "input": [{ "keys": ["N"], "modifiers": [["LangRight"]] }],
+      "output": "む"
+    },
+    {
+      "input": [{ "keys": ["M"], "modifiers": [["LangRight"]] }],
+      "output": "を"
+    },
+    {
+      "input": [{ "keys": ["Comma"], "modifiers": [["LangRight"]] }],
+      "output": "ど"
+    },
+    {
+      "input": [{ "keys": ["Period"], "modifiers": [["LangRight"]] }],
+      "output": "も"
+    },
+    {
+      "input": [{ "keys": ["Slash"], "modifiers": [["LangRight"]] }],
+      "output": "ぽ"
+    },
+    {
+      "input": [{ "keys": ["JpnRo"], "modifiers": [["LangRight"]] }],
+      "output": "／"
+    }
+  ]
+}

--- a/src/core/automaton.test.ts
+++ b/src/core/automaton.test.ts
@@ -3,6 +3,7 @@ import { createDirectInputRule } from "../impl/directInputRule";
 import { loadJsonRule } from "../impl/jsonRuleLoader";
 import {
   loadPresetKeyboardLayoutQwertyJis,
+  loadPresetRuleAsuka290,
   loadPresetRuleNaginatashikiV15,
   loadPresetRuleRoman,
 } from "../impl/presets";
@@ -605,6 +606,73 @@ describe("merge produces n+space merged edge across primitives", () => {
     const sources = new Set<Rule>(lastEdge?.entry?.sources ?? []);
     expect(sources.has(romanRule)).toBe(true);
     expect(sources.has(directRule)).toBe(true);
+  });
+});
+
+/**
+ * テストヘルパ: runInputsOn と同じだが、各 InputEvent に「その打鍵時点の
+ * KeyboardState のスナップショット」を渡す。browser/eventHandler.ts が
+ * `new KeyboardState([...keyboardState.downedKeys])` でコピーを渡しているのと
+ * 同じ挙動を再現する。
+ */
+function runInputsWithSnapshotOn(
+  automaton: Automaton,
+  events: { key: (typeof VirtualKeys)[keyof typeof VirtualKeys]; type: "keydown" | "keyup" }[],
+): string[] {
+  const state = new KeyboardState();
+  const results: string[] = [];
+  for (const ev of events) {
+    if (ev.type === "keydown") {
+      state.keydown(ev.key);
+    } else {
+      state.keyup(ev.key);
+    }
+    const result = automaton.input(
+      new InputEvent(
+        new InputStroke(ev.key, ev.type),
+        new KeyboardState([...state.downedKeys]),
+        performance.now(),
+      ),
+    );
+    results.push(result.toString());
+  }
+  return results;
+}
+
+describe("Automaton modifier 押しっぱなしでの連続入力 (飛鳥290 回帰)", () => {
+  const rule = loadPresetRuleAsuka290();
+
+  test("LangRight を押しっぱなしで S を 1 回打鍵すると 'お' が入力できる", () => {
+    const automaton = build(rule, "お");
+    const results = runInputsWithSnapshotOn(automaton, [
+      { key: VirtualKeys.LangRight, type: "keydown" },
+      { key: VirtualKeys.S, type: "keydown" },
+      { key: VirtualKeys.S, type: "keyup" },
+      { key: VirtualKeys.LangRight, type: "keyup" },
+    ]);
+    // LangRight を modifier として S 打鍵で「お」が確定する
+    expect(results[1]).toBe("finished");
+    expect(automaton.currentView().finishedWord).toBe("お");
+  });
+
+  test("LangRight を押しっぱなしで S を 2 回打鍵すると 'おお' が入力できる", () => {
+    const automaton = build(rule, "おお");
+    const results = runInputsWithSnapshotOn(automaton, [
+      { key: VirtualKeys.LangRight, type: "keydown" },
+      { key: VirtualKeys.S, type: "keydown" }, // 1 文字目の「お」
+      { key: VirtualKeys.S, type: "keyup" },
+      { key: VirtualKeys.S, type: "keydown" }, // 2 文字目の「お」
+      { key: VirtualKeys.S, type: "keyup" },
+      { key: VirtualKeys.LangRight, type: "keyup" },
+    ]);
+    // 1 回目の S keydown で 1 文字目の「お」が確定
+    expect(results[1]).toBe("kana_succeeded");
+    // 2 回目の S keydown で 2 文字目の「お」が確定し、ワードが完了する。
+    // LangRight を押しっぱなしのまま 2 回目の S を打鍵しても pending にならず
+    // 「お」が入力できることを確認する。
+    expect(results[3]).toBe("finished");
+    expect(automaton.currentNode.isFinished).toBe(true);
+    expect(automaton.currentView().finishedWord).toBe("おお");
   });
 });
 

--- a/src/impl/presets/index.ts
+++ b/src/impl/presets/index.ts
@@ -15,6 +15,7 @@ export { loadPresetKeyboardLayoutQwertyJis } from "./keyboardLayoutQwertyJis";
 export { loadPresetKeyboardLayoutQwertyUs } from "./keyboardLayoutQwertyUs";
 export { loadPresetKeyboardLayoutTomisukeJis } from "./keyboardLayoutTomisukeJis";
 export { loadPresetRuleAsuka123 } from "./ruleAsuka123";
+export { loadPresetRuleAsuka290 } from "./ruleAsuka290";
 export { loadPresetRuleAzikRomantable } from "./ruleAzikRomantable";
 export { loadPresetRuleJisKana } from "./ruleJisKana";
 export { loadPresetRuleNaginatashikiV15 } from "./ruleNaginatashikiV15";

--- a/src/impl/presets/ruleAsuka290.ts
+++ b/src/impl/presets/ruleAsuka290.ts
@@ -1,0 +1,8 @@
+import presetRuleAsuka290 from "../../assets/rules/asuka_290.json";
+import type { Rule } from "../../core/rule";
+import { loadJsonRule } from "../jsonRuleLoader";
+
+/** 飛鳥カナ配列 (290 配列) のプリセット `Rule` を返す。 */
+export function loadPresetRuleAsuka290(): Rule {
+  return loadJsonRule(presetRuleAsuka290);
+}

--- a/src/impl/presets/rules.test.ts
+++ b/src/impl/presets/rules.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 import {
   loadPresetKeyboardLayoutQwertyJis,
   loadPresetRuleAsuka123,
+  loadPresetRuleAsuka290,
   loadPresetRuleAzikRomantable,
   loadPresetRuleJisKana,
   loadPresetRuleNicola,
@@ -36,6 +37,11 @@ test("load nicola rule", () => {
 test("load asuka 123 rule", () => {
   const rule = loadPresetRuleAsuka123();
   expect(rule.entries.length).toBeGreaterThan(80);
+});
+
+test("load asuka 290 rule", () => {
+  const rule = loadPresetRuleAsuka290();
+  expect(rule.entries.length).toBeGreaterThan(100);
 });
 
 test("load shingeta rule", () => {


### PR DESCRIPTION
## Summary

このPRは以下の3点を行う。

### 1. 飛鳥290 の追加

飛鳥カナ配列（290 配列）のプリセットルール `loadPresetRuleAsuka290` を追加し、emiel パッケージから export する。ルール定義は `src/assets/rules/asuka_290.json`。

### 2. 飛鳥123 を同時打鍵から modifier に変更

飛鳥123 のシフトキー (LangLeft / LangRight) を、入力定義の `keys`（同時打鍵）から `modifiers` に移動する。これにより、シフトを押しっぱなしにしたまま複数キーを連続入力する「連続シフト」に対応する。

### 3. テストの追加

- rules.test.ts: 飛鳥290 ルールが読み込めることの確認
- automaton.test.ts: modifier (LangRight) を押しっぱなしで連続打鍵しても各文字が確定することを確認する飛鳥290 の回帰テスト

## 設計の背景

飛鳥123 では従来シフトキーを `keys` 配列に含めて同時打鍵として扱っていたが、これだと 1 打ごとにシフトを離す必要があった。`modifiers` として定義することで、シフト押下中の連続打鍵で各文字が確定するようになり、実際の打鍵スタイル（連続シフト）に合わせられる。

回帰テスト用のヘルパ `runInputsWithSnapshotOn` は、`browser/eventHandler.ts` が各 InputEvent に KeyboardState のスナップショット（コピー）を渡している挙動を再現し、modifier 押しっぱなしでの連続入力が正しく確定することを固定する。

## Test plan

- [x] pnpm run test（全 44 件パス）
- [x] pnpm run lint
- [x] pnpm run fmt:check

🤖 Generated with [Claude Code](https://claude.com/claude-code)