### PR TITLE
chore: release v0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "emiel",
   "author": "tomoemon",
   "packageManager": "pnpm@11.1.2",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

v0.4.2 リリース準備。`package.json` の version を 0.4.1 → 0.4.2 に bump。

## 変更内容 (v0.4.1 以降)

- fix: examples のライトモード視認性改善と英数字混在ワード対応 (#54)
- ci: npm publish を release-tag workflow の後続ジョブに統合 (#55)
- ci: release.yaml を npm-publish.yaml にリネーム (#53)
- ci: release workflow にイベント非連鎖の経緯コメント追加・workflow_dispatch 対応 (#52)

## リリースフロー

マージ後、`release-tag` workflow が自動で以下を実行する:

1. `release-tag` ジョブがタグ `v0.4.2` を作成し GitHub release を生成
2. 後続の `publish` ジョブが同一 run 内で npm publish を実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)