### PR TITLE
ci: release workflow に workflow_dispatch を追加

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,10 @@ name: release
 on:
   release:
     types: [published]
+  # release-tag workflow は GITHUB_TOKEN で GitHub release を作成するが、
+  # GITHUB_TOKEN が起こしたイベントは他の workflow をトリガーしない仕様の
+  # ため、上の release: published では起動しない。手動で publish できるよう
+  # workflow_dispatch を用意している。
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ name: release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:
@@ -13,7 +14,12 @@ jobs:
       id-token: write
 
     steps:
+      # release イベントはタグを、workflow_dispatch は実行対象ブランチ
+      # (通常は main) をチェックアウトする。publish するバージョンは
+      # どちらの場合もチェックアウトした package.json から取得する。
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
       - name: Setup Node.js 24.x
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -27,10 +33,6 @@ jobs:
       - run: pnpm run fmt:check
       - run: pnpm run test
       - run: pnpm run build
-      - name: Sync package.json version with release tag
-        run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          npm version "$VERSION" --no-git-tag-version --allow-same-version
       - name: Publish to npm
-        if: github.event.release.prerelease == false
+        if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
         run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

- `release.yaml` に `workflow_dispatch` を追加し、npm publish を手動実行できるようにする
- publish するバージョンはチェックアウトした `package.json` から取得するため、実行時の入力は不要
- `workflow_dispatch` 実行時に publish ステップがスキップされないよう prerelease 判定を修正

## 設計の背景

`release-tag.yaml` は `GITHUB_TOKEN` を使って GitHub release を作成しているが、GitHub の仕様により `GITHUB_TOKEN` が起こしたイベントは他の workflow をトリガーしない。そのため `release.yaml`（`on: release: types: [published]`）が起動せず、npm publish が走らなかった（v0.4.1 が npm 未公開のまま）。

恒久対応として `workflow_dispatch` を追加し、自動チェーンが切れた場合でも手動で publish できる経路を用意する。

変更点の詳細:

- `checkout` の `ref` を、release イベントはタグ (`github.event.release.tag_name`)、手動実行は対象ブランチ (`github.ref`、通常 main) に切り替え
- publish するバージョンは release イベント・手動実行のどちらもチェックアウトした `package.json` から取得する。release-tag が package.json の変更を起点にタグを作るため、タグ側の package.json は常にそのバージョンになっており、入力やタグ指定は不要
- バージョンを package.json から取得するようになったため、タグ名から version を同期していた `Sync package.json version with release tag` ステップを削除
- publish ステップの条件を `github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false` に変更（手動実行時は `github.event.release` が存在せず判定が false になり publish がスキップされてしまうため）

## 検討した代替案

- `workflow_dispatch` にタグ入力を設ける案: 当初はタグ文字列を入力させる実装だったが、`type: choice` の選択肢は静的にしか定義できず release tag を動的に一覧化できない。自由入力は打ち間違いの余地がある。最新 main の `package.json` の version をそのまま使えば入力自体が不要になるため、入力を撤廃した
- `release-tag.yaml` の `gh release create` を PAT に切り替える案: 自動チェーンは復活するが、PAT の発行・secret 管理・更新の運用コストがかかるため見送り
- `release-tag.yaml` 内で publish まで行う案: workflow の責務（タグ作成 / 公開）が混ざるため見送り

## Test plan

- [ ] マージ後、Actions から `release` workflow を `workflow_dispatch`（main ブランチ）で実行し、npm に 0.4.1 が publish されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)